### PR TITLE
Release/0.2.5

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r tests/requirements-test.txt
+          pip install -e .
 
       - name: Unit tests
         run: pytest -v -m unit

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -68,6 +68,10 @@ jobs:
     name: e2e tests (post-publish)
     runs-on: ubuntu-latest
     needs: publish-testpypi
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -64,8 +64,8 @@ jobs:
           verbose: true
           skip-existing: true
 
-  post-publish-integration:
-    name: Integration tests (post-publish)
+  post-publish-e2e:
+    name: e2e tests (post-publish)
     runs-on: ubuntu-latest
     needs: publish-testpypi
 

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -30,8 +30,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r tests/requirements-test.txt
 
-      - name: Unit & Integration Tests
-        run: python tests/tests_runner.py
+      - name: Unit tests
+        run: pytest -v -m unit
+
+      - name: Integration tests
+        run: pytest -v -m integration
 
   publish-testpypi:
     name: Publish to TestPyPI (dev)
@@ -59,3 +62,25 @@ jobs:
           repository-url: https://test.pypi.org/legacy/
           verbose: true
           skip-existing: true
+
+  post-publish-integration:
+    name: Integration tests (post-publish)
+    runs-on: ubuntu-latest
+    needs: publish-testpypi
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+
+      - name: Install package from TestPyPI
+        run: |
+          pip install --index-url https://test.pypi.org/simple/ \
+            --extra-index-url https://pypi.org/simple \
+            llm-api-adapter
+
+      - name: Integration tests
+        run: pytest -v -m integration

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -76,6 +76,9 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
+        
+      - name: Wait for TestPyPI
+        run: sleep 30
 
       - name: Install test runner + deps
         run: |

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -77,11 +77,16 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
 
+      - name: Install test runner + deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r tests/requirements-test.txt
+
       - name: Install package from TestPyPI
         run: |
           pip install --index-url https://test.pypi.org/simple/ \
             --extra-index-url https://pypi.org/simple \
             llm-api-adapter
 
