### PR TITLE
Release/0.2.3 - Adds unified reasoning support across providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This lightweight SDK for Python allows you to use LLM APIs from various provider
 
 ### Version
 
-Current version: 0.2.2
+Current version: 0.2.3
 
 
 ## Features
@@ -20,6 +20,7 @@ Current version: 0.2.2
 - **Flexible Configuration**: Manage request parameters like temperature, max tokens, and other settings for fine-tuned control.
 - **Token and Cost Accounting**: Automatic calculation of token usage and cost per request.
 - **Pricing Registry**: Model prices are stored in a unified JSON registry with per-model input/output pricing and currency support.
+- **Unified Reasoning Support**: A single `reasoning_level` parameter that works identically across all providers.
 
 ## Installation
 
@@ -107,6 +108,8 @@ print(response.content)
 
 The SDK provides a set of standardized errors for easier debugging and integration:
 
+### API Errors
+
 - **LLMAPIError**: Base class for all API-related errors. This error is also used for any unexpected LLM API errors.
 
 - **LLMAPIAuthorizationError**: Raised when authentication or authorization fails.
@@ -123,15 +126,21 @@ The SDK provides a set of standardized errors for easier debugging and integrati
 
 - **LLMAPIUsageLimitError**: Raised when usage limits are exceeded.
 
+### Config Errors
+
+- **LLMConfigError**: Raised when the request configuration is invalid or incompatible.
+
+- **LLMReasoningLevelError**: Raised only for Anthropic models when max_tokens is less than reasoning_level.
+
 ## Configuration and Management
 
 ### Using Different Providers and Models
 
 The SDK allows you to easily switch between LLM providers and specify the model you want to use. Currently supported providers are OpenAI, Anthropic, and Google.
 
-- **OpenAI**: You can use models like `gpt-5-pro`, `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`, `gpt-4o`, `gpt-4o-mini`.
+- **OpenAI**: You can use models like `gpt-5.1`, `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`, `gpt-4o`, `gpt-4o-mini`.
 - **Anthropic**: Available models include `claude-sonnet-4-5`, `claude-haiku-4-5`, `claude-opus-4-1`, `claude-opus-4-0`, `claude-sonnet-4-0`, `claude-3-7-sonnet-latest`, `claude-3-5-haiku-latest`, `claude-3-haiku-20240307`.
-- **Google**: Models such as `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`, `gemini-2.0-flash`, `gemini-2.0-flash-lite` can be used.
+- **Google**: Models such as `gemini-3-pro-preview`, `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`, `gemini-2.0-flash`, `gemini-2.0-flash-lite` can be used.
 
 Example:
 
@@ -229,6 +238,79 @@ The `ChatResponse` object returned by `chat` includes:
 8. **cost\_total**: Total combined cost.
 9. **content**: The generated text response.
 10. **finish\_reason**: Reason why generation stopped (e.g., `"stop"`, `"length"`).
+
+## Reasoning Support
+
+This section describes the unified `reasoning_level` parameter that works the same way for all supported providers and their models.
+
+```python
+response = adapter.chat(
+    messages=[UserMessage("Solve this step-by-step")],
+    reasoning_level=2048,
+)
+```
+
+### Default behavior
+
+If `reasoning_level` is not passed, reasoning is:
+
+- fully disabled where the provider allows it, or
+- reduced to the minimal supported level if it cannot be turned off.
+
+This keeps behavior consistent when switching providers or models.
+
+### `reasoning_level` parameter
+
+`reasoning_level` is optional and provider‑agnostic.
+
+Supported forms:
+
+- **int** — explicit numeric level
+- **str** — one of: `"none"`, `"low"`, `"medium"`, `"high"`
+
+Internal mapping:
+
+```json
+{
+  "none": 0,
+  "low": 100,
+  "medium": 1000,
+  "high": 10000
+}
+```
+
+String values are automatically converted to numbers, and numeric values can be normalized back to named levels.
+
+### Usage examples
+
+```python
+# Named level
+response = adapter.chat(
+    messages=[UserMessage("Explain this")],
+    reasoning_level="medium",
+)
+
+# Explicit numeric level
+response = adapter.chat(
+    messages=[UserMessage("Solve this step-by-step")],
+    reasoning_level=2048,
+)
+
+# Reasoning disabled (default)
+response = adapter.chat(
+    messages=[UserMessage("Simple answer, no reasoning")],
+)
+```
+
+### Provider independence
+
+`reasoning_level` has the same semantics for all providers:
+
+- same parameter name
+- same string levels
+- same numeric mapping
+
+This allows switching between OpenAI, Anthropic, and Google without changing reasoning configuration in your code.
 
 ## Token Usage and Pricing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-api-adapter"
-version = "0.2.2"
+version = "0.2.3"
 description = "Lightweight, pluggable adapter for multiple LLM APIs (OpenAI, Anthropic, Google)"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/llm_api_adapter/adapters/anthropic_adapter.py
+++ b/src/llm_api_adapter/adapters/anthropic_adapter.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 import logging
 from typing import List, Optional
+import warnings
 
 from ..adapters.base_adapter import LLMAdapterBase
 from ..errors.llm_api_error import LLMAPIError
@@ -64,11 +65,15 @@ class AnthropicAdapter(LLMAdapterBase):
             error_message = getattr(e, "text", None) or str(e)
             self.handle_error(error=e, error_message=error_message)
 
-    def _normalize_reasoning_level(self, level: str | int) -> str:
+    def _normalize_reasoning_level(self, level: str | int) -> str | None:
         minimum_level = 1024
         normalized_level = None
-        if not self.is_reasoning:
-            raise ValueError(f"Model does not support reasoning.")
+        if level and not self.is_reasoning:
+            warning_message = (f"Model '{self.model}' does not support reasoning "
+                               "— reasoning disabled.")
+            warnings.warn(warning_message, UserWarning)
+            logger.info(warning_message)
+            return None
         if isinstance(level, bool):
             raise ValueError("Invalid type for level: bool is not accepted")
         if isinstance(level, str):

--- a/src/llm_api_adapter/adapters/anthropic_adapter.py
+++ b/src/llm_api_adapter/adapters/anthropic_adapter.py
@@ -5,6 +5,7 @@ import warnings
 
 from ..adapters.base_adapter import LLMAdapterBase
 from ..errors.llm_api_error import LLMAPIError
+from ..errors.config_errors import LLMConfigError
 from ..llms.anthropic.sync_client import ClaudeSyncClient
 from ..models.messages.chat_message import Message, Messages
 from ..models.responses.chat_response import ChatResponse
@@ -45,6 +46,11 @@ class AnthropicAdapter(LLMAdapterBase):
             if reasoning_level:
                 normalized_reasoning_level = self._normalize_reasoning_level(reasoning_level)
                 if normalized_reasoning_level:
+                    self.validate_reasoning_and_tokens(
+                        max_tokens=max_tokens,
+                        reasoning_level=reasoning_level,
+                        normalized_reasoning_level=normalized_reasoning_level
+                    )
                     params["thinking"] = {
                         "type": "enabled",
                         "budget_tokens": normalized_reasoning_level
@@ -65,7 +71,7 @@ class AnthropicAdapter(LLMAdapterBase):
             error_message = getattr(e, "text", None) or str(e)
             self.handle_error(error=e, error_message=error_message)
 
-    def _normalize_reasoning_level(self, level: str | int) -> str | None:
+    def _normalize_reasoning_level(self, level: str | int) -> int | None:
         minimum_level = 1024
         normalized_level = None
         if level and not self.is_reasoning:
@@ -87,6 +93,28 @@ class AnthropicAdapter(LLMAdapterBase):
         if normalized_level:
             if normalized_level >= minimum_level:
                 return normalized_level
+            warning_message = (
+                f"Reasoning level '{level}' is below the minimum supported value {minimum_level}; "
+                f"using {minimum_level} instead.")
+            warnings.warn(warning_message, UserWarning)
+            logger.info(warning_message)
             return minimum_level
         raise ValueError("Invalid type for level: expected int or str, "
                          f"got {type(level).__name__!r}")
+    
+    def validate_reasoning_and_tokens(
+        self,
+        max_tokens: int,
+        reasoning_level: int | str,
+        normalized_reasoning_level: int
+    ) -> None:
+        if max_tokens <= normalized_reasoning_level:
+            raise LLMConfigError(
+            detail=(
+                f"Provided max_tokens={max_tokens}, "
+                f"reasoning_level={normalized_reasoning_level} "
+                f"(requested '{reasoning_level}'). "
+                f"Increase max_tokens above {normalized_reasoning_level} "
+                "or reduce reasoning_level."
+            )
+        )

--- a/src/llm_api_adapter/adapters/anthropic_adapter.py
+++ b/src/llm_api_adapter/adapters/anthropic_adapter.py
@@ -74,8 +74,9 @@ class AnthropicAdapter(LLMAdapterBase):
         if isinstance(level, str):
             if level in self.reasoning_levels:
                 normalized_level = self.reasoning_levels[level]
-            raise ValueError(f"Unknown reasoning level key: {level!r}. "
-                            f"Valid keys: {list(self.reasoning_levels.keys())}")
+            else:
+                raise ValueError(f"Unknown reasoning level key: {level!r}. "
+                                 f"Valid keys: {list(self.reasoning_levels.keys())}")
         if isinstance(level, int):
             normalized_level = level
         if normalized_level:

--- a/src/llm_api_adapter/adapters/anthropic_adapter.py
+++ b/src/llm_api_adapter/adapters/anthropic_adapter.py
@@ -20,7 +20,8 @@ class AnthropicAdapter(LLMAdapterBase):
         messages: List[Message] | Messages,
         max_tokens: int,
         temperature: float = 1.0,
-        top_p: float = 1.0
+        top_p: float = 1.0,
+        reasoning_level: Optional[str | int] = None
     ) -> ChatResponse:
         temperature = self._validate_parameter(
             name="temperature", value=temperature, min_value=0, max_value=2
@@ -32,14 +33,23 @@ class AnthropicAdapter(LLMAdapterBase):
             normalized_messages = self._normalize_messages(messages)
             system_prompt, transformed_messages = normalized_messages.to_anthropic()
             client = ClaudeSyncClient(api_key=self.api_key)
-            response = client.chat_completion(
-                model=self.model,
-                messages=transformed_messages,
-                max_tokens=max_tokens,
-                temperature=temperature,
-                top_p=top_p,
-                system=system_prompt,
-            )
+            params = {
+                "model": self.model,
+                "messages": transformed_messages,
+                "max_tokens": max_tokens,
+                "temperature": temperature,
+                "top_p": top_p,
+                "system": system_prompt,
+            }
+            if reasoning_level:
+                normalized_reasoning_level = self._normalize_reasoning_level(reasoning_level)
+                if normalized_reasoning_level:
+                    params["thinking"] = {
+                        "type": "enabled",
+                        "budget_tokens": normalized_reasoning_level
+                    }
+            params = {k: v for k, v in params.items() if v is not None}
+            response = client.chat_completion(**params)
             chat_response = ChatResponse.from_anthropic_response(response)
             if self.pricing:
                 chat_response.apply_pricing(
@@ -53,3 +63,24 @@ class AnthropicAdapter(LLMAdapterBase):
         except Exception as e:
             error_message = getattr(e, "text", None) or str(e)
             self.handle_error(error=e, error_message=error_message)
+
+    def _normalize_reasoning_level(self, level: str | int) -> str:
+        minimum_level = 1024
+        normalized_level = None
+        if not self.is_reasoning:
+            raise ValueError(f"Model does not support reasoning.")
+        if isinstance(level, bool):
+            raise ValueError("Invalid type for level: bool is not accepted")
+        if isinstance(level, str):
+            if level in self.reasoning_levels:
+                normalized_level = self.reasoning_levels[level]
+            raise ValueError(f"Unknown reasoning level key: {level!r}. "
+                            f"Valid keys: {list(self.reasoning_levels.keys())}")
+        if isinstance(level, int):
+            normalized_level = level
+        if normalized_level:
+            if normalized_level >= minimum_level:
+                return normalized_level
+            return minimum_level
+        raise ValueError("Invalid type for level: expected int or str, "
+                         f"got {type(level).__name__!r}")

--- a/src/llm_api_adapter/adapters/anthropic_adapter.py
+++ b/src/llm_api_adapter/adapters/anthropic_adapter.py
@@ -18,7 +18,7 @@ class AnthropicAdapter(LLMAdapterBase):
     def chat(
         self,
         messages: List[Message] | Messages,
-        max_tokens: Optional[int] = None,
+        max_tokens: int,
         temperature: float = 1.0,
         top_p: float = 1.0
     ) -> ChatResponse:

--- a/src/llm_api_adapter/adapters/base_adapter.py
+++ b/src/llm_api_adapter/adapters/base_adapter.py
@@ -86,8 +86,6 @@ class LLMAdapterBase(ABC):
     def handle_error(self, error: Exception, error_message: Optional[str] = None):
         err_msg = (f"Error with the provider '{self.company}' "
                f"the model '{self.model}': {error_message}. ")
-        if error_message:
-            err_msg += f"{error_message}"
         logger.error(err_msg)
         raise
 

--- a/src/llm_api_adapter/adapters/base_adapter.py
+++ b/src/llm_api_adapter/adapters/base_adapter.py
@@ -1,8 +1,8 @@
 from abc import ABC, abstractmethod
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import logging
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 import warnings
 
 from ..llm_registry.llm_registry import Pricing, LLM_REGISTRY
@@ -11,37 +11,58 @@ from ..models.responses.chat_response import ChatResponse
 
 logger = logging.getLogger(__name__)
 
+REASONING_LEVELS_DEFAULT = {
+    "none": 0,
+    "low": 100,
+    "medium": 1000,
+    "high": 10000,
+}
+
+
 @dataclass
 class LLMAdapterBase(ABC):
     api_key: str
     model: str
     company: str
     pricing: Optional[Pricing] = None
+    is_reasoning: bool = False
+    reasoning_levels: Dict[str, int] = field(
+        default_factory=lambda: REASONING_LEVELS_DEFAULT.copy()
+    )
 
     def __post_init__(self):
         if not self.api_key:
             error_message = "api_key must be a non-empty string"
             logger.error(error_message)
             raise ValueError(error_message)
-        if self.pricing is None:
-            provider = LLM_REGISTRY.providers.get(self.company)
-            model_spec = provider.models.get(self.model) if provider else None
-            if not model_spec:
-                warnings.warn(
-                    (f"Model '{self.model}' is not verified for the {self.company} adapter. "
-                     f"Continuing with the selected adapter."),
-                    UserWarning
-                )
-                logger.warning(f"Unverified model used: {self.model}")
-                self.pricing = None
-            else:
-                base_pricing = getattr(model_spec, "pricing", None)
-                self.pricing = deepcopy(base_pricing) if base_pricing else None
+        provider = LLM_REGISTRY.providers.get(self.company)
+        model_spec = provider.models.get(self.model) if provider else None
+        if not model_spec:
+            warnings.warn(
+                (f"Model '{self.model}' is not verified for the {self.company} adapter. "
+                 f"Continuing with the selected adapter."),
+                 UserWarning
+            )
+            logger.warning(f"Unverified model used: {self.model}")
+            self.pricing = None
+        else:
+            base_pricing = getattr(model_spec, "pricing", None)
+            self.pricing = deepcopy(base_pricing) if base_pricing else None
+            self.is_reasoning = getattr(model_spec, "is_reasoning", False)
 
     @abstractmethod
     def chat(self, **kwargs) -> ChatResponse:
         """
         Generates a response based on the provided conversation.
+        """
+        pass
+
+    @abstractmethod
+    def _normalize_reasoning_level(self, level: str | int) -> int | str:
+        """
+        Convert a user-provided reasoning level ('none', 'low', 'medium', 'high' or numeric)
+        into the provider-specific format.
+        Models without reasoning support should ignore
         """
         pass
 
@@ -54,7 +75,7 @@ class LLMAdapterBase(ABC):
             logger.error(error_message)
             raise ValueError(error_message)
         return value
-    
+
     def _normalize_messages(self, messages: Any) -> Messages:
         if isinstance(messages, Messages):
             return messages

--- a/src/llm_api_adapter/adapters/google_adapter.py
+++ b/src/llm_api_adapter/adapters/google_adapter.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 import logging
 from typing import List, Optional
+import warnings
 
 from ..adapters.base_adapter import LLMAdapterBase
 from ..errors.llm_api_error import LLMAPIError
@@ -69,11 +70,15 @@ class GoogleAdapter(LLMAdapterBase):
             error_message = getattr(e, "text", None) or str(e)
             self.handle_error(error=e, error_message=error_message)
 
-    def _normalize_reasoning_level(self, level: str | int) -> str:
+    def _normalize_reasoning_level(self, level: str | int | None) -> str | None:
         minimum_level = 0
         normalized_level = None
-        if not self.is_reasoning:
-            raise ValueError(f"Model does not support reasoning.")
+        if level and not self.is_reasoning:
+            warning_message = (f"Model '{self.model}' does not support reasoning "
+                               "— reasoning disabled.")
+            warnings.warn(warning_message, UserWarning)
+            logger.info(warning_message)
+            return None
         if isinstance(level, bool):
             raise ValueError("Invalid type for level: bool is not accepted")
         if isinstance(level, str):

--- a/src/llm_api_adapter/adapters/google_adapter.py
+++ b/src/llm_api_adapter/adapters/google_adapter.py
@@ -20,7 +20,8 @@ class GoogleAdapter(LLMAdapterBase):
         messages: List[Message] | Messages,
         max_tokens: Optional[int] = None,
         temperature: float = 1.0,
-        top_p: float = 1.0
+        top_p: float = 1.0,
+        reasoning_level: Optional[str | int] = None
     ) -> ChatResponse:
         temperature = self._validate_parameter(
             name="temperature", value=temperature, min_value=0, max_value=2
@@ -31,13 +32,21 @@ class GoogleAdapter(LLMAdapterBase):
         try:
             normalized_messages = self._normalize_messages(messages)
             system_prompt, transformed_messages = normalized_messages.to_google()
+            generation_config = {
+                "maxOutputTokens": max_tokens,
+                "temperature": temperature,
+                "topP": top_p,
+            }
+            if reasoning_level:
+                normalized_reasoning_level = self._normalize_reasoning_level(reasoning_level)
+                if normalized_reasoning_level:
+                    generation_config["thinkingConfig"] = {
+                        "thinkingBudget": reasoning_level,
+                        "includeThoughts": False
+                    }
             payload = {
                 "contents": transformed_messages,
-                "generationConfig": {
-                    "maxOutputTokens": max_tokens,
-                    "temperature": temperature,
-                    "topP": top_p,
-                },
+                "generationConfig": generation_config
             }
             if system_prompt:
                 payload["system_instruction"] = {"parts": [{"text": system_prompt}]}
@@ -59,3 +68,25 @@ class GoogleAdapter(LLMAdapterBase):
         except Exception as e:
             error_message = getattr(e, "text", None) or str(e)
             self.handle_error(error=e, error_message=error_message)
+
+    def _normalize_reasoning_level(self, level: str | int) -> str:
+        minimum_level = 0
+        normalized_level = None
+        if not self.is_reasoning:
+            raise ValueError(f"Model does not support reasoning.")
+        if isinstance(level, bool):
+            raise ValueError("Invalid type for level: bool is not accepted")
+        if isinstance(level, str):
+            if level in self.reasoning_levels:
+                normalized_level = self.reasoning_levels[level]
+            else:
+                raise ValueError(f"Unknown reasoning level key: {level!r}. "
+                                 f"Valid keys: {list(self.reasoning_levels.keys())}")
+        if isinstance(level, int):
+            normalized_level = level
+        if normalized_level:
+            if normalized_level >= minimum_level:
+                return normalized_level
+            return minimum_level
+        raise ValueError("Invalid type for level: expected int or str, "
+                         f"got {type(level).__name__!r}")

--- a/src/llm_api_adapter/adapters/openai_adapter.py
+++ b/src/llm_api_adapter/adapters/openai_adapter.py
@@ -20,7 +20,8 @@ class OpenAIAdapter(LLMAdapterBase):
         messages: List[Message] | Messages,
         max_tokens: Optional[int] = None,
         temperature: float = 1.0,
-        top_p: float = 1.0
+        top_p: float = 1.0,
+        reasoning_level: Optional[str | int] = None
     ) -> ChatResponse:
         temperature = self._validate_parameter(
             name="temperature", value=temperature, min_value=0, max_value=2
@@ -31,14 +32,18 @@ class OpenAIAdapter(LLMAdapterBase):
         try:
             normalized_messages = self._normalize_messages(messages)
             transformed_messages = normalized_messages.to_openai()
+            normalized_reasoning_level = self._normalize_reasoning_level(reasoning_level)
             client = OpenAISyncClient(api_key=self.api_key)
-            response = client.chat_completion(
-                model=self.model,
-                messages=transformed_messages,
-                max_tokens=max_tokens,
-                temperature=temperature,
-                top_p=top_p,
-            )
+            params = {
+                "model": self.model,
+                "messages": transformed_messages,
+                "max_tokens": max_tokens,
+                "temperature": temperature,
+                "top_p": top_p,
+                "reasoning_effort": normalized_reasoning_level, 
+            }
+            params = {k: v for k, v in params.items() if v is not None}
+            response = client.chat_completion(**params)
             chat_response = ChatResponse.from_openai_response(response)
             if self.pricing:
                 chat_response.apply_pricing(
@@ -52,3 +57,18 @@ class OpenAIAdapter(LLMAdapterBase):
         except Exception as e:
             error_message = getattr(e, "text", None) or str(e)
             self.handle_error(error=e, error_message=error_message)
+
+    def _normalize_reasoning_level(self, level: str | int) -> int | str:
+        if not self.is_reasoning:
+            raise ValueError(f"Model does not support reasoning.")
+        if isinstance(level, str):
+            if level in self.reasoning_levels:
+                return level
+            raise ValueError(f"Unknown reasoning level key: {level!r}. "
+                             f"Valid keys: {list(self.reasoning_levels)}")
+        if isinstance(level, int):
+            for key, val in self.reasoning_levels.items():
+                if level <= val:
+                    return key
+            return list(self.reasoning_levels.keys())[-1]
+        return level

--- a/src/llm_api_adapter/adapters/openai_adapter.py
+++ b/src/llm_api_adapter/adapters/openai_adapter.py
@@ -33,7 +33,6 @@ class OpenAIAdapter(LLMAdapterBase):
             normalized_messages = self._normalize_messages(messages)
             transformed_messages = normalized_messages.to_openai()
             normalized_reasoning_level = self._normalize_reasoning_level(reasoning_level)
-            print(f"normalized_reasoning_level: {normalized_reasoning_level}")
             client = OpenAISyncClient(api_key=self.api_key)
             params = {
                 "model": self.model,

--- a/src/llm_api_adapter/adapters/openai_adapter.py
+++ b/src/llm_api_adapter/adapters/openai_adapter.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 import logging
 from typing import List, Optional
+import warnings
 
 from ..adapters.base_adapter import LLMAdapterBase
 from ..errors.llm_api_error import LLMAPIError
@@ -58,9 +59,13 @@ class OpenAIAdapter(LLMAdapterBase):
             error_message = getattr(e, "text", None) or str(e)
             self.handle_error(error=e, error_message=error_message)
 
-    def _normalize_reasoning_level(self, level: str | int | None) -> str:
-        if not self.is_reasoning:
-            raise ValueError(f"Model does not support reasoning.")
+    def _normalize_reasoning_level(self, level: str | int | None) -> str | None:
+        if level and not self.is_reasoning:
+            warning_message = (f"Model '{self.model}' does not support reasoning "
+                               "— reasoning disabled.")
+            warnings.warn(warning_message, UserWarning)
+            logger.info(warning_message)
+            return None
         if self.is_reasoning and level is None:
             return "none"
         if isinstance(level, bool):

--- a/src/llm_api_adapter/adapters/openai_adapter.py
+++ b/src/llm_api_adapter/adapters/openai_adapter.py
@@ -33,6 +33,7 @@ class OpenAIAdapter(LLMAdapterBase):
             normalized_messages = self._normalize_messages(messages)
             transformed_messages = normalized_messages.to_openai()
             normalized_reasoning_level = self._normalize_reasoning_level(reasoning_level)
+            print(f"normalized_reasoning_level: {normalized_reasoning_level}")
             client = OpenAISyncClient(api_key=self.api_key)
             params = {
                 "model": self.model,
@@ -58,9 +59,11 @@ class OpenAIAdapter(LLMAdapterBase):
             error_message = getattr(e, "text", None) or str(e)
             self.handle_error(error=e, error_message=error_message)
 
-    def _normalize_reasoning_level(self, level: str | int) -> str:
+    def _normalize_reasoning_level(self, level: str | int | None) -> str:
         if not self.is_reasoning:
             raise ValueError(f"Model does not support reasoning.")
+        if self.is_reasoning and level is None:
+            return "none"
         if isinstance(level, bool):
             raise ValueError("Invalid type for level: bool is not accepted")
         if isinstance(level, str):

--- a/src/llm_api_adapter/adapters/openai_adapter.py
+++ b/src/llm_api_adapter/adapters/openai_adapter.py
@@ -58,17 +58,20 @@ class OpenAIAdapter(LLMAdapterBase):
             error_message = getattr(e, "text", None) or str(e)
             self.handle_error(error=e, error_message=error_message)
 
-    def _normalize_reasoning_level(self, level: str | int) -> int | str:
+    def _normalize_reasoning_level(self, level: str | int) -> str:
         if not self.is_reasoning:
             raise ValueError(f"Model does not support reasoning.")
+        if isinstance(level, bool):
+            raise ValueError("Invalid type for level: bool is not accepted")
         if isinstance(level, str):
             if level in self.reasoning_levels:
                 return level
             raise ValueError(f"Unknown reasoning level key: {level!r}. "
-                             f"Valid keys: {list(self.reasoning_levels)}")
+                            f"Valid keys: {list(self.reasoning_levels.keys())}")
         if isinstance(level, int):
             for key, val in self.reasoning_levels.items():
                 if level <= val:
                     return key
             return list(self.reasoning_levels.keys())[-1]
-        return level
+        raise ValueError("Invalid type for level: expected int or str, "
+                         f"got {type(level).__name__!r}")

--- a/src/llm_api_adapter/errors/config_errors.py
+++ b/src/llm_api_adapter/errors/config_errors.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class LLMConfigError(Exception):
+    """Raised when the request configuration is invalid or incompatible."""
+    message: str = "Invalid LLM request configuration."
+    detail: Optional[str] = None
+
+    def __post_init__(self):
+        full_message = self.message
+        if self.detail:
+            full_message = f"{self.message} Detail: {self.detail}"
+        super().__init__(full_message)
+
+
+class LLMReasoningLevelError(LLMConfigError):
+    """Raised when reasoning_level is greater max_tokens."""
+    message: str = "Reasoning level is too high: 'max_tokens' must be > 'reasoning_level'."

--- a/src/llm_api_adapter/errors/llm_api_error.py
+++ b/src/llm_api_adapter/errors/llm_api_error.py
@@ -20,7 +20,7 @@ class LLMAPIAuthorizationError(LLMAPIError):
     """Raised when authentication or authorization fails."""
     message: str = "Authentication or authorization failed."
     openai_api_errors = ["InvalidAuthenticationError", "AuthenticationError"]
-    google_api_errors = ["INVALID_ARGUMENT", "PERMISSION_DENIED"]
+    google_api_errors = ["PERMISSION_DENIED"]
     anthropic_api_errors = ["AuthenticationError", "PermissionError"]
 
 

--- a/src/llm_api_adapter/llm_registry/llm_registry.json
+++ b/src/llm_api_adapter/llm_registry/llm_registry.json
@@ -62,12 +62,30 @@
     "google": {
       "currency": "USD",
       "models": {
-        "gemini-3-pro-preview": {"pricing": {"in_per_1m": 2.0, "out_per_1m": 12.0}},
-        "gemini-2.5-pro": {"pricing": {"in_per_1m": 1.25, "out_per_1m": 10.0}},
-        "gemini-2.5-flash": {"pricing": {"in_per_1m": 0.3, "out_per_1m": 2.5}},
-        "gemini-2.5-flash-lite": {"pricing": {"in_per_1m": 0.1, "out_per_1m": 0.4}},
-        "gemini-2.0-flash": {"pricing": {"in_per_1m": 0.1, "out_per_1m": 0.4}},
-        "gemini-2.0-flash-lite": {"pricing": {"in_per_1m": 0.075, "out_per_1m": 0.3}}
+        "gemini-3-pro-preview": {
+          "pricing": {"in_per_1m": 2.0, "out_per_1m": 12.0},
+          "is_reasoning": true
+        },
+        "gemini-2.5-pro": {
+          "pricing": {"in_per_1m": 1.25, "out_per_1m": 10.0},
+          "is_reasoning": true
+        },
+        "gemini-2.5-flash": {
+          "pricing": {"in_per_1m": 0.3, "out_per_1m": 2.5},
+          "is_reasoning": true
+        },
+        "gemini-2.5-flash-lite": {
+          "pricing": {"in_per_1m": 0.1, "out_per_1m": 0.4},
+          "is_reasoning": true
+        },
+        "gemini-2.0-flash": {
+          "pricing": {"in_per_1m": 0.1, "out_per_1m": 0.4},
+          "is_reasoning": true
+        },
+        "gemini-2.0-flash-lite": {
+          "pricing": {"in_per_1m": 0.075, "out_per_1m": 0.3},
+          "is_reasoning": true
+        }
       }
     }
   }

--- a/src/llm_api_adapter/llm_registry/llm_registry.json
+++ b/src/llm_api_adapter/llm_registry/llm_registry.json
@@ -1,15 +1,26 @@
 {
   "schema_version": 3,
-  "effective_date": "2025-11-23",
+  "effective_date": "2025-11-28",
   "providers": {
     "openai": {
       "currency": "USD",
       "models": {
-        "gpt-5.1": {"pricing": {"in_per_1m": 1.25, "out_per_1m": 10.0}},
-        "gpt-5-pro": {"pricing": {"in_per_1m": 15.0, "out_per_1m": 120.0}},
-        "gpt-5": {"pricing": {"in_per_1m": 1.25, "out_per_1m": 10.0}},
-        "gpt-5-mini": {"pricing": {"in_per_1m": 0.25, "out_per_1m": 2.0}},
-        "gpt-5-nano": {"pricing": {"in_per_1m": 0.05, "out_per_1m": 0.4}},
+        "gpt-5.1": {
+          "pricing": {"in_per_1m": 1.25, "out_per_1m": 10.0},
+          "is_reasoning": true
+        },
+        "gpt-5": {
+          "pricing": {"in_per_1m": 1.25, "out_per_1m": 10.0},
+          "is_reasoning": true
+        },
+        "gpt-5-mini": {
+          "pricing": {"in_per_1m": 0.25, "out_per_1m": 2.0},
+          "is_reasoning": true
+        },
+        "gpt-5-nano": {
+          "pricing": {"in_per_1m": 0.05, "out_per_1m": 0.4},
+          "is_reasoning": true
+        },
         "gpt-4.1": {"pricing": {"in_per_1m": 2.0, "out_per_1m": 8.0}},
         "gpt-4.1-mini": {"pricing": {"in_per_1m": 0.4, "out_per_1m": 1.6}},
         "gpt-4.1-nano": {"pricing": {"in_per_1m": 0.1, "out_per_1m": 0.4}},
@@ -20,6 +31,7 @@
     "anthropic": {
       "currency": "USD",
       "models": {
+        "claude-opus-4-5": {"pricing": {"in_per_1m": 5.0, "out_per_1m": 25.0}},
         "claude-sonnet-4-5": {"pricing": {"in_per_1m": 3.0, "out_per_1m": 15.0}},
         "claude-haiku-4-5": {"pricing": {"in_per_1m": 1.0, "out_per_1m": 5.0}},
         "claude-opus-4-1": {"pricing": {"in_per_1m": 15.0, "out_per_1m": 75.0}},

--- a/src/llm_api_adapter/llm_registry/llm_registry.json
+++ b/src/llm_api_adapter/llm_registry/llm_registry.json
@@ -31,13 +31,30 @@
     "anthropic": {
       "currency": "USD",
       "models": {
-        "claude-opus-4-5": {"pricing": {"in_per_1m": 5.0, "out_per_1m": 25.0}},
-        "claude-sonnet-4-5": {"pricing": {"in_per_1m": 3.0, "out_per_1m": 15.0}},
-        "claude-haiku-4-5": {"pricing": {"in_per_1m": 1.0, "out_per_1m": 5.0}},
-        "claude-opus-4-1": {"pricing": {"in_per_1m": 15.0, "out_per_1m": 75.0}},
-        "claude-opus-4-0": {"pricing": {"in_per_1m": 15.0, "out_per_1m": 75.0}},
-        "claude-sonnet-4-0": {"pricing": {"in_per_1m": 3.0, "out_per_1m": 15.0}},
-        "claude-3-7-sonnet-latest": {"pricing": {"in_per_1m": 3.0, "out_per_1m": 15.0}},
+        "claude-sonnet-4-5": {
+          "pricing": {"in_per_1m": 3.0, "out_per_1m": 15.0},
+          "is_reasoning": true
+        },
+        "claude-haiku-4-5": {
+          "pricing": {"in_per_1m": 1.0, "out_per_1m": 5.0},
+          "is_reasoning": true
+        },
+        "claude-opus-4-1": {
+          "pricing": {"in_per_1m": 15.0, "out_per_1m": 75.0},
+          "is_reasoning": true
+        },
+        "claude-opus-4-0": {
+          "pricing": {"in_per_1m": 15.0, "out_per_1m": 75.0},
+          "is_reasoning": true
+        },
+        "claude-sonnet-4-0": {
+          "pricing": {"in_per_1m": 3.0, "out_per_1m": 15.0},
+          "is_reasoning": true
+        },
+        "claude-3-7-sonnet-latest": {
+          "pricing": {"in_per_1m": 3.0, "out_per_1m": 15.0},
+          "is_reasoning": true
+        },
         "claude-3-5-haiku-latest": {"pricing": {"in_per_1m": 0.8, "out_per_1m": 4.0}},
         "claude-3-haiku-20240307": {"pricing": {"in_per_1m": 0.25, "out_per_1m": 1.25}}
       }

--- a/src/llm_api_adapter/llm_registry/llm_registry.json
+++ b/src/llm_api_adapter/llm_registry/llm_registry.json
@@ -1,10 +1,11 @@
 {
-  "schema_version": 2,
-  "effective_date": "2025-11-03",
+  "schema_version": 3,
+  "effective_date": "2025-11-23",
   "providers": {
     "openai": {
       "currency": "USD",
       "models": {
+        "gpt-5.1": {"pricing": {"in_per_1m": 1.25, "out_per_1m": 10.0}},
         "gpt-5-pro": {"pricing": {"in_per_1m": 15.0, "out_per_1m": 120.0}},
         "gpt-5": {"pricing": {"in_per_1m": 1.25, "out_per_1m": 10.0}},
         "gpt-5-mini": {"pricing": {"in_per_1m": 0.25, "out_per_1m": 2.0}},
@@ -32,6 +33,7 @@
     "google": {
       "currency": "USD",
       "models": {
+        "gemini-3-pro-preview": {"pricing": {"in_per_1m": 2.0, "out_per_1m": 12.0}},
         "gemini-2.5-pro": {"pricing": {"in_per_1m": 1.25, "out_per_1m": 10.0}},
         "gemini-2.5-flash": {"pricing": {"in_per_1m": 0.3, "out_per_1m": 2.5}},
         "gemini-2.5-flash-lite": {"pricing": {"in_per_1m": 0.1, "out_per_1m": 0.4}},

--- a/src/llm_api_adapter/llm_registry/llm_registry.py
+++ b/src/llm_api_adapter/llm_registry/llm_registry.py
@@ -26,6 +26,7 @@ class Pricing:
 class ModelSpec:
     name: str
     pricing: Optional[Pricing] = None
+    is_reasoning: bool = False
 
     @classmethod
     def from_dict(cls, name: str, d: Dict[str, Any]) -> "ModelSpec":
@@ -36,7 +37,8 @@ class ModelSpec:
             pricing = Pricing(in_per_token, out_per_token)
         else:
             pricing = None
-        return cls(name=name, pricing=pricing)
+        is_reasoning = bool(d.get("is_reasoning", False))
+        return cls(name=name, pricing=pricing, is_reasoning=is_reasoning)
 
 
 @dataclass(frozen=True)

--- a/src/llm_api_adapter/llms/anthropic/sync_client.py
+++ b/src/llm_api_adapter/llms/anthropic/sync_client.py
@@ -28,15 +28,17 @@ class ClaudeSyncClient:
         }
 
     def chat_completion(self, model: str, **kwargs):
+        url = f"{self.endpoint}/messages"
+        payload = self._prepare_chat_payload_for_model(model, kwargs)
+        response = self._send_request(url, payload)
+        return response.json()
+
+    def _prepare_chat_payload_for_model(self, model: str, kwargs: dict) -> dict:
         if model.startswith(
             ("claude-sonnet-4-5", "claude-opus-4-1", "claude-haiku-4-5")
         ):
-            if "top_p" in kwargs:
-                kwargs.pop("top_p", None)
-        url = f"{self.endpoint}/messages"
-        payload = {"model": model, **kwargs}
-        response = self._send_request(url, payload)
-        return response.json()
+            kwargs.pop("top_p", None)
+        return {"model": model, **kwargs}
 
     def _send_request(self, url, payload):
         try:

--- a/src/llm_api_adapter/llms/anthropic/sync_client.py
+++ b/src/llm_api_adapter/llms/anthropic/sync_client.py
@@ -60,7 +60,7 @@ class ClaudeSyncClient:
     def _handle_http_error(self, http_err):
         status_code = http_err.response.status_code
         try:
-            error_json = http_err.response.json()
+            error_json = http_err.response.json().get("error")
             error_type = error_json.get("type")
             error_message = error_json.get("message")
         except Exception:

--- a/src/llm_api_adapter/llms/google/sync_client.py
+++ b/src/llm_api_adapter/llms/google/sync_client.py
@@ -25,15 +25,28 @@ class GeminiSyncClient:
         }
 
     def chat_completion(self, model: str, **kwargs):
-        if model.startswith(("gemini-2.5")):
-            gen_cfg = kwargs.get("generationConfig", {})
-            if "maxOutputTokens" in gen_cfg:
-                gen_cfg.pop("maxOutputTokens", None)
-                kwargs["generationConfig"] = gen_cfg
         url = f"{self.endpoint}/models/{model}:generateContent"
-        payload = {"model": model, **kwargs}
+        payload = self._prepare_chat_payload_for_model(model, kwargs)
         response = self._send_request(url, payload)
         return response.json()
+
+    def _prepare_chat_payload_for_model(self, model: str, kwargs: dict) -> dict:
+        gen_cfg = kwargs.get("generationConfig", {})
+        if "maxOutputTokens" in gen_cfg:
+            if model.startswith(("gemini-2.5")):
+                gen_cfg.pop("maxOutputTokens", None)
+                kwargs["generationConfig"] = gen_cfg
+        if "thinkingConfig" in gen_cfg:
+            MIN_THINKING_BUDGET = {
+                "gemini-2.5-flash-lite": 512,
+                "gemini-2.5-pro": 128,
+            }
+            thinking_config = gen_cfg["thinkingConfig"]
+            thinking_budget = thinking_config.get("thinkingBudget")
+            min_budget = MIN_THINKING_BUDGET.get(model)
+            if min_budget is None or thinking_budget < min_budget:
+                thinking_config["thinkingBudget"] = min_budget
+        return {"model": model, **kwargs}
 
     def _send_request(self, url, payload):
         try:

--- a/src/llm_api_adapter/llms/openai/sync_client.py
+++ b/src/llm_api_adapter/llms/openai/sync_client.py
@@ -30,6 +30,8 @@ class OpenAISyncClient:
         if model.startswith(("gpt-4.1", "gpt-5", "o1")):
             if "max_tokens" in kwargs:
                 kwargs["max_completion_tokens"] = kwargs.pop("max_tokens")
+        if "reasoning_effort" in kwargs and model in ("gpt-5-nano, gpt-5-mini"):
+            kwargs["reasoning_effort"] = "minimal"
         url = f"{self.endpoint}/chat/completions"
         payload = {"model": model, **kwargs}
         response = self._send_request(url, payload)

--- a/src/llm_api_adapter/llms/openai/sync_client.py
+++ b/src/llm_api_adapter/llms/openai/sync_client.py
@@ -27,15 +27,18 @@ class OpenAISyncClient:
         }
 
     def chat_completion(self, model: str, **kwargs):
+        url = f"{self.endpoint}/chat/completions"
+        payload = self._prepare_chat_payload_for_model(model, kwargs)
+        response = self._send_request(url, payload)
+        return response.json()
+
+    def _prepare_chat_payload_for_model(self, model: str, kwargs: dict) -> dict:
         if model.startswith(("gpt-4.1", "gpt-5", "o1")):
             if "max_tokens" in kwargs:
                 kwargs["max_completion_tokens"] = kwargs.pop("max_tokens")
         if "reasoning_effort" in kwargs and model in ("gpt-5-nano, gpt-5-mini"):
             kwargs["reasoning_effort"] = "minimal"
-        url = f"{self.endpoint}/chat/completions"
-        payload = {"model": model, **kwargs}
-        response = self._send_request(url, payload)
-        return response.json()
+        return {"model": model, **kwargs}
 
     def _send_request(self, url, payload):
         try:

--- a/src/llm_api_adapter/models/responses/chat_response.py
+++ b/src/llm_api_adapter/models/responses/chat_response.py
@@ -57,11 +57,16 @@ class ChatResponse:
             output_tokens=u.get("output_tokens", 0),
             total_tokens=u.get("input_tokens", 0) + u.get("output_tokens", 0),
         )
+        content = api_response.get("content", [])
+        first_text = next(
+            (block.get("text") for block in content if block.get("type") == "text"),
+            None
+        )
         return cls(
             model=api_response.get("model"),
             response_id=api_response.get("id"),
             usage=usage,
-            content=api_response.get("content")[0].get("text"),
+            content=first_text,
             finish_reason=api_response.get("stop_reason"),
         )
 

--- a/src/llm_api_adapter/models/responses/chat_response.py
+++ b/src/llm_api_adapter/models/responses/chat_response.py
@@ -1,5 +1,8 @@
 from dataclasses import dataclass, field
 from typing import Optional
+import warnings
+
+from ...errors.llm_api_error import LLMAPIError
 
 
 @dataclass
@@ -30,12 +33,19 @@ class ChatResponse:
             output_tokens=u.get("completion_tokens", 0),
             total_tokens=u.get("total_tokens", 0),
         )
+        text = api_response["choices"][0]["message"]["content"]
+        if not text or not text.strip():
+            warnings.warn(
+                "OpenAI returned empty content. "
+                "The model may have stopped early due to a low max_tokens value.",
+                UserWarning,
+            )
         return cls(
             model=api_response.get("model"),
             response_id=api_response.get("id"),
             timestamp=api_response.get("created"),
             usage=usage,
-            content=api_response["choices"][0]["message"]["content"],
+            content=text,
             finish_reason=api_response["choices"][0].get("finish_reason"),
         )
 
@@ -65,9 +75,17 @@ class ChatResponse:
             total_tokens=u.get("totalTokenCount", 0),
         )
         first_candidate = api_response["candidates"][0]
+        content = first_candidate.get("content", {})
+        parts = content.get("parts")
+        if not parts or not isinstance(parts, list):
+            raise LLMAPIError(
+                "Google API returned malformed response",
+                detail="content.parts missing — likely max_output_tokens too small"
+            )
+        text = parts[0].get("text")
         return cls(
             usage=usage,
-            content=first_candidate["content"]["parts"][0]["text"],
+            content=text,
             finish_reason=str(first_candidate.get("finishReason")),
         )
 

--- a/tests/integration/test_universal_adapter.py
+++ b/tests/integration/test_universal_adapter.py
@@ -37,7 +37,7 @@ def anthropic_client_mock():
             "model": "claude-sonnet-4-5",
             "id": "response123",
             "usage": {"input_tokens": 5, "output_tokens": 7},
-            "content": [{"text": "Hello from mocked Anthropic!"}],
+            "content": [{"type": "text", "text": "Hello from mocked Anthropic!"}],
             "stop_reason": "stop"
         })
         yield mock
@@ -114,7 +114,7 @@ def test_anthropic_chat(anthropic_client_mock):
         AIMessage("Sure!"),
         UserMessage("How does AI learn?"),
     ]
-    resp = adapter.chat(messages=messages)
+    resp = adapter.chat(messages=messages, max_tokens=2000)
     assert resp.content == "Hello from mocked Anthropic!"
 
 def test_anthropic_chat_with_raw_dict_messages(anthropic_client_mock):
@@ -129,7 +129,7 @@ def test_anthropic_chat_with_raw_dict_messages(anthropic_client_mock):
         model="claude-sonnet-4-5",
         api_key="dummy_key"
     )
-    resp = adapter.chat(messages=messages)
+    resp = adapter.chat(messages=messages, max_tokens=2000)
     assert resp.content == "Hello from mocked Anthropic!"
 
 def test_google_usage_and_pricing(google_client_mock):
@@ -163,7 +163,7 @@ def test_anthropic_tokens_and_pricing(anthropic_client_mock):
     adapter.pricing.set_currency("USD")
 
     messages = [UserMessage("Hello")]
-    resp = adapter.chat(messages=messages)
+    resp = adapter.chat(messages=messages, max_tokens="2000")
 
     # The mocked Anthropic response provides input_tokens=5 and output_tokens=7
     assert resp.usage.input_tokens == 5

--- a/tests/unit/adapters/test_anthropic_adapter.py
+++ b/tests/unit/adapters/test_anthropic_adapter.py
@@ -73,3 +73,43 @@ def test_pricing_is_applied_when_present(adapter):
             price_output_per_token=adapter.pricing.out_per_token,
             currency=adapter.pricing.currency,
         )
+
+def test_normalize_reasoning_level_int_below_minimum_warns(adapter):
+    adapter.is_reasoning = True
+    with pytest.warns(UserWarning):
+        result = adapter._normalize_reasoning_level(512)
+    assert result == 1024
+
+def test_normalize_reasoning_level_bool_raises(adapter):
+    adapter.is_reasoning = True
+    with pytest.raises(ValueError):
+        adapter._normalize_reasoning_level(True)
+
+def test_normalize_reasoning_level_unknown_str_raises(adapter):
+    adapter.is_reasoning = True
+    adapter.reasoning_levels = {"low": 2048}
+    with pytest.raises(ValueError):
+        adapter._normalize_reasoning_level("unknown-key")
+
+def test_chat_sets_thinking_when_reasoning_level_provided(adapter):
+    adapter.is_reasoning = True
+    adapter.reasoning_levels = {"high": 4096}
+    fake_response = {"some": "anthropic response"}
+    fake_chat_response = ChatResponse(content="fake")
+    with patch.object(ClaudeSyncClient, "chat_completion", return_value=fake_response) as mock_chat, \
+         patch.object(ChatResponse, "from_anthropic_response", return_value=fake_chat_response):
+        adapter.chat([UserMessage("hi")], max_tokens=10000, reasoning_level="high")
+        mock_chat.assert_called_once()
+        kwargs = mock_chat.call_args.kwargs
+        assert "thinking" in kwargs
+        assert kwargs["thinking"]["type"] == "enabled"
+        assert kwargs["thinking"]["budget_tokens"] == 4096
+
+def test_validate_reasoning_and_tokens_raises_llmconfigerror(adapter):
+    from src.llm_api_adapter.errors.config_errors import LLMConfigError
+    with pytest.raises(LLMConfigError):
+        adapter.validate_reasoning_and_tokens(
+            max_tokens=1024,
+            reasoning_level="high",
+            normalized_reasoning_level=2048
+        )

--- a/tests/unit/adapters/test_anthropic_adapter.py
+++ b/tests/unit/adapters/test_anthropic_adapter.py
@@ -35,7 +35,7 @@ def test_chat_handles_llmapi_error(adapter):
     with patch.object(
         ClaudeSyncClient, method, side_effect=LLMAPIError("API error")
     ), patch.object(adapter, "handle_error") as mock_handle_error:
-        adapter.chat(messages)
+        adapter.chat(messages=messages, max_tokens=2000)
         mock_handle_error.assert_called_once()
 
 def test_chat_handles_generic_exception(adapter):
@@ -44,7 +44,7 @@ def test_chat_handles_generic_exception(adapter):
     with patch.object(
         ClaudeSyncClient, method, side_effect=Exception("Generic error")
     ), patch.object(adapter, "handle_error") as mock_handle_error:
-        adapter.chat(messages)
+        adapter.chat(messages=messages, max_tokens=2000)
         mock_handle_error.assert_called_once()
 
 def test_pricing_is_applied_when_present(adapter):

--- a/tests/unit/adapters/test_base_adapter.py
+++ b/tests/unit/adapters/test_base_adapter.py
@@ -18,6 +18,10 @@ class DummyClient:
 
 
 class _TestAdapter(LLMAdapterBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.client = DummyClient()
+
     def chat(self, messages, **kwargs):
         try:
             raw_response = self.client.chat_completion(messages, **kwargs)
@@ -25,8 +29,13 @@ class _TestAdapter(LLMAdapterBase):
                 return ChatResponse(**raw_response)
             except Exception:
                 return raw_response
-        except (LLMAPIError, Exception) as e:
+        except LLMAPIError as e:
             return self.handle_error(e)
+        except Exception as e:
+            return self.handle_error(e)
+    
+    def _normalize_reasoning_level(self, reasoning_level):
+        return reasoning_level
 
 
 @pytest.fixture

--- a/tests/unit/adapters/test_google_adapter.py
+++ b/tests/unit/adapters/test_google_adapter.py
@@ -86,3 +86,53 @@ def test_pricing_is_applied_when_present(adapter):
         currency=adapter.pricing.currency,
     )
     assert result is fake_chat_response
+
+def test_chat_includes_system_instruction_in_payload(adapter):
+    from src.llm_api_adapter.models.messages.chat_message import Prompt, UserMessage
+    messages = [Prompt("system prompt"), UserMessage("hello")]
+    fake_response = {"some": "google response"}
+    with patch.object(GeminiSyncClient, "chat_completion", return_value=fake_response) as mock_client, \
+         patch.object(ChatResponse, "from_google_response", return_value=ChatResponse()):
+        adapter.chat(messages, max_tokens=5)
+    kwargs = mock_client.call_args[1]
+    assert "contents" in kwargs
+    assert "system_instruction" in kwargs
+    assert isinstance(kwargs["system_instruction"], dict)
+
+def test_chat_adds_thinking_config_when_reasoning_level_set(adapter):
+    from src.llm_api_adapter.models.messages.chat_message import UserMessage
+    adapter.is_reasoning = True
+    adapter.reasoning_levels = {"medium": 5}
+    fake_response = {"some": "google response"}
+    with patch.object(GeminiSyncClient, "chat_completion", return_value=fake_response) as mock_client, \
+         patch.object(ChatResponse, "from_google_response", return_value=ChatResponse()):
+        adapter.chat([UserMessage("hi")], reasoning_level="medium")
+    kwargs = mock_client.call_args[1]
+    assert "generationConfig" in kwargs
+    gen_cfg = kwargs["generationConfig"]
+    assert "thinkingConfig" in gen_cfg
+    assert isinstance(gen_cfg["thinkingConfig"], dict)
+    assert gen_cfg["thinkingConfig"]["includeThoughts"] is False
+
+def test_normalize_reasoning_level_bool_raises(adapter):
+    with pytest.raises(ValueError):
+        adapter._normalize_reasoning_level(True)
+
+def test_normalize_reasoning_level_unknown_string_raises(adapter):
+    adapter.is_reasoning = True
+    adapter.reasoning_levels = {"low": 1}
+    with pytest.raises(ValueError):
+        adapter._normalize_reasoning_level("unknown_key")
+
+def test_normalize_reasoning_level_int_clamped_and_returns(adapter):
+    adapter.is_reasoning = True
+    adapter.reasoning_levels = {"low": 1}
+    assert adapter._normalize_reasoning_level(-1) == 0
+    assert adapter._normalize_reasoning_level(3) == 3
+
+def test_normalize_reasoning_level_warns_if_model_not_supporting(adapter):
+    adapter.is_reasoning = False
+    adapter.reasoning_levels = {"medium": 5}
+    with pytest.warns(UserWarning):
+        result = adapter._normalize_reasoning_level("medium")
+    assert result is None

--- a/tests/unit/adapters/test_openai_adapter.py
+++ b/tests/unit/adapters/test_openai_adapter.py
@@ -86,3 +86,40 @@ def test_pricing_is_applied_when_present(adapter):
         currency=adapter.pricing.currency,
     )
     assert result is fake_chat_response
+
+def test_normalize_reasoning_level_disabled_warns_and_returns_none(adapter):
+    adapter.is_reasoning = False
+    with pytest.warns(UserWarning) as record:
+        res = adapter._normalize_reasoning_level("low")
+    assert res is None
+    assert any("does not support reasoning" in str(w.message) for w in record)
+
+def test_normalize_reasoning_level_enabled_none_returns_none_string(adapter):
+    adapter.is_reasoning = True
+    res = adapter._normalize_reasoning_level(None)
+    assert res == "none"
+
+def test_normalize_reasoning_level_bool_raises(adapter):
+    adapter.is_reasoning = True
+    with pytest.raises(ValueError, match="bool is not accepted"):
+        adapter._normalize_reasoning_level(True)
+
+def test_normalize_reasoning_level_valid_string_key_returns_key(adapter):
+    adapter.is_reasoning = True
+    adapter.reasoning_levels = {"low": 1, "medium": 5, "high": 10}
+    assert adapter._normalize_reasoning_level("medium") == "medium"
+
+def test_normalize_reasoning_level_invalid_string_key_raises(adapter):
+    adapter.is_reasoning = True
+    adapter.reasoning_levels = {"low": 1, "medium": 5}
+    with pytest.raises(ValueError) as exc:
+        adapter._normalize_reasoning_level("unknown")
+    assert "Unknown reasoning level key" in str(exc.value)
+    assert "low" in str(exc.value) and "medium" in str(exc.value)
+
+def test_normalize_reasoning_level_int_maps_to_correct_key(adapter):
+    adapter.is_reasoning = True
+    adapter.reasoning_levels = {"low": 1, "medium": 5, "high": 10}
+    assert adapter._normalize_reasoning_level(0) == "low"
+    assert adapter._normalize_reasoning_level(3) == "medium"
+    assert adapter._normalize_reasoning_level(100) == "high"

--- a/tests/unit/errors/test_llm_api_error.py
+++ b/tests/unit/errors/test_llm_api_error.py
@@ -23,7 +23,7 @@ def test_llmapierror_message_and_detail():
     [
         (LLMAPIAuthorizationError, "Authentication or authorization failed.",
          ["InvalidAuthenticationError", "AuthenticationError"],
-         ["INVALID_ARGUMENT", "PERMISSION_DENIED"],
+         ["PERMISSION_DENIED"],
          ["AuthenticationError", "PermissionError"]),
         (LLMAPIRateLimitError, "Rate limit exceeded.",
          ["RateLimitError"],

--- a/tests/unit/llms/google/test_sync_client.py
+++ b/tests/unit/llms/google/test_sync_client.py
@@ -57,7 +57,7 @@ def test_send_request_exceptions(
 @pytest.mark.parametrize("status_code,error_status,expected_exception", [
     (401, "UNAUTHENTICATED", LLMAPIAuthorizationError),
     (429, "RESOURCE_EXHAUSTED", LLMAPIRateLimitError),
-    (400, "INVALID_ARGUMENT", LLMAPIAuthorizationError),
+    (400, "PERMISSION_DENIED", LLMAPIAuthorizationError),
     (500, "INTERNAL", LLMAPIServerError),
 ])
 @patch("src.llm_api_adapter.llms.google.sync_client.requests.post")

--- a/tests/unit/models/responses/test_chat_response.py
+++ b/tests/unit/models/responses/test_chat_response.py
@@ -26,7 +26,7 @@ def test_from_anthropic_response(monkeypatch):
         "usage": {"input_tokens": 30, "output_tokens": 70},
         "model": "claude-2",
         "id": "anthropic123",
-        "content": [{"text": "Hello from Anthropic!"}],
+        "content": [{"type": "text", "text": "Hello from Anthropic!"}],
         "stop_reason": "end"
     }
     monkeypatch.setattr("builtins.print", lambda *args, **kwargs: None)

--- a/tests/unit/test_universal_adapter.py
+++ b/tests/unit/test_universal_adapter.py
@@ -18,6 +18,9 @@ def test_selects_adapter_and_delegates(monkeypatch):
         def greet(self, name: str) -> str:
             return f"hello {name} from {self.company}"
 
+        def _normalize_reasoning_level(self, reasoning_level):
+            return reasoning_level
+
     monkeypatch.setattr(
         universal_module.LLMAdapterBase,
         "__subclasses__",
@@ -70,6 +73,9 @@ def test_getattr_missing_raises_attribute_error(monkeypatch):
 
         def chat(self, *args, **kwargs):
             return {"response": "ok"}
+        
+        def _normalize_reasoning_level(self, reasoning_level):
+            return reasoning_level
 
     monkeypatch.setattr(
         universal_module.LLMAdapterBase,


### PR DESCRIPTION
### Reasoning Support
- Added provider-agnostic `reasoning_level`.
- Added string-numeric mapping: `none=0`, `low=100`, `medium=1000`, `high=10000`.
- Automatic provider-aware normalization.
- When reasoning cannot be disabled, adapter uses minimal allowed value.

### Error Handling
- Added `LLMConfigError` (base config error).
- Added `LLMReasoningLevelError` for Anthropic max_tokens conflicts.