-      - name: Integration tests
-        run: pytest -v -m integration
+      - name: e2e tests
+        run: pytest -v -m e2e

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -1,4 +1,4 @@
-name: CI (main)
+name: Tests
 
 env:
   PYTHON_VERSION: "3.10"

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: CI (main)
 
 env:
   PYTHON_VERSION: "3.10"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LLM API Adapter SDK for Python
 [![PyPI Downloads](https://static.pepy.tech/personalized-badge/llm-api-adapter?period=total&units=INTERNATIONAL_SYSTEM&left_color=BLACK&right_color=GREEN&left_text=downloads)](https://pepy.tech/projects/llm-api-adapter)
-[![CI (main)](https://github.com/Inozem/llm_api_adapter/actions/workflows/ci-main.yml/badge.svg)](https://github.com/Inozem/llm_api_adapter/actions/workflows/ci-main.yml)
+[![Tests](https://github.com/Inozem/llm_api_adapter/actions/workflows/ci-main.yml/badge.svg)](https://github.com/Inozem/llm_api_adapter/actions/workflows/ci-main.yml)
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ The SDK provides a set of standardized errors for easier debugging and integrati
 
 The SDK allows you to easily switch between LLM providers and specify the model you want to use. Currently supported providers are OpenAI, Anthropic, and Google.
 
-- **OpenAI**: You can use models like `gpt-5.2-pro`, `gpt-5.2`, `gpt-5.1`, `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`, `gpt-4o`, `gpt-4o-mini`.
+- **OpenAI**: You can use models like `gpt-5.2`, `gpt-5.1`, `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`, `gpt-4o`, `gpt-4o-mini`.
 - **Anthropic**: Available models include `claude-opus-4-5`, `claude-sonnet-4-5`, `claude-haiku-4-5`, `claude-opus-4-1`, `claude-opus-4-0`, `claude-sonnet-4-0`, `claude-3-7-sonnet-latest`, `claude-3-5-haiku-latest`, `claude-3-haiku-20240307`.
 - **Google**: Models such as `gemini-3-pro-preview`, `gemini-3-flash-preview`, `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`, `gemini-2.0-flash`, `gemini-2.0-flash-lite` can be used.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This lightweight SDK for Python allows you to use LLM APIs from various provider
 
 ### Version
 
-Current version: 0.2.4
+Current version: 0.2.5
 
 
 ## Features
@@ -22,6 +22,7 @@ Current version: 0.2.4
 - **Token and Cost Accounting**: Automatic calculation of token usage and cost per request.
 - **Pricing Registry**: Model prices are stored in a unified JSON registry with per-model input/output pricing and currency support.
 - **Unified Reasoning Support**: A single `reasoning_level` parameter that works identically across all providers.
+- **Request Timeouts:** Per-request timeout control with a unified `timeout_s` parameter.
 
 ## Installation
 
@@ -240,6 +241,51 @@ The `ChatResponse` object returned by `chat` includes:
 9. **content**: The generated text response.
 10. **finish\_reason**: Reason why generation stopped (e.g., `"stop"`, `"length"`).
 
+## Timeout Support
+
+The SDK supports per-request timeouts for all providers.
+
+### timeout\_s parameter
+
+`timeout_s` defines the maximum time (in seconds) the SDK will wait for an LLM response.
+
+If the timeout is exceeded, the request is aborted and `LLMAPITimeoutError` is raised.
+
+### Example
+
+```python
+chat_params = {
+    "messages": messages,
+    "timeout_s": 2.5
+}
+gpt = UniversalLLMAPIAdapter(
+    organization="openai",
+    model="gpt-5.2",
+    api_key=openai_api_key
+)
+response = gpt.chat(**chat_params)
+```
+
+### Notes
+
+- Timeout is applied uniformly across all providers.
+- The parameter is optional; if omitted, the provider default is used.
+- Timeout affects the full request lifecycle (network + model execution).
+
+### Handling timeout errors
+
+Timeouts raise a dedicated exception that can be handled explicitly:
+
+```python
+from llm_api_adapter.errors.llm_api_error import LLMAPITimeoutError
+
+try:
+    response = gpt.chat(**chat_params)
+except LLMAPITimeoutError:
+    # retry, fallback, or abort
+    print("LLM request timed out")
+```
+
 ## Reasoning Support
 
 This section describes the unified `reasoning_level` parameter that works the same way for all supported providers and their models.
@@ -432,30 +478,35 @@ Use this only in development.
 
 This project uses `pytest` for testing. Tests are located in the `tests/` directory.
 
-To run all tests, use the following command:
+### Test suites
+
+- **unit**: fast, offline, no real provider calls
+- **integration**: adapter-level integration tests (may use mocked/provider-shaped responses)
+- **e2e**: real API calls against providers (requires API keys)
+
+### Running tests
+
+Run everything:
 
 ```bash
 pytest
 ```
 
-Alternatively, you can run the tests using the `tests_runner.py` script:
+Run by marker:
 
 ```bash
-python tests/tests_runner.py
+pytest -m unit
+pytest -m integration
+pytest -m e2e
 ```
 
-### Dependencies
+### E2E requirements
 
-Ensure you have the required dependencies installed. You can install them using:
+E2E tests require provider API keys to be present in environment variables:
 
-```bash
-pip install -r requirements-test.txt
-```
-
-### Test Structure
-
-*   `unit/`: Contains unit tests for individual components.
-*   `integration/`: Contains integration tests to verify the interaction between different parts of the system.
+- `OPENAI_API_KEY`
+- `ANTHROPIC_API_KEY`
+- `GOOGLE_API_KEY`
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-api-adapter"
-version = "0.2.4"
+version = "0.2.5"
 description = "Lightweight, pluggable adapter for multiple LLM APIs (OpenAI, Anthropic, Google)"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    e2e: end-to-end tests (real LLM providers)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 markers =
+    unit: unit tests (no network, pure logic, mocks)
+    integration: integration tests (may use local services/mocked HTTP, no real providers)
     e2e: end-to-end tests (real LLM providers)

--- a/src/llm_api_adapter/adapters/anthropic_adapter.py
+++ b/src/llm_api_adapter/adapters/anthropic_adapter.py
@@ -23,7 +23,8 @@ class AnthropicAdapter(LLMAdapterBase):
         max_tokens: int,
         temperature: float = 1.0,
         top_p: float = 1.0,
-        reasoning_level: Optional[str | int] = None
+        reasoning_level: Optional[str | int] = None,
+        timeout_s: Optional[float] = None,
     ) -> ChatResponse:
         temperature = self._validate_parameter(
             name="temperature", value=temperature, min_value=0, max_value=2
@@ -42,6 +43,7 @@ class AnthropicAdapter(LLMAdapterBase):
                 "temperature": temperature,
                 "top_p": top_p,
                 "system": system_prompt,
+                "timeout_s": timeout_s,
             }
             if reasoning_level:
                 normalized_reasoning_level = self._normalize_reasoning_level(reasoning_level)

--- a/src/llm_api_adapter/adapters/anthropic_adapter.py
+++ b/src/llm_api_adapter/adapters/anthropic_adapter.py
@@ -76,7 +76,7 @@ class AnthropicAdapter(LLMAdapterBase):
     def _normalize_reasoning_level(self, level: str | int) -> int | None:
         minimum_level = 1024
         normalized_level = None
-        if level and not self.is_reasoning:
+        if level is not None and not self.is_reasoning:
             warning_message = (f"Model '{self.model}' does not support reasoning "
                                "— reasoning disabled.")
             warnings.warn(warning_message, UserWarning)
@@ -92,7 +92,7 @@ class AnthropicAdapter(LLMAdapterBase):
                                  f"Valid keys: {list(self.reasoning_levels.keys())}")
         if isinstance(level, int):
             normalized_level = level
-        if normalized_level:
+        if normalized_level is not None:
             if normalized_level >= minimum_level:
                 return normalized_level
             warning_message = (

--- a/src/llm_api_adapter/adapters/google_adapter.py
+++ b/src/llm_api_adapter/adapters/google_adapter.py
@@ -22,7 +22,8 @@ class GoogleAdapter(LLMAdapterBase):
         max_tokens: Optional[int] = None,
         temperature: float = 1.0,
         top_p: float = 1.0,
-        reasoning_level: Optional[str | int] = None
+        reasoning_level: Optional[str | int] = None,
+        timeout_s: Optional[float] = None,
     ) -> ChatResponse:
         temperature = self._validate_parameter(
             name="temperature", value=temperature, min_value=0, max_value=2
@@ -54,6 +55,7 @@ class GoogleAdapter(LLMAdapterBase):
             client = GeminiSyncClient(self.api_key)
             response_json = client.chat_completion(
                 model=self.model,
+                timeout_s=timeout_s,
                 **payload
             )
             chat_response = ChatResponse.from_google_response(response_json)

--- a/src/llm_api_adapter/adapters/google_adapter.py
+++ b/src/llm_api_adapter/adapters/google_adapter.py
@@ -75,7 +75,7 @@ class GoogleAdapter(LLMAdapterBase):
     def _normalize_reasoning_level(self, level: str | int | None) -> str | None:
         minimum_level = 0
         normalized_level = None
-        if level and not self.is_reasoning:
+        if level is not None and not self.is_reasoning:
             warning_message = (f"Model '{self.model}' does not support reasoning "
                                "— reasoning disabled.")
             warnings.warn(warning_message, UserWarning)
@@ -91,7 +91,7 @@ class GoogleAdapter(LLMAdapterBase):
                                  f"Valid keys: {list(self.reasoning_levels.keys())}")
         if isinstance(level, int):
             normalized_level = level
-        if normalized_level:
+        if normalized_level is not None:
             if normalized_level >= minimum_level:
                 return normalized_level
             return minimum_level

--- a/src/llm_api_adapter/adapters/openai_adapter.py
+++ b/src/llm_api_adapter/adapters/openai_adapter.py
@@ -22,7 +22,8 @@ class OpenAIAdapter(LLMAdapterBase):
         max_tokens: Optional[int] = None,
         temperature: float = 1.0,
         top_p: float = 1.0,
-        reasoning_level: Optional[str | int] = None
+        reasoning_level: Optional[str | int] = None,
+        timeout_s: Optional[float] = None
     ) -> ChatResponse:
         temperature = self._validate_parameter(
             name="temperature", value=temperature, min_value=0, max_value=2
@@ -41,10 +42,10 @@ class OpenAIAdapter(LLMAdapterBase):
                 "max_tokens": max_tokens,
                 "temperature": temperature,
                 "top_p": top_p,
-                "reasoning_effort": normalized_reasoning_level, 
+                "reasoning_effort": normalized_reasoning_level,
             }
             params = {k: v for k, v in params.items() if v is not None}
-            response = client.chat_completion(**params)
+            response = client.chat_completion(timeout=timeout_s, **params)
             chat_response = ChatResponse.from_openai_response(response)
             if self.pricing:
                 chat_response.apply_pricing(

--- a/src/llm_api_adapter/adapters/openai_adapter.py
+++ b/src/llm_api_adapter/adapters/openai_adapter.py
@@ -61,27 +61,30 @@ class OpenAIAdapter(LLMAdapterBase):
             self.handle_error(error=e, error_message=error_message)
 
     def _normalize_reasoning_level(self, level: str | int | None) -> str | None:
-        if level and not self.is_reasoning:
-            warning_message = (f"Model '{self.model}' does not support reasoning "
-                               "— reasoning disabled.")
+        if level is None:
+            return "none" if self.is_reasoning else None
+        if not self.is_reasoning and level not in ("none", 0):
+            warning_message = (
+                f"Model '{self.model}' does not support reasoning — reasoning disabled."
+            )
             warnings.warn(warning_message, UserWarning)
             logger.info(warning_message)
-            return None
-        if self.is_reasoning and level is None:
-            return "none"
-        if level is None:
             return None
         if isinstance(level, bool):
             raise ValueError("Invalid type for level: bool is not accepted")
         if isinstance(level, str):
             if level in self.reasoning_levels:
                 return level
-            raise ValueError(f"Unknown reasoning level key: {level!r}. "
-                            f"Valid keys: {list(self.reasoning_levels.keys())}")
+            raise ValueError(
+                f"Unknown reasoning level key: {level!r}. "
+                f"Valid keys: {list(self.reasoning_levels.keys())}"
+            )
         if isinstance(level, int):
             for key, val in self.reasoning_levels.items():
                 if level <= val:
                     return key
             return list(self.reasoning_levels.keys())[-1]
-        raise ValueError("Invalid type for level: expected int or str, "
-                         f"got {type(level).__name__!r}")
+        raise ValueError(
+            "Invalid type for level: expected int or str, "
+            f"got {type(level).__name__!r}"
+        )

--- a/src/llm_api_adapter/adapters/openai_adapter.py
+++ b/src/llm_api_adapter/adapters/openai_adapter.py
@@ -69,6 +69,8 @@ class OpenAIAdapter(LLMAdapterBase):
             return None
         if self.is_reasoning and level is None:
             return "none"
+        if level is None:
+            return None
         if isinstance(level, bool):
             raise ValueError("Invalid type for level: bool is not accepted")
         if isinstance(level, str):

--- a/src/llm_api_adapter/llm_registry/llm_registry.json
+++ b/src/llm_api_adapter/llm_registry/llm_registry.json
@@ -5,10 +5,6 @@
     "openai": {
       "currency": "USD",
       "models": {
-        "gpt-5.2-pro": {
-          "pricing": {"in_per_1m": 21.0, "out_per_1m": 168.0},
-          "is_reasoning": true
-        },
         "gpt-5.2": {
           "pricing": {"in_per_1m": 1.75, "out_per_1m": 14.0},
           "is_reasoning": true

--- a/src/llm_api_adapter/llms/anthropic/sync_client.py
+++ b/src/llm_api_adapter/llms/anthropic/sync_client.py
@@ -40,7 +40,7 @@ class ClaudeSyncClient:
             kwargs.pop("top_p", None)
         return {"model": model, **kwargs}
 
-    def _send_request(self, url: str, payload: dict, timeout_s: float):
+    def _send_request(self, url: str, payload: dict, timeout_s: float | None = None):
         try:
             response = requests.post(
                 url, headers=self._headers(), json=payload, timeout=timeout_s,

--- a/src/llm_api_adapter/llms/anthropic/sync_client.py
+++ b/src/llm_api_adapter/llms/anthropic/sync_client.py
@@ -27,10 +27,10 @@ class ClaudeSyncClient:
             "Content-Type": "application/json"
         }
 
-    def chat_completion(self, model: str, **kwargs):
+    def chat_completion(self, model: str, timeout_s: float | None = None, **kwargs):
         url = f"{self.endpoint}/messages"
         payload = self._prepare_chat_payload_for_model(model, kwargs)
-        response = self._send_request(url, payload)
+        response = self._send_request(url, payload, timeout_s)
         return response.json()
 
     def _prepare_chat_payload_for_model(self, model: str, kwargs: dict) -> dict:
@@ -40,10 +40,10 @@ class ClaudeSyncClient:
             kwargs.pop("top_p", None)
         return {"model": model, **kwargs}
 
-    def _send_request(self, url, payload):
+    def _send_request(self, url: str, payload: dict, timeout_s: float):
         try:
             response = requests.post(
-                url, headers=self._headers(), json=payload
+                url, headers=self._headers(), json=payload, timeout=timeout_s,
             )
             response.raise_for_status()
         except requests.exceptions.Timeout as e:

--- a/src/llm_api_adapter/llms/google/sync_client.py
+++ b/src/llm_api_adapter/llms/google/sync_client.py
@@ -24,10 +24,10 @@ class GeminiSyncClient:
             "Content-Type": "application/json"
         }
 
-    def chat_completion(self, model: str, **kwargs):
+    def chat_completion(self, model: str, timeout_s: float | None = None, **kwargs):
         url = f"{self.endpoint}/models/{model}:generateContent"
         payload = self._prepare_chat_payload_for_model(model, kwargs)
-        response = self._send_request(url, payload)
+        response = self._send_request(url, payload, timeout_s)
         return response.json()
 
     def _prepare_chat_payload_for_model(self, model: str, kwargs: dict) -> dict:
@@ -48,10 +48,10 @@ class GeminiSyncClient:
                 thinking_config["thinkingBudget"] = min_budget
         return {"model": model, **kwargs}
 
-    def _send_request(self, url, payload):
+    def _send_request(self, url: str, payload: dict, timeout_s: float):
         try:
             response = requests.post(
-                url, headers=self._headers(), json=payload, timeout=30
+                url, headers=self._headers(), json=payload,  timeout=timeout_s,
             )
             response.raise_for_status()
         except requests.exceptions.Timeout as e:

--- a/src/llm_api_adapter/llms/google/sync_client.py
+++ b/src/llm_api_adapter/llms/google/sync_client.py
@@ -48,7 +48,7 @@ class GeminiSyncClient:
                 thinking_config["thinkingBudget"] = min_budget
         return {"model": model, **kwargs}
 
-    def _send_request(self, url: str, payload: dict, timeout_s: float):
+    def _send_request(self, url: str, payload: dict, timeout_s: float | None = None):
         try:
             response = requests.post(
                 url, headers=self._headers(), json=payload,  timeout=timeout_s,

--- a/src/llm_api_adapter/llms/google/sync_client.py
+++ b/src/llm_api_adapter/llms/google/sync_client.py
@@ -76,15 +76,9 @@ class GeminiSyncClient:
             error_status = ""
             error_message = None
         detail = error_message or str(http_err)
-        error_map = {
-            401: LLMAPIAuthorizationError,
-            429: LLMAPIRateLimitError,
-        }
-        if status_code in error_map:
-            raise error_map[status_code](detail=detail)
-        elif error_status in LLMAPIAuthorizationError.google_api_errors:
+        if self._is_google_auth_error(status_code, error_status, error_message):
             raise LLMAPIAuthorizationError(detail=detail)
-        elif error_status in LLMAPIRateLimitError.google_api_errors:
+        elif status_code == 429 or error_status in LLMAPIRateLimitError.google_api_errors:
             raise LLMAPIRateLimitError(detail=detail)
         elif 400 <= status_code < 500:
             raise LLMAPIClientError(detail=detail)
@@ -95,3 +89,21 @@ class GeminiSyncClient:
             raise LLMAPIServerError(detail=detail)
         else:
             raise LLMAPIClientError(detail=detail)
+
+    def _is_google_auth_error(self, status_code, error_status, error_message: str | None) -> bool:
+        if status_code in (401, 403):
+            return True
+        if error_status in LLMAPIAuthorizationError.google_api_errors:
+            return True
+        if error_message:
+            msg = error_message.lower()
+            return any(
+                k in msg
+                for k in (
+                    "api key not valid",
+                    "api key invalid",
+                    "api key not found",
+                    "invalid api key",
+                )
+            )
+        return False

--- a/src/llm_api_adapter/llms/openai/sync_client.py
+++ b/src/llm_api_adapter/llms/openai/sync_client.py
@@ -26,10 +26,10 @@ class OpenAISyncClient:
             "Content-Type": "application/json"
         }
 
-    def chat_completion(self, model: str, **kwargs):
+    def chat_completion(self, model: str, timeout: float | None = None, **kwargs):
         url = f"{self.endpoint}/chat/completions"
         payload = self._prepare_chat_payload_for_model(model, kwargs)
-        response = self._send_request(url, payload)
+        response = self._send_request(url, payload, timeout)
         return response.json()
 
     def _prepare_chat_payload_for_model(self, model: str, kwargs: dict) -> dict:
@@ -41,10 +41,10 @@ class OpenAISyncClient:
                 kwargs["reasoning_effort"] = "minimal"
         return {"model": model, **kwargs}
 
-    def _send_request(self, url, payload):
+    def _send_request(self, url: str, payload: dict, timeout: float):
         try:
             response = requests.post(
-                url, headers=self._headers(), json=payload
+                url, headers=self._headers(), json=payload, timeout=timeout
             )
             response.raise_for_status()
         except requests.exceptions.Timeout as e:

--- a/src/llm_api_adapter/llms/openai/sync_client.py
+++ b/src/llm_api_adapter/llms/openai/sync_client.py
@@ -41,7 +41,7 @@ class OpenAISyncClient:
                 kwargs["reasoning_effort"] = "minimal"
         return {"model": model, **kwargs}
 
-    def _send_request(self, url: str, payload: dict, timeout: float):
+    def _send_request(self, url: str, payload: dict, timeout: float | None = None):
         try:
             response = requests.post(
                 url, headers=self._headers(), json=payload, timeout=timeout

--- a/tests/e2e/__init__.py
+++ b/tests/e2e/__init__.py
@@ -1,0 +1,1 @@
+# Tests package for Azure Functions 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,29 @@
+import os
+
+from dotenv import load_dotenv
+import pytest
+
+from llm_api_adapter.llm_registry.llm_registry import LLM_REGISTRY
+
+load_dotenv()
+
+API_KEY_ENV = {
+    "openai": os.getenv("OPENAI_API_KEY"),
+    "anthropic": os.getenv("ANTHROPIC_API_KEY"),
+    "google": os.getenv("GOOGLE_API_KEY"),
+}
+
+@pytest.fixture(scope="session")
+def providers():
+    providers_with_models = []
+    for provider_name, provider_spec in LLM_REGISTRY.providers.items():
+        api_key = API_KEY_ENV.get(provider_name)
+        registry_models = list(provider_spec.models.keys())
+        providers_with_models.append(
+            {
+                "name": provider_name,
+                "api_key": api_key,
+                "models": registry_models,
+            }
+        )
+    return providers_with_models

--- a/tests/e2e/test_errors.py
+++ b/tests/e2e/test_errors.py
@@ -38,4 +38,4 @@ def test_chat_timeout_error(providers):
                 temperature=1.0,
             )
             with pytest.raises(LLMAPITimeoutError):
-                adapter.chat(**base_kwargs, **{"timeout_s": 0.001})
+                adapter.chat(**base_kwargs, **{"timeout_s": 0.1})

--- a/tests/e2e/test_errors.py
+++ b/tests/e2e/test_errors.py
@@ -1,0 +1,41 @@
+import pytest
+
+from llm_api_adapter.errors.llm_api_error import LLMAPIAuthorizationError, LLMAPITimeoutError
+from llm_api_adapter.models.messages.chat_message import UserMessage
+from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
+
+@pytest.mark.e2e
+def test_chat_auth_error_invalid_api_key(providers):
+    """
+    Verifies that an invalid API key is converted into a LLMAPIAuthorizationError.
+    """
+    for p in providers:
+        for model in p["models"]:
+            adapter = UniversalLLMAPIAdapter(
+                organization=p["name"],
+                model=model,
+                api_key="NON_VALID_KEY",
+            )
+            with pytest.raises(LLMAPIAuthorizationError) as excinfo:
+                adapter.chat(messages=[UserMessage("Say 'OK'.")], max_tokens=8)
+            print(f"{p['name']=} {model=}: {excinfo.value}")
+
+@pytest.mark.e2e
+def test_chat_timeout_error(providers):
+    """
+    Verifies that an extremely small timeout is converted into a LLMAPITimeoutError.
+    """
+    for p in providers:
+        for model in p["models"]:
+            adapter = UniversalLLMAPIAdapter(
+                organization=p["name"],
+                model=model,
+                api_key=p["api_key"],
+            )
+            base_kwargs = dict(
+                messages=[UserMessage("Say 'OK'.")],
+                max_tokens=512,
+                temperature=1.0,
+            )
+            with pytest.raises(LLMAPITimeoutError):
+                adapter.chat(**base_kwargs, **{"timeout_s": 0.001})

--- a/tests/e2e/test_llm_adapter_chat.py
+++ b/tests/e2e/test_llm_adapter_chat.py
@@ -1,4 +1,5 @@
 from math import isclose
+import time
 
 import pytest
 
@@ -8,6 +9,8 @@ from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
 @pytest.mark.e2e
 def test_chat_accepts_basic_params_and_returns_contract(providers):
     for p in providers:
+        sleep = 3
+        time.sleep(sleep)
         for model in p["models"]:
             adapter = UniversalLLMAPIAdapter(
                 organization=p["name"],
@@ -43,6 +46,8 @@ def test_chat_accepts_basic_params_and_returns_contract(providers):
 @pytest.mark.e2e
 def test_chat_with_reasoning_level_returns_valid_contract(providers):
     for p in providers:
+        sleep = 3
+        time.sleep(sleep)
         for model in p["models"]:
             adapter = UniversalLLMAPIAdapter(
                 organization=p["name"],

--- a/tests/e2e/test_llm_adapter_chat.py
+++ b/tests/e2e/test_llm_adapter_chat.py
@@ -1,0 +1,74 @@
+from math import isclose
+
+import pytest
+
+from llm_api_adapter.models.messages.chat_message import UserMessage     
+from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
+
+@pytest.mark.e2e
+def test_chat_accepts_basic_params_and_returns_contract(providers):
+    for p in providers:
+        for model in p["models"]:
+            adapter = UniversalLLMAPIAdapter(
+                organization=p["name"],
+                model=model,
+                api_key=p["api_key"],
+            )
+            resp = adapter.chat(
+                messages=[UserMessage("Say 'OK'.")],
+                max_tokens=1026,
+                temperature=1.0,
+                top_p=1.0,
+            )
+
+            # content
+            assert isinstance(resp.content, str)
+
+            # model & finish
+            assert isinstance(resp.finish_reason, str)
+
+            # usage
+            assert resp.usage is not None
+            assert resp.usage.input_tokens >= 0
+            assert resp.usage.output_tokens >= 0
+            assert resp.usage.total_tokens >= resp.usage.input_tokens
+
+            # cost
+            assert resp.currency
+            assert resp.cost_input >= 0
+            assert resp.cost_output >= 0
+            assert resp.cost_total >= 0
+            assert abs(resp.cost_total - (resp.cost_input + resp.cost_output)) < 1e-9
+
+@pytest.mark.e2e
+def test_chat_with_reasoning_level_returns_valid_contract(providers):
+    for p in providers:
+        for model in p["models"]:
+            adapter = UniversalLLMAPIAdapter(
+                organization=p["name"],
+                model=model,
+                api_key=p["api_key"],
+            )
+            resp = adapter.chat(
+                messages=[{"role": "user", "content": "Say 'OK'."}],
+                max_tokens=1026,
+                reasoning_level=1024,
+            )
+
+            # contract
+            assert isinstance(resp.content, str)
+            assert isinstance(resp.finish_reason, str) and resp.finish_reason
+
+            # usage (reasoning may add extra tokens; don't assume exact equality)
+            assert resp.usage is not None
+            assert resp.usage.input_tokens >= 0
+            assert resp.usage.output_tokens >= 0
+            assert resp.usage.total_tokens >= 0
+            assert resp.usage.total_tokens >= resp.usage.input_tokens + resp.usage.output_tokens
+
+            # cost
+            assert isinstance(resp.currency, str) and resp.currency
+            assert resp.cost_input is not None and resp.cost_input >= 0
+            assert resp.cost_output is not None and resp.cost_output >= 0
+            assert resp.cost_total is not None and resp.cost_total >= 0
+            assert isclose(resp.cost_total, resp.cost_input + resp.cost_output, rel_tol=0, abs_tol=1e-9)

--- a/tests/integration/test_universal_adapter.py
+++ b/tests/integration/test_universal_adapter.py
@@ -42,6 +42,7 @@ def anthropic_client_mock():
         })
         yield mock
 
+@pytest.mark.integration
 def test_openai_chat(openai_client_mock):
     messages = [
         Prompt("You are an assistant."),
@@ -57,6 +58,7 @@ def test_openai_chat(openai_client_mock):
     response = adapter.chat(messages=messages)
     assert response.content == "Hello from mocked OpenAI!"
 
+@pytest.mark.integration
 def test_openai_chat_with_raw_dict_messages(openai_client_mock):
     messages = [
         {"role": "system", "content": "You are a friendly assistant who answers only yes or no."},
@@ -72,6 +74,7 @@ def test_openai_chat_with_raw_dict_messages(openai_client_mock):
     resp = adapter.chat(messages=messages)
     assert resp.content == "Hello from mocked OpenAI!"
 
+@pytest.mark.integration
 def test_google_chat(google_client_mock):
     adapter = UniversalLLMAPIAdapter(
         organization="google",
@@ -87,6 +90,7 @@ def test_google_chat(google_client_mock):
     resp = adapter.chat(messages=messages)
     assert resp.content == "Hello from mocked Google!"
 
+@pytest.mark.integration
 def test_google_chat_with_raw_dict_messages(google_client_mock):
     messages = [
         {"role": "system", "content": "You are a friendly assistant who answers only yes or no."},
@@ -102,6 +106,7 @@ def test_google_chat_with_raw_dict_messages(google_client_mock):
     resp = adapter.chat(messages=messages)
     assert resp.content == "Hello from mocked Google!"
 
+@pytest.mark.integration
 def test_anthropic_chat(anthropic_client_mock):
     adapter = UniversalLLMAPIAdapter(
         organization="anthropic",
@@ -117,6 +122,7 @@ def test_anthropic_chat(anthropic_client_mock):
     resp = adapter.chat(messages=messages, max_tokens=2000)
     assert resp.content == "Hello from mocked Anthropic!"
 
+@pytest.mark.integration
 def test_anthropic_chat_with_raw_dict_messages(anthropic_client_mock):
     messages = [
         {"role": "system", "content": "You are a friendly assistant who answers only yes or no."},
@@ -132,6 +138,7 @@ def test_anthropic_chat_with_raw_dict_messages(anthropic_client_mock):
     resp = adapter.chat(messages=messages, max_tokens=2000)
     assert resp.content == "Hello from mocked Anthropic!"
 
+@pytest.mark.integration
 def test_google_usage_and_pricing(google_client_mock):
     adapter = UniversalLLMAPIAdapter(
         organization="google",
@@ -151,6 +158,7 @@ def test_google_usage_and_pricing(google_client_mock):
     assert resp.cost_total == 0
     assert resp.currency == "EUR"
 
+@pytest.mark.integration
 def test_anthropic_tokens_and_pricing(anthropic_client_mock):
     adapter = UniversalLLMAPIAdapter(
         organization="anthropic",

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -1,4 +1,5 @@
 # Test dependencies
+python-dotenv
 httpx==0.28.1
 pytest==8.4.1
 pytest-asyncio==1.0.0

--- a/tests/unit/adapters/test_anthropic_adapter.py
+++ b/tests/unit/adapters/test_anthropic_adapter.py
@@ -21,6 +21,7 @@ def adapter():
     (2.1, 256, False),
     (0.0, 256, True),
 ])
+@pytest.mark.unit
 def test_temperature_validation(adapter, temperature, width, valid):
     if valid:
         result = adapter._validate_parameter("temperature", temperature, 0, 2)
@@ -29,6 +30,7 @@ def test_temperature_validation(adapter, temperature, width, valid):
         with pytest.raises(ValueError):
             adapter._validate_parameter("temperature", temperature, 0, 2)
 
+@pytest.mark.unit
 def test_chat_handles_llmapi_error(adapter):
     messages = [Prompt("system prompt"), UserMessage("hello")]
     method = "chat_completion"
@@ -38,6 +40,7 @@ def test_chat_handles_llmapi_error(adapter):
         adapter.chat(messages=messages, max_tokens=2000)
         mock_handle_error.assert_called_once()
 
+@pytest.mark.unit
 def test_chat_handles_generic_exception(adapter):
     messages = [Prompt("system prompt"), UserMessage("hello")]
     method = "chat_completion"
@@ -47,6 +50,7 @@ def test_chat_handles_generic_exception(adapter):
         adapter.chat(messages=messages, max_tokens=2000)
         mock_handle_error.assert_called_once()
 
+@pytest.mark.unit
 def test_pricing_is_applied_when_present(adapter):
     adapter.pricing = type("P", (), {
         "in_per_token": 0.001, "out_per_token": 0.002, "currency": "USD"
@@ -74,23 +78,27 @@ def test_pricing_is_applied_when_present(adapter):
             currency=adapter.pricing.currency,
         )
 
+@pytest.mark.unit
 def test_normalize_reasoning_level_int_below_minimum_warns(adapter):
     adapter.is_reasoning = True
     with pytest.warns(UserWarning):
         result = adapter._normalize_reasoning_level(512)
     assert result == 1024
 
+@pytest.mark.unit
 def test_normalize_reasoning_level_bool_raises(adapter):
     adapter.is_reasoning = True
     with pytest.raises(ValueError):
         adapter._normalize_reasoning_level(True)
 
+@pytest.mark.unit
 def test_normalize_reasoning_level_unknown_str_raises(adapter):
     adapter.is_reasoning = True
     adapter.reasoning_levels = {"low": 2048}
     with pytest.raises(ValueError):
         adapter._normalize_reasoning_level("unknown-key")
 
+@pytest.mark.unit
 def test_chat_sets_thinking_when_reasoning_level_provided(adapter):
     adapter.is_reasoning = True
     adapter.reasoning_levels = {"high": 4096}
@@ -105,6 +113,7 @@ def test_chat_sets_thinking_when_reasoning_level_provided(adapter):
         assert kwargs["thinking"]["type"] == "enabled"
         assert kwargs["thinking"]["budget_tokens"] == 4096
 
+@pytest.mark.unit
 def test_validate_reasoning_and_tokens_raises_llmconfigerror(adapter):
     from src.llm_api_adapter.errors.config_errors import LLMConfigError
     with pytest.raises(LLMConfigError):

--- a/tests/unit/adapters/test_base_adapter.py
+++ b/tests/unit/adapters/test_base_adapter.py
@@ -57,6 +57,7 @@ def adapter():
     (1.0, 256, -0.1, False),
     (1.0, 256, 1.1, False),
 ])
+@pytest.mark.unit
 def test_parameter_validation(adapter, temperature, max_tokens, top_p, valid):
     if valid:
         temp_result = adapter._validate_parameter(
@@ -73,7 +74,7 @@ def test_parameter_validation(adapter, temperature, max_tokens, top_p, valid):
             with pytest.raises(ValueError):
                 adapter._validate_parameter("top_p", top_p, 0, 1)
 
-
+@pytest.mark.unit
 def test_chat_handles_llmapi_error(adapter):
     messages = [Prompt("system prompt"), UserMessage("hello")]
     with patch.object(
@@ -82,7 +83,7 @@ def test_chat_handles_llmapi_error(adapter):
         adapter.chat(messages)
         mock_handle_error.assert_called_once()
 
-
+@pytest.mark.unit
 def test_chat_handles_generic_exception(adapter):
     messages = [Prompt("system prompt"), UserMessage("hello")]
     with patch.object(
@@ -91,10 +92,12 @@ def test_chat_handles_generic_exception(adapter):
         adapter.chat(messages)
         mock_handle_error.assert_called_once()
 
+@pytest.mark.unit
 def test_init_with_empty_api_key_raises():
     with pytest.raises(ValueError):
         _TestAdapter(company="any", api_key="", model="m1")
 
+@pytest.mark.unit
 def test_unverified_model_warns_and_leaves_pricing_none(monkeypatch):
     monkeypatch.setattr(
         base_module,
@@ -106,6 +109,7 @@ def test_unverified_model_warns_and_leaves_pricing_none(monkeypatch):
         a = _TestAdapter(company="missing", api_key="k", model="unknown-model")
     assert a.pricing is None
 
+@pytest.mark.unit
 def test_pricing_copied_from_registry(monkeypatch):
     base_pricing = {"cost_per_token": 0.001}
     provider = SimpleNamespace(
@@ -121,6 +125,7 @@ def test_pricing_copied_from_registry(monkeypatch):
     assert adapter_instance.pricing == base_pricing
     assert adapter_instance.pricing is not base_pricing
 
+@pytest.mark.unit
 def test_normalize_messages_accepts_list_and_messages(adapter):
     raw_messages = [UserMessage("hi")]
     normalized = adapter._normalize_messages(raw_messages)
@@ -130,10 +135,12 @@ def test_normalize_messages_accepts_list_and_messages(adapter):
     with pytest.raises(TypeError):
         adapter._normalize_messages(123)
 
+@pytest.mark.unit
 def test_generate_chat_answer_emits_deprecation_warning(adapter):
     with pytest.warns(DeprecationWarning):
         adapter.generate_chat_answer(messages=[UserMessage("hi")])
 
+@pytest.mark.unit
 def test_handle_error_reraises_and_logs(adapter, caplog):
     err = Exception("boom")
     with pytest.raises(Exception) as excinfo:

--- a/tests/unit/adapters/test_google_adapter.py
+++ b/tests/unit/adapters/test_google_adapter.py
@@ -23,6 +23,7 @@ def adapter():
     (1.0, 256, -0.1, False),
     (1.0, 256, 1.1, False),
 ])
+@pytest.mark.unit
 def test_parameter_validation(adapter, temperature, max_tokens, top_p, valid):
     if valid:
         temp_result = adapter._validate_parameter(
@@ -39,6 +40,7 @@ def test_parameter_validation(adapter, temperature, max_tokens, top_p, valid):
             with pytest.raises(ValueError):
                 adapter._validate_parameter("top_p", top_p, 0, 1)
 
+@pytest.mark.unit
 def test_chat_handles_llmapi_error(adapter):
     messages = [Prompt("system prompt"), UserMessage("hello")]
     method = "chat_completion"
@@ -48,6 +50,7 @@ def test_chat_handles_llmapi_error(adapter):
         adapter.chat(messages)
         mock_handle_error.assert_called_once()
 
+@pytest.mark.unit
 def test_chat_handles_generic_exception(adapter):
     messages = [Prompt("system prompt"), UserMessage("hello")]
     method = "chat_completion"
@@ -57,6 +60,7 @@ def test_chat_handles_generic_exception(adapter):
         adapter.chat(messages)
         mock_handle_error.assert_called_once()
 
+@pytest.mark.unit
 def test_pricing_is_applied_when_present(adapter):
     adapter.pricing = type("P", (), {
         "in_per_token": 0.001, "out_per_token": 0.002, "currency": "USD"
@@ -87,6 +91,7 @@ def test_pricing_is_applied_when_present(adapter):
     )
     assert result is fake_chat_response
 
+@pytest.mark.unit
 def test_chat_includes_system_instruction_in_payload(adapter):
     from src.llm_api_adapter.models.messages.chat_message import Prompt, UserMessage
     messages = [Prompt("system prompt"), UserMessage("hello")]
@@ -99,6 +104,7 @@ def test_chat_includes_system_instruction_in_payload(adapter):
     assert "system_instruction" in kwargs
     assert isinstance(kwargs["system_instruction"], dict)
 
+@pytest.mark.unit
 def test_chat_adds_thinking_config_when_reasoning_level_set(adapter):
     from src.llm_api_adapter.models.messages.chat_message import UserMessage
     adapter.is_reasoning = True
@@ -114,22 +120,26 @@ def test_chat_adds_thinking_config_when_reasoning_level_set(adapter):
     assert isinstance(gen_cfg["thinkingConfig"], dict)
     assert gen_cfg["thinkingConfig"]["includeThoughts"] is False
 
+@pytest.mark.unit
 def test_normalize_reasoning_level_bool_raises(adapter):
     with pytest.raises(ValueError):
         adapter._normalize_reasoning_level(True)
 
+@pytest.mark.unit
 def test_normalize_reasoning_level_unknown_string_raises(adapter):
     adapter.is_reasoning = True
     adapter.reasoning_levels = {"low": 1}
     with pytest.raises(ValueError):
         adapter._normalize_reasoning_level("unknown_key")
 
+@pytest.mark.unit
 def test_normalize_reasoning_level_int_clamped_and_returns(adapter):
     adapter.is_reasoning = True
     adapter.reasoning_levels = {"low": 1}
     assert adapter._normalize_reasoning_level(-1) == 0
     assert adapter._normalize_reasoning_level(3) == 3
 
+@pytest.mark.unit
 def test_normalize_reasoning_level_warns_if_model_not_supporting(adapter):
     adapter.is_reasoning = False
     adapter.reasoning_levels = {"medium": 5}

--- a/tests/unit/adapters/test_openai_adapter.py
+++ b/tests/unit/adapters/test_openai_adapter.py
@@ -23,6 +23,7 @@ def adapter():
     (1.0, 256, -0.1, False),
     (1.0, 256, 1.1, False),
 ])
+@pytest.mark.unit
 def test_parameter_validation(adapter, temperature, max_tokens, top_p, valid):
     if valid:
         temp_result = adapter._validate_parameter(
@@ -39,6 +40,7 @@ def test_parameter_validation(adapter, temperature, max_tokens, top_p, valid):
             with pytest.raises(ValueError):
                 adapter._validate_parameter("top_p", top_p, 0, 1)
 
+@pytest.mark.unit
 def test_chat_handles_llmapi_error(adapter):
     messages = [Prompt("system prompt"), UserMessage("hello")]
     method = "chat_completion"
@@ -48,6 +50,7 @@ def test_chat_handles_llmapi_error(adapter):
         adapter.chat(messages)
         mock_handle_error.assert_called_once()
 
+@pytest.mark.unit
 def test_chat_handles_generic_exception(adapter):
     messages = [Prompt("system prompt"), UserMessage("hello")]
     method = "chat_completion"
@@ -57,6 +60,7 @@ def test_chat_handles_generic_exception(adapter):
         adapter.chat(messages)
         mock_handle_error.assert_called_once()
 
+@pytest.mark.unit
 def test_pricing_is_applied_when_present(adapter):
     adapter.pricing = type("P", (), {
         "in_per_token": 0.001, "out_per_token": 0.002, "currency": "USD"
@@ -87,6 +91,7 @@ def test_pricing_is_applied_when_present(adapter):
     )
     assert result is fake_chat_response
 
+@pytest.mark.unit
 def test_normalize_reasoning_level_disabled_warns_and_returns_none(adapter):
     adapter.is_reasoning = False
     with pytest.warns(UserWarning) as record:
@@ -94,21 +99,25 @@ def test_normalize_reasoning_level_disabled_warns_and_returns_none(adapter):
     assert res is None
     assert any("does not support reasoning" in str(w.message) for w in record)
 
+@pytest.mark.unit
 def test_normalize_reasoning_level_enabled_none_returns_none_string(adapter):
     adapter.is_reasoning = True
     res = adapter._normalize_reasoning_level(None)
     assert res == "none"
 
+@pytest.mark.unit
 def test_normalize_reasoning_level_bool_raises(adapter):
     adapter.is_reasoning = True
     with pytest.raises(ValueError, match="bool is not accepted"):
         adapter._normalize_reasoning_level(True)
 
+@pytest.mark.unit
 def test_normalize_reasoning_level_valid_string_key_returns_key(adapter):
     adapter.is_reasoning = True
     adapter.reasoning_levels = {"low": 1, "medium": 5, "high": 10}
     assert adapter._normalize_reasoning_level("medium") == "medium"
 
+@pytest.mark.unit
 def test_normalize_reasoning_level_invalid_string_key_raises(adapter):
     adapter.is_reasoning = True
     adapter.reasoning_levels = {"low": 1, "medium": 5}
@@ -117,6 +126,7 @@ def test_normalize_reasoning_level_invalid_string_key_raises(adapter):
     assert "Unknown reasoning level key" in str(exc.value)
     assert "low" in str(exc.value) and "medium" in str(exc.value)
 
+@pytest.mark.unit
 def test_normalize_reasoning_level_int_maps_to_correct_key(adapter):
     adapter.is_reasoning = True
     adapter.reasoning_levels = {"low": 1, "medium": 5, "high": 10}

--- a/tests/unit/errors/test_llm_api_error.py
+++ b/tests/unit/errors/test_llm_api_error.py
@@ -11,6 +11,7 @@ from src.llm_api_adapter.errors.llm_api_error import (
     LLMAPIUsageLimitError,
 )
 
+@pytest.mark.unit
 def test_llmapierror_message_and_detail():
     err = LLMAPIError(message="Error occurred", detail="Detailed info")
     assert str(err) == "Error occurred Detail: Detailed info"
@@ -51,6 +52,7 @@ def test_llmapierror_message_and_detail():
          []),
     ],
 )
+@pytest.mark.unit
 def test_error_subclasses_attributes(
     error_class, default_message, openai_errors, google_errors, anthropic_errors
 ):

--- a/tests/unit/llm_registry/test_llm_registry.py
+++ b/tests/unit/llm_registry/test_llm_registry.py
@@ -7,6 +7,7 @@ from src.llm_api_adapter.llm_registry.llm_registry import (
     DEFAULT_REGISTRY_PATH, ModelSpec, Pricing, ProviderSpec, RegistrySpec
 )
 
+@pytest.mark.unit
 def test_pricing_setters():
     p = Pricing(in_per_token=0.0, out_per_token=0.0)
     p.set_in_per_1m(1500.0)
@@ -16,6 +17,7 @@ def test_pricing_setters():
     assert pytest.approx(p.out_per_token, rel=1e-9) == 2500.0 / 1_000_000
     assert p.currency == "EUR"
 
+@pytest.mark.unit
 def test_model_and_provider_from_dict():
     model_data = {"pricing": {"in_per_1m": 1000, "out_per_1m": 2000}}
     model = ModelSpec.from_dict("gpt-test", model_data)
@@ -28,6 +30,7 @@ def test_model_and_provider_from_dict():
     assert "gpt-test" in provider.models
     assert isinstance(provider.models["gpt-test"], ModelSpec)
 
+@pytest.mark.unit
 def test_registry_reads_json_and_module_loads_llm_registry(tmp_path):
     content = {
         "schema_version": 42,
@@ -57,6 +60,7 @@ def test_registry_reads_json_and_module_loads_llm_registry(tmp_path):
     assert pytest.approx(model.pricing.in_per_token, rel=1e-9) == 1234 / 1_000_000
     assert pytest.approx(model.pricing.out_per_token, rel=1e-9) == 5678 / 1_000_000
 
+@pytest.mark.unit
 def test_default_registry_json_exists():
     assert isinstance(DEFAULT_REGISTRY_PATH, Path)
     assert DEFAULT_REGISTRY_PATH.exists(), f"Expected JSON at {DEFAULT_REGISTRY_PATH}"

--- a/tests/unit/llms/anthropic/test_sync_client.py
+++ b/tests/unit/llms/anthropic/test_sync_client.py
@@ -29,6 +29,7 @@ def mock_post_success():
     ) as mock_post:
         yield mock_post, mock_response
 
+@pytest.mark.unit
 def test_chat_completion_success(client, mock_post_success):
     mock_post, _ = mock_post_success
     result = client.chat_completion(
@@ -45,6 +46,7 @@ def test_chat_completion_success(client, mock_post_success):
     (requests.exceptions.Timeout("timeout"), LLMAPITimeoutError),
     (requests.exceptions.RequestException("generic error"), LLMAPIClientError),
 ])
+@pytest.mark.unit
 @patch("src.llm_api_adapter.llms.anthropic.sync_client.requests.post")
 def test_send_request_exceptions(
     mock_post, client, exception, expected_exception
@@ -59,6 +61,7 @@ def test_send_request_exceptions(
     (400, "bad_request", LLMAPIClientError),
     (500, "server_error", LLMAPIServerError),
 ])
+@pytest.mark.unit
 @patch("src.llm_api_adapter.llms.openai.sync_client.requests.post")
 def test_send_request_http_errors(
     mock_post, client, status_code, error_type, expected_exception
@@ -73,6 +76,7 @@ def test_send_request_http_errors(
     with pytest.raises(expected_exception):
         client._send_request("http://example.com", {})
 
+@pytest.mark.unit
 @patch("src.llm_api_adapter.llms.anthropic.sync_client.requests.post")
 def test_send_request_fallback_error_parsing(mock_post, client):
     mock_response = Mock()

--- a/tests/unit/llms/google/test_sync_client.py
+++ b/tests/unit/llms/google/test_sync_client.py
@@ -29,6 +29,7 @@ def mock_post_success():
     ) as mock_post:
         yield mock_post, mock_response
 
+@pytest.mark.unit
 def test_chat_completion_success(client, mock_post_success):
     mock_post, _ = mock_post_success
     result = client.chat_completion(
@@ -46,6 +47,7 @@ def test_chat_completion_success(client, mock_post_success):
     (requests.exceptions.Timeout("timeout"), LLMAPITimeoutError),
     (requests.exceptions.RequestException("generic error"), LLMAPIClientError),
 ])
+@pytest.mark.unit
 @patch("src.llm_api_adapter.llms.google.sync_client.requests.post")
 def test_send_request_exceptions(
     mock_post, client, exception, expected_exception
@@ -60,6 +62,7 @@ def test_send_request_exceptions(
     (400, "PERMISSION_DENIED", LLMAPIAuthorizationError),
     (500, "INTERNAL", LLMAPIServerError),
 ])
+@pytest.mark.unit
 @patch("src.llm_api_adapter.llms.google.sync_client.requests.post")
 def test_send_request_http_errors(
     mock_post, client, status_code, error_status, expected_exception
@@ -74,6 +77,7 @@ def test_send_request_http_errors(
     with pytest.raises(expected_exception):
         client._send_request("http://example.com", {})
 
+@pytest.mark.unit
 @patch("src.llm_api_adapter.llms.google.sync_client.requests.post")
 def test_send_request_fallback_error_parsing(mock_post, client):
     mock_response = Mock()

--- a/tests/unit/llms/openai/test_sync_client.py
+++ b/tests/unit/llms/openai/test_sync_client.py
@@ -29,6 +29,7 @@ def mock_post_success():
     ) as mock_post:
         yield mock_post, mock_response
 
+@pytest.mark.unit
 def test_chat_completion_success(client, mock_post_success):
     mock_post, _ = mock_post_success
     result = client.chat_completion(
@@ -46,6 +47,7 @@ def test_chat_completion_success(client, mock_post_success):
     (requests.exceptions.Timeout("timeout"), LLMAPITimeoutError),
     (requests.exceptions.RequestException("generic error"), LLMAPIClientError),
 ])
+@pytest.mark.unit
 @patch("src.llm_api_adapter.llms.openai.sync_client.requests.post")
 def test_send_request_exceptions(
     mock_post, client, exception, expected_exception
@@ -60,6 +62,7 @@ def test_send_request_exceptions(
     (400, "bad_request", LLMAPIClientError),
     (500, "server_error", LLMAPIServerError),
 ])
+@pytest.mark.unit
 @patch("src.llm_api_adapter.llms.openai.sync_client.requests.post")
 def test_send_request_http_errors(
     mock_post, client, status_code, error_type, expected_exception
@@ -74,6 +77,7 @@ def test_send_request_http_errors(
     with pytest.raises(expected_exception):
         client._send_request("http://example.com", {})
 
+@pytest.mark.unit
 @patch("src.llm_api_adapter.llms.openai.sync_client.requests.post")
 def test_send_request_fallback_error_parsing(mock_post, client):
     mock_response = Mock()

--- a/tests/unit/models/messages/test_chat_message.py
+++ b/tests/unit/models/messages/test_chat_message.py
@@ -5,12 +5,14 @@ from src.llm_api_adapter.models.messages.chat_message import (
     Message, Prompt, UserMessage, AIMessage, Messages
 )
 
+@pytest.mark.unit
 def test_prompt_to_anthropic_and_google_and_openai():
     p = Prompt(content="system instructions")
     assert p.to_anthropic() == "system instructions"
     assert p.to_google() == "system instructions"
     assert p.to_openai() == {"role": "system", "content": "system instructions"}
 
+@pytest.mark.unit
 def test_user_and_ai_to_google_and_openai():
     u = UserMessage(content="hello user")
     a = AIMessage(content="hello ai")
@@ -19,6 +21,7 @@ def test_user_and_ai_to_google_and_openai():
     assert u.to_openai() == {"role": "user", "content": "hello user"}
     assert a.to_openai() == {"role": "assistant", "content": "hello ai"}
 
+@pytest.mark.unit
 def test_messages_to_anthropic_with_prompt_and_messages():
     items = [Prompt(content="sys"), UserMessage(content="u1"), AIMessage(content="a1")]
     msgs = Messages(items=items)
@@ -29,6 +32,7 @@ def test_messages_to_anthropic_with_prompt_and_messages():
         {"role": "assistant", "content": "a1"},
     ]
 
+@pytest.mark.unit
 def test_messages_to_google_with_prompt_and_messages():
     items = [Prompt(content="sysg"), UserMessage(content="ug"), AIMessage(content="ag")]
     msgs = Messages(items=items)
@@ -39,6 +43,7 @@ def test_messages_to_google_with_prompt_and_messages():
         {"role": "model", "parts": [{"text": "ag"}]},
     ]
 
+@pytest.mark.unit
 def test_messages_to_anthropic_and_google_multiple_prompts_raise():
     items = [Prompt(content="p1"), Prompt(content="p2")]
     msgs = Messages(items=items)
@@ -49,6 +54,7 @@ def test_messages_to_anthropic_and_google_multiple_prompts_raise():
         msgs.to_google()
     assert "Multiple system prompts are not allowed for Google." in str(excinfo_gg.value)
 
+@pytest.mark.unit
 def test_messages_to_openai_returns_list_of_dicts():
     items = [UserMessage(content="u"), AIMessage(content="a")]
     msgs = Messages(items=items)
@@ -58,16 +64,19 @@ def test_messages_to_openai_returns_list_of_dicts():
         {"role": "assistant", "content": "a"},
     ]
 
+@pytest.mark.unit
 def test_messages_post_init_dict_missing_role_raises():
     with pytest.raises(ValueError) as excinfo:
         Messages(items=[{"content": "no role"}])
     assert "Missing 'role' in message data" in str(excinfo.value)
 
+@pytest.mark.unit
 def test_messages_post_init_dict_missing_content_raises():
     with pytest.raises(ValueError) as excinfo:
         Messages(items=[{"role": "user"}])
     assert "Missing 'content' in message data" in str(excinfo.value)
 
+@pytest.mark.unit
 def test_messages_post_init_dict_unsupported_role_raises():
     with pytest.raises(ValueError) as excinfo:
         Messages(items=[{"role": "unknown", "content": "x"}])

--- a/tests/unit/models/responses/test_chat_response.py
+++ b/tests/unit/models/responses/test_chat_response.py
@@ -1,5 +1,8 @@
+import pytest
+
 from src.llm_api_adapter.models.responses.chat_response import ChatResponse
 
+@pytest.mark.unit
 def test_from_openai_response():
     api_response = {
         "model": "gpt-4",
@@ -21,6 +24,7 @@ def test_from_openai_response():
     assert response.content == "Hello from OpenAI!"
     assert response.finish_reason == "stop"
 
+@pytest.mark.unit
 def test_from_anthropic_response(monkeypatch):
     api_response = {
         "usage": {"input_tokens": 30, "output_tokens": 70},
@@ -37,6 +41,7 @@ def test_from_anthropic_response(monkeypatch):
     assert response.content == "Hello from Anthropic!"
     assert response.finish_reason == "end"
 
+@pytest.mark.unit
 def test_from_google_response():
     api_response = {
         "candidates": [

--- a/tests/unit/test_universal_adapter.py
+++ b/tests/unit/test_universal_adapter.py
@@ -5,6 +5,7 @@ import pytest
 import src.llm_api_adapter.universal_adapter as universal_module
 from src.llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
 
+@pytest.mark.unit
 def test_selects_adapter_and_delegates(monkeypatch):
     @dataclass
     class FakeAdapter(universal_module.LLMAdapterBase):
@@ -35,6 +36,7 @@ def test_selects_adapter_and_delegates(monkeypatch):
     assert ua.adapter.api_key == "sk-test"
     assert ua.greet("Alice") == "hello Alice from anthropic"
 
+@pytest.mark.unit
 def test_unsupported_organization_raises(monkeypatch):
     @dataclass
     class OtherAdapter(universal_module.LLMAdapterBase):
@@ -56,6 +58,7 @@ def test_unsupported_organization_raises(monkeypatch):
             organization="UnknownCorp", model="gpt", api_key="k"
         )
 
+@pytest.mark.unit
 def test_invalid_inputs_raise_value_error():
     with pytest.raises(ValueError, match="Invalid organization"):
         UniversalLLMAPIAdapter(organization="", model="m", api_key="k")
@@ -64,6 +67,7 @@ def test_invalid_inputs_raise_value_error():
     with pytest.raises(ValueError, match="Invalid API key"):
         UniversalLLMAPIAdapter(organization="Anthropic", model="m", api_key="")
 
+@pytest.mark.unit
 def test_getattr_missing_raises_attribute_error(monkeypatch):
     @dataclass
     class FakeAdapter(universal_module.LLMAdapterBase):


### PR DESCRIPTION
### Added
- Per-request timeout support via a unified `timeout_s` parameter across all providers.

### Testing
- Added end-to-end (E2E) tests using real provider APIs.
- E2E tests validate:
  - unified chat response contract
  - error mapping (authorization, timeout)

### Fixed
- Correct handling of `reasoning_level="none"` and `reasoning_level=None` across providers.
- Fixed `LLMAPIAuthorizationError` mapping for the Google adapter.
- Removed unsupported model from the registry.