### PR TITLE
Release/0.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+.devtree/

--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@
 
 ## Overview
 
-This lightweight SDK for Python allows you to use LLM APIs from various providers and models through a unified interface. It is designed to be minimal, dependency-free, and easy to integrate into any Python project. Currently, the project supports API integration for OpenAI, Anthropic, and Google, focusing on chat functionality with consistent cost tracking and unified error handling.
+This lightweight SDK for Python allows you to use LLM APIs from multiple providers through a unified interface. It is designed to be minimal, dependency‑free, and easy to integrate into any Python project.
+
+Currently, the project supports OpenAI, Anthropic, and Google with a consistent chat API, unified error handling, token/cost accounting, reasoning control, timeout support, and unified tool/function calling. Switching between providers or models requires no code changes beyond replacing the organization and model values when creating the adapter.
 
 ### Version
 
-Current version: 0.2.5
+Current version: 0.3.0
 
 
 ## Features
@@ -16,6 +18,7 @@ Current version: 0.2.5
 - **Unified Interface**: Work seamlessly with different LLM providers using a single, consistent API.
 - **Multiple Provider Support**: Currently supports OpenAI, Anthropic, and Google APIs, allowing easy switching between them.
 - **Chat Functionality**: Provides an easy way to interact with chat-based LLMs.
+- **Tool / Function Calling**: Provider-agnostic tool definitions and normalized tool calls.
 - **Extensible Design**: Built to easily extend support for additional providers and new functionalities in the future.
 - **Error Handling**: Standardized error messages across all supported LLMs, simplifying integration and debugging.
 - **Flexible Configuration**: Manage request parameters like temperature, max tokens, and other settings for fine-tuned control.
@@ -140,9 +143,9 @@ The SDK provides a set of standardized errors for easier debugging and integrati
 
 The SDK allows you to easily switch between LLM providers and specify the model you want to use. Currently supported providers are OpenAI, Anthropic, and Google.
 
-- **OpenAI**: You can use models like `gpt-5.2`, `gpt-5.1`, `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`, `gpt-4o`, `gpt-4o-mini`.
-- **Anthropic**: Available models include `claude-opus-4-5`, `claude-sonnet-4-5`, `claude-haiku-4-5`, `claude-opus-4-1`, `claude-opus-4-0`, `claude-sonnet-4-0`, `claude-3-7-sonnet-latest`, `claude-3-5-haiku-latest`, `claude-3-haiku-20240307`.
-- **Google**: Models such as `gemini-3-pro-preview`, `gemini-3-flash-preview`, `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`, `gemini-2.0-flash`, `gemini-2.0-flash-lite` can be used.
+- **OpenAI**: You can use models like `gpt-5.4`, `gpt-5.2`, `gpt-5.1`, `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`, `gpt-4o`, `gpt-4o-mini`.
+- **Anthropic**: Available models include `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-opus-4-5`, `claude-sonnet-4-5`, `claude-haiku-4-5`, `claude-opus-4-1`, `claude-opus-4-0`, `claude-sonnet-4-0`, `claude-3-haiku-20240307`.
+- **Google**: Models such as `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite-preview`, `gemini-3-flash-preview`, `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite` can be used.
 
 Example:
 
@@ -358,6 +361,109 @@ response = adapter.chat(
 - same numeric mapping
 
 This allows switching between OpenAI, Anthropic, and Google without changing reasoning configuration in your code.
+
+## Tool / Function Calling
+
+The SDK provides a unified provider‑agnostic tool calling interface.
+
+Tools are defined using `ToolSpec`, and tool calls are returned in normalized form through `ChatResponse.tool_calls`.
+
+The adapter **does not execute tools**. Tool execution must be implemented by the caller.
+
+### ToolSpec
+
+```python
+from llm_api_adapter.models.tools import ToolSpec
+
+tool = ToolSpec(
+    name="get_weather",
+    description="Get current weather for a city",
+    json_schema={
+        "type": "object",
+        "properties": {
+            "city": {"type": "string"}
+        },
+        "required": ["city"],
+        "additionalProperties": False
+    }
+)
+```
+
+### Tool parameters
+
+`chat()` supports:
+
+- `tools`
+- `tool_choice`
+
+### Tool round‑trip example
+
+```python
+import json
+from typing import Any, Dict
+
+from llm_api_adapter.models.messages.chat_message import (
+    Prompt,
+    UserMessage,
+    AIMessage,
+    ToolMessage,
+)
+from llm_api_adapter.models.tools import ToolSpec
+from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
+
+
+tools = [
+    ToolSpec(
+        name="get_weather",
+        description="Get current weather for a city",
+        json_schema={
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+            "additionalProperties": False,
+        },
+    )
+]
+
+
+def run_tool(name: str, args: Dict[str, Any]) -> Dict[str, Any]:
+    if name == "get_weather":
+        return {"city": args["city"], "temperature": 22, "unit": "C"}
+    raise ValueError(f"Unknown tool: {name}")
+
+
+adapter = UniversalLLMAPIAdapter(
+    organization="openai",
+    model="gpt-5.2",
+    api_key=openai_api_key,
+)
+
+messages = [
+    Prompt("If the user asks about weather, call get_weather."),
+    UserMessage("What's the weather in Tel Aviv today?")
+]
+
+first = adapter.chat(
+    messages=messages,
+    tools=tools,
+    tool_choice="auto",
+)
+
+if first.tool_calls:
+    messages.append(AIMessage(content="", tool_calls=first.tool_calls))
+
+    for tc in first.tool_calls:
+        result = run_tool(tc.name, tc.arguments)
+        messages.append(
+            ToolMessage(
+                tool_call_id=tc.call_id,
+                content=json.dumps(result)
+            )
+        )
+
+    final = adapter.chat(messages=messages)
+    print(final.content)
+```
 
 ## Token Usage and Pricing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-api-adapter"
-version = "0.2.5"
+version = "0.3.0"
 description = "Lightweight, pluggable adapter for multiple LLM APIs (OpenAI, Anthropic, Google)"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/llm_api_adapter/adapters/anthropic_adapter.py
+++ b/src/llm_api_adapter/adapters/anthropic_adapter.py
@@ -92,31 +92,14 @@ class AnthropicAdapter(LLMAdapterBase):
             payload["description"] = tool.description
         return payload
 
-    def _to_anthropic_tool_choice(self, tool_choice: Any) -> Dict[str, Any]:
-        """
-        Anthropic tool_choice:
-          - {"type": "auto"}
-          - {"type": "any"}
-          - {"type": "tool", "name": "<tool_name>"}
-
-        tool_choice after base normalization is expected to be:
-          - "auto" | "any" | "<tool_name>"
-          - or dict-like with {"type": ..., "name": ...}
-        """
-        if isinstance(tool_choice, str):
-            if tool_choice in ("auto", "any"):
-                return {"type": tool_choice}
-            return {"type": "tool", "name": tool_choice}
-        if isinstance(tool_choice, dict):
-            tc_type = tool_choice.get("type")
-            tc_name = tool_choice.get("name")
-            if tc_type in ("auto", "any"):
-                return {"type": tc_type}
-            if tc_type == "tool" and tc_name:
-                return {"type": "tool", "name": tc_name}
-            if tc_name:
-                return {"type": "tool", "name": tc_name}
-        raise ValueError(f"Unsupported tool_choice for Anthropic: {tool_choice!r}")
+    def _to_anthropic_tool_choice(self, tool_choice: Optional[str]) -> Optional[Dict[str, Any]]:
+        if tool_choice is None:
+            return None
+        if tool_choice == "none":
+            return None
+        if tool_choice in ("auto", "any"):
+            return {"type": tool_choice}
+        return {"type": "tool", "name": tool_choice}
 
     def _normalize_reasoning_level(self, level: str | int) -> int | None:
         minimum_level = 1024

--- a/src/llm_api_adapter/adapters/anthropic_adapter.py
+++ b/src/llm_api_adapter/adapters/anthropic_adapter.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 import logging
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 import warnings
 
 from ..adapters.base_adapter import LLMAdapterBase
@@ -9,6 +11,7 @@ from ..errors.config_errors import LLMConfigError
 from ..llms.anthropic.sync_client import ClaudeSyncClient
 from ..models.messages.chat_message import Message, Messages
 from ..models.responses.chat_response import ChatResponse
+from ..models.tools.tool_spec import ToolSpec
 
 logger = logging.getLogger(__name__)
 
@@ -25,18 +28,23 @@ class AnthropicAdapter(LLMAdapterBase):
         top_p: float = 1.0,
         reasoning_level: Optional[str | int] = None,
         timeout_s: Optional[float] = None,
+        *,
+        tools: Optional[List[ToolSpec]] = None,
+        tool_choice: Optional[str | dict] = None,
+        parallel_tool_calls: Optional[bool] = None,
     ) -> ChatResponse:
         temperature = self._validate_parameter(
             name="temperature", value=temperature, min_value=0, max_value=2
         )
-        top_p = self._validate_parameter(
-            name="top_p", value=top_p, min_value=0, max_value=1
-        )
+        top_p = self._validate_parameter(name="top_p", value=top_p, min_value=0, max_value=1)
         try:
+            self._validate_tools(tools)
+            validated_tools = tools
+            normalized_tool_choice = self._normalize_tool_choice(tool_choice, validated_tools)
             normalized_messages = self._normalize_messages(messages)
             system_prompt, transformed_messages = normalized_messages.to_anthropic()
             client = ClaudeSyncClient(api_key=self.api_key)
-            params = {
+            params: Dict[str, Any] = {
                 "model": self.model,
                 "messages": transformed_messages,
                 "max_tokens": max_tokens,
@@ -45,18 +53,23 @@ class AnthropicAdapter(LLMAdapterBase):
                 "system": system_prompt,
                 "timeout_s": timeout_s,
             }
+            if validated_tools:
+                params["tools"] = [self._to_anthropic_tool(t) for t in validated_tools]
+            if normalized_tool_choice is not None:
+                params["tool_choice"] = self._to_anthropic_tool_choice(normalized_tool_choice)
+            if parallel_tool_calls is False:
+                params["disable_parallel_tool_use"] = True
+            elif parallel_tool_calls is True:
+                params["disable_parallel_tool_use"] = False
             if reasoning_level:
                 normalized_reasoning_level = self._normalize_reasoning_level(reasoning_level)
                 if normalized_reasoning_level:
                     self.validate_reasoning_and_tokens(
                         max_tokens=max_tokens,
                         reasoning_level=reasoning_level,
-                        normalized_reasoning_level=normalized_reasoning_level
+                        normalized_reasoning_level=normalized_reasoning_level,
                     )
-                    params["thinking"] = {
-                        "type": "enabled",
-                        "budget_tokens": normalized_reasoning_level
-                    }
+                    params["thinking"] = {"type": "enabled", "budget_tokens": normalized_reasoning_level}
             params = {k: v for k, v in params.items() if v is not None}
             response = client.chat_completion(**params)
             chat_response = ChatResponse.from_anthropic_response(response)
@@ -64,7 +77,7 @@ class AnthropicAdapter(LLMAdapterBase):
                 chat_response.apply_pricing(
                     price_input_per_token=self.pricing.in_per_token,
                     price_output_per_token=self.pricing.out_per_token,
-                    currency=self.pricing.currency
+                    currency=self.pricing.currency,
                 )
             return chat_response
         except LLMAPIError as e:
@@ -73,12 +86,45 @@ class AnthropicAdapter(LLMAdapterBase):
             error_message = getattr(e, "text", None) or str(e)
             self.handle_error(error=e, error_message=error_message)
 
+    def _to_anthropic_tool(self, tool: ToolSpec) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {"name": tool.name, "input_schema": tool.json_schema}
+        if tool.description:
+            payload["description"] = tool.description
+        return payload
+
+    def _to_anthropic_tool_choice(self, tool_choice: Any) -> Dict[str, Any]:
+        """
+        Anthropic tool_choice:
+          - {"type": "auto"}
+          - {"type": "any"}
+          - {"type": "tool", "name": "<tool_name>"}
+
+        tool_choice after base normalization is expected to be:
+          - "auto" | "any" | "<tool_name>"
+          - or dict-like with {"type": ..., "name": ...}
+        """
+        if isinstance(tool_choice, str):
+            if tool_choice in ("auto", "any"):
+                return {"type": tool_choice}
+            return {"type": "tool", "name": tool_choice}
+        if isinstance(tool_choice, dict):
+            tc_type = tool_choice.get("type")
+            tc_name = tool_choice.get("name")
+            if tc_type in ("auto", "any"):
+                return {"type": tc_type}
+            if tc_type == "tool" and tc_name:
+                return {"type": "tool", "name": tc_name}
+            if tc_name:
+                return {"type": "tool", "name": tc_name}
+        raise ValueError(f"Unsupported tool_choice for Anthropic: {tool_choice!r}")
+
     def _normalize_reasoning_level(self, level: str | int) -> int | None:
         minimum_level = 1024
-        normalized_level = None
+        normalized_level: int | None = None
         if level is not None and not self.is_reasoning:
-            warning_message = (f"Model '{self.model}' does not support reasoning "
-                               "— reasoning disabled.")
+            warning_message = (
+                f"Model '{self.model}' does not support reasoning — reasoning disabled."
+            )
             warnings.warn(warning_message, UserWarning)
             logger.info(warning_message)
             return None
@@ -88,8 +134,10 @@ class AnthropicAdapter(LLMAdapterBase):
             if level in self.reasoning_levels:
                 normalized_level = self.reasoning_levels[level]
             else:
-                raise ValueError(f"Unknown reasoning level key: {level!r}. "
-                                 f"Valid keys: {list(self.reasoning_levels.keys())}")
+                raise ValueError(
+                    f"Unknown reasoning level key: {level!r}. "
+                    f"Valid keys: {list(self.reasoning_levels.keys())}"
+                )
         if isinstance(level, int):
             normalized_level = level
         if normalized_level is not None:
@@ -97,26 +145,29 @@ class AnthropicAdapter(LLMAdapterBase):
                 return normalized_level
             warning_message = (
                 f"Reasoning level '{level}' is below the minimum supported value {minimum_level}; "
-                f"using {minimum_level} instead.")
+                f"using {minimum_level} instead."
+            )
             warnings.warn(warning_message, UserWarning)
             logger.info(warning_message)
             return minimum_level
-        raise ValueError("Invalid type for level: expected int or str, "
-                         f"got {type(level).__name__!r}")
-    
+        raise ValueError(
+            "Invalid type for level: expected int or str, "
+            f"got {type(level).__name__!r}"
+        )
+
     def validate_reasoning_and_tokens(
         self,
         max_tokens: int,
         reasoning_level: int | str,
-        normalized_reasoning_level: int
+        normalized_reasoning_level: int,
     ) -> None:
         if max_tokens <= normalized_reasoning_level:
             raise LLMConfigError(
-            detail=(
-                f"Provided max_tokens={max_tokens}, "
-                f"reasoning_level={normalized_reasoning_level} "
-                f"(requested '{reasoning_level}'). "
-                f"Increase max_tokens above {normalized_reasoning_level} "
-                "or reduce reasoning_level."
+                detail=(
+                    f"Provided max_tokens={max_tokens}, "
+                    f"reasoning_level={normalized_reasoning_level} "
+                    f"(requested '{reasoning_level}'). "
+                    f"Increase max_tokens above {normalized_reasoning_level} "
+                    "or reduce reasoning_level."
+                )
             )
-        )

--- a/src/llm_api_adapter/adapters/anthropic_adapter.py
+++ b/src/llm_api_adapter/adapters/anthropic_adapter.py
@@ -32,6 +32,7 @@ class AnthropicAdapter(LLMAdapterBase):
         tools: Optional[List[ToolSpec]] = None,
         tool_choice: Optional[str | dict] = None,
         parallel_tool_calls: Optional[bool] = None,
+        previous_response_id: Optional[str] = None,
     ) -> ChatResponse:
         temperature = self._validate_parameter(
             name="temperature", value=temperature, min_value=0, max_value=2

--- a/src/llm_api_adapter/adapters/base_adapter.py
+++ b/src/llm_api_adapter/adapters/base_adapter.py
@@ -131,39 +131,77 @@ class LLMAdapterBase(ABC):
         self,
         tool_choice: Any,
         tools: Optional[List[ToolSpec]],
-    ) -> Any:
+    ) -> Optional[str]:
         if tool_choice is None:
             return None
+        tool_names = {t.name for t in tools or []}
         if isinstance(tool_choice, str):
+            if tool_choice == "required":
+                raise ToolChoiceError(
+                    detail="tool_choice='required' is not supported; use 'any'"
+                )
             if tool_choice in ("auto", "none"):
                 return tool_choice
-            if tool_choice in ("required", "any"):
+            if tool_choice == "any":
                 if not tools:
                     raise ToolChoiceError(
-                        detail=f"tool_choice={tool_choice!r} requires tools to be provided"
+                        detail="tool_choice='any' requires tools to be provided"
                     )
-                return tool_choice
+                return "any"
             if not tools:
-                raise ToolChoiceError(detail="tool_choice references a tool but tools=None")
-            if any(t.name == tool_choice for t in tools):
+                raise ToolChoiceError(
+                    detail="tool_choice references a tool but tools=None"
+                )
+            if tool_choice in tool_names:
                 return tool_choice
-            raise ToolChoiceError(detail=f"Unknown tool_choice string: {tool_choice!r}")
+            raise ToolChoiceError(
+                detail=f"Unknown tool_choice string: {tool_choice!r}"
+            )
         if isinstance(tool_choice, dict):
             tc_type = tool_choice.get("type")
             tc_name = tool_choice.get("name")
-            if tc_type in ("required", "any") and not tools:
+            if tc_type == "required":
                 raise ToolChoiceError(
-                    detail=f"tool_choice.type={tc_type!r} requires tools to be provided"
+                    detail="tool_choice.type='required' is not supported; use 'any'"
                 )
-            if isinstance(tc_name, str):
+            if tc_type in ("auto", "none"):
+                return tc_type
+            if tc_type == "any":
                 if not tools:
-                    raise ToolChoiceError(detail="tool_choice references a tool but tools=None")
-                if not any(t.name == tc_name for t in tools):
+                    raise ToolChoiceError(
+                        detail=f"tool_choice.type={tc_type!r} requires tools to be provided"
+                    )
+                return "any"
+            if tc_type == "tool":
+                if not isinstance(tc_name, str) or not tc_name:
+                    raise ToolChoiceError(
+                        detail="tool_choice.type='tool' requires non-empty name"
+                    )
+                if not tools:
+                    raise ToolChoiceError(
+                        detail="tool_choice references a tool but tools=None"
+                    )
+                if tc_name not in tool_names:
                     raise ToolChoiceError(
                         detail=f"tool_choice references unknown tool: {tc_name!r}"
                     )
-            return tool_choice
-        raise ToolChoiceError(detail=f"Invalid tool_choice type: {type(tool_choice).__name__}")
+                return tc_name
+            if isinstance(tc_name, str):
+                if not tools:
+                    raise ToolChoiceError(
+                        detail="tool_choice references a tool but tools=None"
+                    )
+                if tc_name not in tool_names:
+                    raise ToolChoiceError(
+                        detail=f"tool_choice references unknown tool: {tc_name!r}"
+                    )
+                return tc_name
+            raise ToolChoiceError(
+                detail=f"Invalid tool_choice dict: {tool_choice!r}"
+            )
+        raise ToolChoiceError(
+            detail=f"Invalid tool_choice type: {type(tool_choice).__name__}"
+        )
 
     def handle_error(self, error: Exception, error_message: Optional[str] = None):
         err_msg = (

--- a/src/llm_api_adapter/adapters/base_adapter.py
+++ b/src/llm_api_adapter/adapters/base_adapter.py
@@ -1,13 +1,18 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from dataclasses import dataclass, field
 import logging
-from typing import Any, Dict, Optional
+import re
+from typing import Any, Dict, List, Optional
 import warnings
 
+from ..errors.llm_api_error import InvalidToolSchemaError, ToolChoiceError
 from ..llm_registry.llm_registry import Pricing, LLM_REGISTRY
 from ..models.messages.chat_message import Messages
 from ..models.responses.chat_response import ChatResponse
+from ..models.tools import ToolSpec
 
 logger = logging.getLogger(__name__)
 
@@ -17,6 +22,8 @@ REASONING_LEVELS_DEFAULT = {
     "medium": 1000,
     "high": 10000,
 }
+
+TOOL_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
 
 
 @dataclass
@@ -39,9 +46,11 @@ class LLMAdapterBase(ABC):
         model_spec = provider.models.get(self.model) if provider else None
         if not model_spec:
             warnings.warn(
-                (f"Model '{self.model}' is not verified for the {self.company} adapter. "
-                 f"Continuing with the selected adapter."),
-                 UserWarning
+                (
+                    f"Model '{self.model}' is not verified for the {self.company} adapter. "
+                    f"Continuing with the selected adapter."
+                ),
+                UserWarning,
             )
             logger.warning(f"Unverified model used: {self.model}")
             self.pricing = None
@@ -55,7 +64,7 @@ class LLMAdapterBase(ABC):
         """
         Generates a response based on the provided conversation.
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def _normalize_reasoning_level(self, level: str | int) -> int | str:
@@ -64,14 +73,15 @@ class LLMAdapterBase(ABC):
         into the provider-specific format.
         Models without reasoning support should ignore
         """
-        pass
+        raise NotImplementedError
 
     def _validate_parameter(
         self, name: str, value: float, min_value: float, max_value: float
     ) -> float:
         if not (min_value <= value <= max_value):
-            error_message = (f"{name} must be between {min_value} and "
-                             f"{max_value}, got {value}")
+            error_message = (
+                f"{name} must be between {min_value} and {max_value}, got {value}"
+            )
             logger.error(error_message)
             raise ValueError(error_message)
         return value
@@ -83,18 +93,88 @@ class LLMAdapterBase(ABC):
             return Messages(messages)
         raise TypeError("messages must be a list or Messages instance")
 
+    def _validate_tools(self, tools: Optional[List[ToolSpec]]) -> None:
+        """
+        Contract-level validation only.
+        Provider-specific constraints are handled in provider adapters.
+        """
+        if tools is None:
+            return
+        if not isinstance(tools, list):
+            raise InvalidToolSchemaError(detail="tools must be a list[ToolSpec] or None")
+        seen: set[str] = set()
+        for t in tools:
+            if not isinstance(t, ToolSpec):
+                raise InvalidToolSchemaError(
+                    detail="tools must contain ToolSpec items only"
+                )
+            if not t.name or not isinstance(t.name, str):
+                raise InvalidToolSchemaError(
+                    detail="ToolSpec.name must be a non-empty string"
+                )
+            if not TOOL_NAME_RE.match(t.name):
+                raise InvalidToolSchemaError(
+                    detail=(
+                        f"Invalid tool name {t.name!r}. "
+                        "Must match ^[a-zA-Z0-9_-]{1,64}$"
+                    )
+                )
+            if t.name in seen:
+                raise InvalidToolSchemaError(detail=f"Duplicate tool name: {t.name!r}")
+            seen.add(t.name)
+            if not isinstance(t.json_schema, dict):
+                raise InvalidToolSchemaError(
+                    detail=f"Tool {t.name!r}: json_schema must be a dict"
+                )
+
+    def _normalize_tool_choice(
+        self,
+        tool_choice: Any,
+        tools: Optional[List[ToolSpec]],
+    ) -> Any:
+        """
+        Validation + minimal normalization.
+        Returns tool_choice as-is (adapter will map to provider payload later).
+        """
+        if tool_choice is None:
+            return None
+        if isinstance(tool_choice, str):
+            if tool_choice in ("auto", "none", "required"):
+                return tool_choice
+            if tools and any(t.name == tool_choice for t in tools):
+                return tool_choice
+            raise ToolChoiceError(detail=f"Unknown tool_choice string: {tool_choice!r}")
+        if isinstance(tool_choice, dict):
+            name = tool_choice.get("name")
+            if isinstance(name, str):
+                if not tools:
+                    raise ToolChoiceError(
+                        detail="tool_choice references a tool but tools=None"
+                    )
+                if not any(t.name == name for t in tools):
+                    raise ToolChoiceError(
+                        detail=f"tool_choice references unknown tool: {name!r}"
+                    )
+            return tool_choice
+        raise ToolChoiceError(
+            detail=f"Invalid tool_choice type: {type(tool_choice).__name__}"
+        )
+
     def handle_error(self, error: Exception, error_message: Optional[str] = None):
-        err_msg = (f"Error with the provider '{self.company}' "
-               f"the model '{self.model}': {error_message}. ")
+        err_msg = (
+            f"Error with the provider '{self.company}' "
+            f"the model '{self.model}': {error_message}. "
+        )
         logger.error(err_msg)
         raise
 
     # ---------------- LEGACY ---------------- #
+
     def generate_chat_answer(self, **kwargs) -> ChatResponse:
         """Deprecated: use .chat() instead."""
         warnings.warn(
             "'generate_chat_answer' is deprecated, use 'chat' instead.",
             DeprecationWarning,
-            stacklevel=2
+            stacklevel=2,
         )
         return self.chat(**kwargs)

--- a/src/llm_api_adapter/adapters/base_adapter.py
+++ b/src/llm_api_adapter/adapters/base_adapter.py
@@ -134,73 +134,95 @@ class LLMAdapterBase(ABC):
     ) -> Optional[str]:
         if tool_choice is None:
             return None
-        tool_names = {t.name for t in tools or []}
+        tool_names = self._get_tool_names(tools)
         if isinstance(tool_choice, str):
-            if tool_choice == "required":
-                raise ToolChoiceError(
-                    detail="tool_choice='required' is not supported; use 'any'"
-                )
-            if tool_choice in ("auto", "none"):
-                return tool_choice
-            if tool_choice == "any":
-                if not tools:
-                    raise ToolChoiceError(
-                        detail="tool_choice='any' requires tools to be provided"
-                    )
-                return "any"
-            if not tools:
-                raise ToolChoiceError(
-                    detail="tool_choice references a tool but tools=None"
-                )
-            if tool_choice in tool_names:
-                return tool_choice
-            raise ToolChoiceError(
-                detail=f"Unknown tool_choice string: {tool_choice!r}"
-            )
+            return self._normalize_tool_choice_from_str(tool_choice, tools, tool_names)
         if isinstance(tool_choice, dict):
-            tc_type = tool_choice.get("type")
-            tc_name = tool_choice.get("name")
-            if tc_type == "required":
-                raise ToolChoiceError(
-                    detail="tool_choice.type='required' is not supported; use 'any'"
-                )
-            if tc_type in ("auto", "none"):
-                return tc_type
-            if tc_type == "any":
-                if not tools:
-                    raise ToolChoiceError(
-                        detail=f"tool_choice.type={tc_type!r} requires tools to be provided"
-                    )
-                return "any"
-            if tc_type == "tool":
-                if not isinstance(tc_name, str) or not tc_name:
-                    raise ToolChoiceError(
-                        detail="tool_choice.type='tool' requires non-empty name"
-                    )
-                if not tools:
-                    raise ToolChoiceError(
-                        detail="tool_choice references a tool but tools=None"
-                    )
-                if tc_name not in tool_names:
-                    raise ToolChoiceError(
-                        detail=f"tool_choice references unknown tool: {tc_name!r}"
-                    )
-                return tc_name
-            if isinstance(tc_name, str):
-                if not tools:
-                    raise ToolChoiceError(
-                        detail="tool_choice references a tool but tools=None"
-                    )
-                if tc_name not in tool_names:
-                    raise ToolChoiceError(
-                        detail=f"tool_choice references unknown tool: {tc_name!r}"
-                    )
-                return tc_name
-            raise ToolChoiceError(
-                detail=f"Invalid tool_choice dict: {tool_choice!r}"
-            )
+            return self._normalize_tool_choice_from_dict(tool_choice, tools, tool_names)
         raise ToolChoiceError(
             detail=f"Invalid tool_choice type: {type(tool_choice).__name__}"
+        )
+
+    def _get_tool_names(self, tools: Optional[List[ToolSpec]]) -> set[str]:
+        return {tool.name for tool in tools or []}
+
+    def _normalize_tool_choice_from_str(
+        self,
+        tool_choice: str,
+        tools: Optional[List[ToolSpec]],
+        tool_names: set[str],
+    ) -> str:
+        if tool_choice == "required":
+            self._raise_required_tool_choice_error()
+        if tool_choice in ("auto", "none"):
+            return tool_choice
+        if tool_choice == "any":
+            self._ensure_tools_provided(tools, detail="tool_choice='any' requires tools to be provided")
+            return "any"
+        self._ensure_tools_provided(
+            tools,
+            detail="tool_choice references a tool but tools=None",
+        )
+        if tool_choice in tool_names:
+            return tool_choice
+        raise ToolChoiceError(detail=f"Unknown tool_choice string: {tool_choice!r}")
+
+    def _normalize_tool_choice_from_dict(
+        self,
+        tool_choice: Dict[str, Any],
+        tools: Optional[List[ToolSpec]],
+        tool_names: set[str],
+    ) -> str:
+        tc_type = tool_choice.get("type")
+        tc_name = tool_choice.get("name")
+        if tc_type == "required":
+            self._raise_required_tool_choice_error()
+        if tc_type in ("auto", "none"):
+            return tc_type
+        if tc_type == "any":
+            self._ensure_tools_provided(
+                tools,
+                detail=f"tool_choice.type={tc_type!r} requires tools to be provided",
+            )
+            return "any"
+        if tc_type == "tool":
+            return self._normalize_named_tool_choice(tc_name, tools, tool_names)
+        if isinstance(tc_name, str):
+            return self._normalize_named_tool_choice(tc_name, tools, tool_names)
+        raise ToolChoiceError(detail=f"Invalid tool_choice dict: {tool_choice!r}")
+
+    def _normalize_named_tool_choice(
+        self,
+        tool_name: Any,
+        tools: Optional[List[ToolSpec]],
+        tool_names: set[str],
+    ) -> str:
+        if not isinstance(tool_name, str) or not tool_name:
+            raise ToolChoiceError(
+                detail="tool_choice.type='tool' requires non-empty name"
+            )
+        self._ensure_tools_provided(
+            tools,
+            detail="tool_choice references a tool but tools=None",
+        )
+        if tool_name not in tool_names:
+            raise ToolChoiceError(
+                detail=f"tool_choice references unknown tool: {tool_name!r}"
+            )
+        return tool_name
+
+    def _ensure_tools_provided(
+        self,
+        tools: Optional[List[ToolSpec]],
+        *,
+        detail: str,
+    ) -> None:
+        if not tools:
+            raise ToolChoiceError(detail=detail)
+
+    def _raise_required_tool_choice_error(self) -> None:
+        raise ToolChoiceError(
+            detail="tool_choice='required' is not supported; use 'any'"
         )
 
     def handle_error(self, error: Exception, error_message: Optional[str] = None):

--- a/src/llm_api_adapter/adapters/base_adapter.py
+++ b/src/llm_api_adapter/adapters/base_adapter.py
@@ -132,33 +132,38 @@ class LLMAdapterBase(ABC):
         tool_choice: Any,
         tools: Optional[List[ToolSpec]],
     ) -> Any:
-        """
-        Validation + minimal normalization.
-        Returns tool_choice as-is (adapter will map to provider payload later).
-        """
         if tool_choice is None:
             return None
         if isinstance(tool_choice, str):
-            if tool_choice in ("auto", "none", "required"):
+            if tool_choice in ("auto", "none"):
                 return tool_choice
-            if tools and any(t.name == tool_choice for t in tools):
+            if tool_choice in ("required", "any"):
+                if not tools:
+                    raise ToolChoiceError(
+                        detail=f"tool_choice={tool_choice!r} requires tools to be provided"
+                    )
+                return tool_choice
+            if not tools:
+                raise ToolChoiceError(detail="tool_choice references a tool but tools=None")
+            if any(t.name == tool_choice for t in tools):
                 return tool_choice
             raise ToolChoiceError(detail=f"Unknown tool_choice string: {tool_choice!r}")
         if isinstance(tool_choice, dict):
-            name = tool_choice.get("name")
-            if isinstance(name, str):
+            tc_type = tool_choice.get("type")
+            tc_name = tool_choice.get("name")
+            if tc_type in ("required", "any") and not tools:
+                raise ToolChoiceError(
+                    detail=f"tool_choice.type={tc_type!r} requires tools to be provided"
+                )
+            if isinstance(tc_name, str):
                 if not tools:
+                    raise ToolChoiceError(detail="tool_choice references a tool but tools=None")
+                if not any(t.name == tc_name for t in tools):
                     raise ToolChoiceError(
-                        detail="tool_choice references a tool but tools=None"
-                    )
-                if not any(t.name == name for t in tools):
-                    raise ToolChoiceError(
-                        detail=f"tool_choice references unknown tool: {name!r}"
+                        detail=f"tool_choice references unknown tool: {tc_name!r}"
                     )
             return tool_choice
-        raise ToolChoiceError(
-            detail=f"Invalid tool_choice type: {type(tool_choice).__name__}"
-        )
+        raise ToolChoiceError(detail=f"Invalid tool_choice type: {type(tool_choice).__name__}")
 
     def handle_error(self, error: Exception, error_message: Optional[str] = None):
         err_msg = (

--- a/src/llm_api_adapter/adapters/google_adapter.py
+++ b/src/llm_api_adapter/adapters/google_adapter.py
@@ -65,8 +65,10 @@ class GoogleAdapter(LLMAdapterBase):
             if system_prompt:
                 payload["system_instruction"] = {"parts": [{"text": system_prompt}]}
             if validated_tools:
-                payload["tools"] = [{"functionDeclarations": [self._to_google_function_declaration(t) for t in validated_tools]}]
-            tool_config = self._to_google_tool_config(normalized_tool_choice, validated_tools)
+                payload["tools"] = [
+                    {"functionDeclarations": [self._to_google_function_declaration(t) for t in validated_tools]}
+                ]
+            tool_config = self._to_google_tool_config(normalized_tool_choice)
             if tool_config is not None:
                 payload["toolConfig"] = tool_config
             _ = parallel_tool_calls
@@ -99,45 +101,22 @@ class GoogleAdapter(LLMAdapterBase):
             decl["description"] = tool.description
         return decl
 
-    def _to_google_tool_config(
-        self,
-        tool_choice: Any,
-        tools: Optional[List[ToolSpec]],
-    ) -> Optional[Dict[str, Any]]:
+    def _to_google_tool_config(self, tool_choice: Optional[str], ) -> Optional[Dict[str, Any]]:
         if tool_choice is None:
             return None
-        if not tools:
-            if tool_choice in ("auto", "none"):
-                return None
-            return None
-        mode: Optional[str] = None
-        allowed: Optional[List[str]] = None
-        if isinstance(tool_choice, str):
-            if tool_choice == "none":
-                mode = "NONE"
-            elif tool_choice == "auto":
-                mode = "AUTO"
-            elif tool_choice in ("required", "any"):
-                mode = "ANY"
-            else:
-                mode = "ANY"
-                allowed = [tool_choice]
-        elif isinstance(tool_choice, dict):
-            tc_type = tool_choice.get("type")
-            tc_name = tool_choice.get("name")
-            if tc_type in ("none", "NONE"):
-                mode = "NONE"
-            elif tc_type in ("auto", "AUTO"):
-                mode = "AUTO"
-            elif tc_type in ("required", "any", "ANY"):
-                mode = "ANY"
-            elif isinstance(tc_name, str) and tc_name:
-                mode = "ANY"
-                allowed = [tc_name]
-            else:
-                return None
+        if tool_choice == "none":
+            mode = "NONE"
+            allowed = None
+        elif tool_choice == "auto":
+            mode = "AUTO"
+            allowed = None
+        elif tool_choice == "any":
+            mode = "ANY"
+            allowed = None
         else:
-            return None
+            mode = "ANY"
+            allowed = [tool_choice]
+
         cfg: Dict[str, Any] = {"mode": mode}
         if allowed:
             cfg["allowedFunctionNames"] = allowed

--- a/src/llm_api_adapter/adapters/google_adapter.py
+++ b/src/llm_api_adapter/adapters/google_adapter.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 import logging
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 import warnings
 
 from ..adapters.base_adapter import LLMAdapterBase
@@ -8,6 +10,7 @@ from ..errors.llm_api_error import LLMAPIError
 from ..llms.google.sync_client import GeminiSyncClient
 from ..models.messages.chat_message import Message, Messages
 from ..models.responses.chat_response import ChatResponse
+from ..models.tools import ToolSpec
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +27,10 @@ class GoogleAdapter(LLMAdapterBase):
         top_p: float = 1.0,
         reasoning_level: Optional[str | int] = None,
         timeout_s: Optional[float] = None,
+        *,
+        tools: Optional[List[ToolSpec]] = None,
+        tool_choice: Optional[str | dict] = None,
+        parallel_tool_calls: Optional[bool] = None,
     ) -> ChatResponse:
         temperature = self._validate_parameter(
             name="temperature", value=temperature, min_value=0, max_value=2
@@ -32,6 +39,11 @@ class GoogleAdapter(LLMAdapterBase):
             name="top_p", value=top_p, min_value=0, max_value=1
         )
         try:
+            self._validate_tools(tools)
+            validated_tools = tools
+            normalized_tool_choice = self._normalize_tool_choice(
+                tool_choice, validated_tools
+            )
             normalized_messages = self._normalize_messages(messages)
             system_prompt, transformed_messages = normalized_messages.to_google()
             generation_config = {
@@ -41,29 +53,35 @@ class GoogleAdapter(LLMAdapterBase):
             }
             if reasoning_level:
                 normalized_reasoning_level = self._normalize_reasoning_level(reasoning_level)
-                if normalized_reasoning_level:
+                if normalized_reasoning_level is not None:
                     generation_config["thinkingConfig"] = {
-                        "thinkingBudget": reasoning_level,
-                        "includeThoughts": False
+                        "thinkingBudget": normalized_reasoning_level,
+                        "includeThoughts": False,
                     }
-            payload = {
+            payload: Dict[str, Any] = {
                 "contents": transformed_messages,
-                "generationConfig": generation_config
+                "generationConfig": generation_config,
             }
             if system_prompt:
                 payload["system_instruction"] = {"parts": [{"text": system_prompt}]}
+            if validated_tools:
+                payload["tools"] = [{"functionDeclarations": [self._to_google_function_declaration(t) for t in validated_tools]}]
+            tool_config = self._to_google_tool_config(normalized_tool_choice, validated_tools)
+            if tool_config is not None:
+                payload["toolConfig"] = tool_config
+            _ = parallel_tool_calls
             client = GeminiSyncClient(self.api_key)
             response_json = client.chat_completion(
                 model=self.model,
                 timeout_s=timeout_s,
-                **payload
+                **payload,
             )
             chat_response = ChatResponse.from_google_response(response_json)
             if self.pricing:
                 chat_response.apply_pricing(
                     price_input_per_token=self.pricing.in_per_token,
                     price_output_per_token=self.pricing.out_per_token,
-                    currency=self.pricing.currency
+                    currency=self.pricing.currency,
                 )
             return chat_response
         except LLMAPIError as e:
@@ -72,12 +90,66 @@ class GoogleAdapter(LLMAdapterBase):
             error_message = getattr(e, "text", None) or str(e)
             self.handle_error(error=e, error_message=error_message)
 
-    def _normalize_reasoning_level(self, level: str | int | None) -> str | None:
+    def _to_google_function_declaration(self, tool: ToolSpec) -> Dict[str, Any]:
+        decl: Dict[str, Any] = {
+            "name": tool.name,
+            "parametersJsonSchema": tool.json_schema,
+        }
+        if tool.description:
+            decl["description"] = tool.description
+        return decl
+
+    def _to_google_tool_config(
+        self,
+        tool_choice: Any,
+        tools: Optional[List[ToolSpec]],
+    ) -> Optional[Dict[str, Any]]:
+        if tool_choice is None:
+            return None
+        if not tools:
+            if tool_choice in ("auto", "none"):
+                return None
+            return None
+        mode: Optional[str] = None
+        allowed: Optional[List[str]] = None
+        if isinstance(tool_choice, str):
+            if tool_choice == "none":
+                mode = "NONE"
+            elif tool_choice == "auto":
+                mode = "AUTO"
+            elif tool_choice in ("required", "any"):
+                mode = "ANY"
+            else:
+                mode = "ANY"
+                allowed = [tool_choice]
+        elif isinstance(tool_choice, dict):
+            tc_type = tool_choice.get("type")
+            tc_name = tool_choice.get("name")
+            if tc_type in ("none", "NONE"):
+                mode = "NONE"
+            elif tc_type in ("auto", "AUTO"):
+                mode = "AUTO"
+            elif tc_type in ("required", "any", "ANY"):
+                mode = "ANY"
+            elif isinstance(tc_name, str) and tc_name:
+                mode = "ANY"
+                allowed = [tc_name]
+            else:
+                return None
+        else:
+            return None
+        cfg: Dict[str, Any] = {"mode": mode}
+        if allowed:
+            cfg["allowedFunctionNames"] = allowed
+        return {"functionCallingConfig": cfg}
+
+    def _normalize_reasoning_level(self, level: str | int | None) -> int | None:
         minimum_level = 0
-        normalized_level = None
+        normalized_level: Optional[int] = None
         if level is not None and not self.is_reasoning:
-            warning_message = (f"Model '{self.model}' does not support reasoning "
-                               "— reasoning disabled.")
+            warning_message = (
+                f"Model '{self.model}' does not support reasoning — reasoning disabled."
+            )
             warnings.warn(warning_message, UserWarning)
             logger.info(warning_message)
             return None
@@ -87,13 +159,17 @@ class GoogleAdapter(LLMAdapterBase):
             if level in self.reasoning_levels:
                 normalized_level = self.reasoning_levels[level]
             else:
-                raise ValueError(f"Unknown reasoning level key: {level!r}. "
-                                 f"Valid keys: {list(self.reasoning_levels.keys())}")
+                raise ValueError(
+                    f"Unknown reasoning level key: {level!r}. "
+                    f"Valid keys: {list(self.reasoning_levels.keys())}"
+                )
         if isinstance(level, int):
             normalized_level = level
         if normalized_level is not None:
             if normalized_level >= minimum_level:
                 return normalized_level
             return minimum_level
-        raise ValueError("Invalid type for level: expected int or str, "
-                         f"got {type(level).__name__!r}")
+        raise ValueError(
+            "Invalid type for level: expected int or str, "
+            f"got {type(level).__name__!r}"
+        )

--- a/src/llm_api_adapter/adapters/google_adapter.py
+++ b/src/llm_api_adapter/adapters/google_adapter.py
@@ -31,6 +31,7 @@ class GoogleAdapter(LLMAdapterBase):
         tools: Optional[List[ToolSpec]] = None,
         tool_choice: Optional[str | dict] = None,
         parallel_tool_calls: Optional[bool] = None,
+        previous_response_id: Optional[str] = None,
     ) -> ChatResponse:
         temperature = self._validate_parameter(
             name="temperature", value=temperature, min_value=0, max_value=2

--- a/src/llm_api_adapter/adapters/openai_adapter.py
+++ b/src/llm_api_adapter/adapters/openai_adapter.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 import logging
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 import warnings
 
 from ..adapters.base_adapter import LLMAdapterBase
@@ -8,6 +10,7 @@ from ..errors.llm_api_error import LLMAPIError
 from ..llms.openai.sync_client import OpenAISyncClient
 from ..models.messages.chat_message import Message, Messages
 from ..models.responses.chat_response import ChatResponse
+from ..models.tools import ToolSpec
 
 logger = logging.getLogger(__name__)
 
@@ -23,26 +26,34 @@ class OpenAIAdapter(LLMAdapterBase):
         temperature: float = 1.0,
         top_p: float = 1.0,
         reasoning_level: Optional[str | int] = None,
-        timeout_s: Optional[float] = None
+        timeout_s: Optional[float] = None,
+        tools: Optional[List[ToolSpec]] = None,
+        tool_choice: Any = None,
+        parallel_tool_calls: Optional[bool] = None,
     ) -> ChatResponse:
         temperature = self._validate_parameter(
             name="temperature", value=temperature, min_value=0, max_value=2
         )
-        top_p = self._validate_parameter(
-            name="top_p", value=top_p, min_value=0, max_value=1
-        )
+        top_p = self._validate_parameter(name="top_p", value=top_p, min_value=0, max_value=1)
+        self._validate_tools(tools)
+        normalized_tool_choice = self._normalize_tool_choice(tool_choice, tools)
         try:
             normalized_messages = self._normalize_messages(messages)
             transformed_messages = normalized_messages.to_openai()
             normalized_reasoning_level = self._normalize_reasoning_level(reasoning_level)
+            openai_tools = self._map_tools_to_openai(tools)
+            openai_tool_choice = self._map_tool_choice_to_openai(normalized_tool_choice)
             client = OpenAISyncClient(api_key=self.api_key)
-            params = {
+            params: Dict[str, Any] = {
                 "model": self.model,
                 "messages": transformed_messages,
                 "max_tokens": max_tokens,
                 "temperature": temperature,
                 "top_p": top_p,
                 "reasoning_effort": normalized_reasoning_level,
+                "tools": openai_tools,
+                "tool_choice": openai_tool_choice,
+                "parallel_tool_calls": parallel_tool_calls,
             }
             params = {k: v for k, v in params.items() if v is not None}
             response = client.chat_completion(timeout=timeout_s, **params)
@@ -51,7 +62,7 @@ class OpenAIAdapter(LLMAdapterBase):
                 chat_response.apply_pricing(
                     price_input_per_token=self.pricing.in_per_token,
                     price_output_per_token=self.pricing.out_per_token,
-                    currency=self.pricing.currency
+                    currency=self.pricing.currency,
                 )
             return chat_response
         except LLMAPIError as e:
@@ -59,6 +70,45 @@ class OpenAIAdapter(LLMAdapterBase):
         except Exception as e:
             error_message = getattr(e, "text", None) or str(e)
             self.handle_error(error=e, error_message=error_message)
+
+    def _map_tools_to_openai(self, tools: Optional[List[ToolSpec]]) -> Optional[List[Dict[str, Any]]]:
+        if not tools:
+            return None
+        mapped: List[Dict[str, Any]] = []
+        for t in tools:
+            fn: Dict[str, Any] = {
+                "name": t.name,
+                "parameters": t.json_schema,
+            }
+            if t.description:
+                fn["description"] = t.description
+            mapped.append(
+                {
+                    "type": "function",
+                    "function": fn,
+                }
+            )
+        return mapped
+
+    def _map_tool_choice_to_openai(self, tool_choice: Any) -> Any:
+        """
+        OpenAI accepts:
+          - "auto" | "none" | "required"
+          - {"type":"function","function":{"name":"..."}}
+        We also support passing a tool name string -> forced tool.
+        """
+        if tool_choice is None:
+            return None
+        if isinstance(tool_choice, str):
+            if tool_choice in ("auto", "none", "required"):
+                return tool_choice
+            return {"type": "function", "function": {"name": tool_choice}}
+        if isinstance(tool_choice, dict):
+            name = tool_choice.get("name")
+            if isinstance(name, str) and name:
+                return {"type": "function", "function": {"name": name}}
+            return tool_choice
+        return tool_choice
 
     def _normalize_reasoning_level(self, level: str | int | None) -> str | None:
         if level is None:

--- a/src/llm_api_adapter/adapters/openai_adapter.py
+++ b/src/llm_api_adapter/adapters/openai_adapter.py
@@ -90,25 +90,14 @@ class OpenAIAdapter(LLMAdapterBase):
             )
         return mapped
 
-    def _map_tool_choice_to_openai(self, tool_choice: Any) -> Any:
-        """
-        OpenAI accepts:
-          - "auto" | "none" | "required"
-          - {"type":"function","function":{"name":"..."}}
-        We also support passing a tool name string -> forced tool.
-        """
+    def _map_tool_choice_to_openai(self, tool_choice: Optional[str]) -> Any:
         if tool_choice is None:
             return None
-        if isinstance(tool_choice, str):
-            if tool_choice in ("auto", "none", "required"):
-                return tool_choice
-            return {"type": "function", "function": {"name": tool_choice}}
-        if isinstance(tool_choice, dict):
-            name = tool_choice.get("name")
-            if isinstance(name, str) and name:
-                return {"type": "function", "function": {"name": name}}
+        if tool_choice in ("auto", "none"):
             return tool_choice
-        return tool_choice
+        if tool_choice == "any":
+            return "required"
+        return {"type": "function", "function": {"name": tool_choice}}
 
     def _normalize_reasoning_level(self, level: str | int | None) -> str | None:
         if level is None:

--- a/src/llm_api_adapter/adapters/openai_adapter.py
+++ b/src/llm_api_adapter/adapters/openai_adapter.py
@@ -30,41 +30,81 @@ class OpenAIAdapter(LLMAdapterBase):
         tools: Optional[List[ToolSpec]] = None,
         tool_choice: Any = None,
         parallel_tool_calls: Optional[bool] = None,
+        previous_response_id: Optional[str] = None,
     ) -> ChatResponse:
         temperature = self._validate_parameter(
-            name="temperature", value=temperature, min_value=0, max_value=2
+            name="temperature",
+            value=temperature,
+            min_value=0,
+            max_value=2,
         )
-        top_p = self._validate_parameter(name="top_p", value=top_p, min_value=0, max_value=1)
+        top_p = self._validate_parameter(
+            name="top_p",
+            value=top_p,
+            min_value=0,
+            max_value=1,
+        )
         self._validate_tools(tools)
         normalized_tool_choice = self._normalize_tool_choice(tool_choice, tools)
+
         try:
-            normalized_messages = self._normalize_messages(messages)
-            transformed_messages = normalized_messages.to_openai()
-            normalized_reasoning_level = self._normalize_reasoning_level(reasoning_level)
-            openai_tools = self._map_tools_to_openai(tools)
-            openai_tool_choice = self._map_tool_choice_to_openai(normalized_tool_choice)
             client = OpenAISyncClient(api_key=self.api_key)
+            normalized_messages = self._normalize_messages(messages)
+            use_responses_api = client._should_use_responses_api(self.model)
+            normalized_reasoning_level = self._normalize_reasoning_level(reasoning_level)
+
+            if use_responses_api:
+                transformed_messages = normalized_messages.to_openai_responses_input()
+                instructions = normalized_messages.to_openai_responses_instructions()
+                openai_tools = self._map_tools_to_openai_responses(tools)
+                openai_tool_choice = self._map_tool_choice_to_openai_responses(
+                    normalized_tool_choice
+                )
+            else:
+                transformed_messages = normalized_messages.to_openai()
+                instructions = None
+                openai_tools = self._map_tools_to_openai(tools)
+                openai_tool_choice = self._map_tool_choice_to_openai(
+                    normalized_tool_choice
+                )
+
             params: Dict[str, Any] = {
                 "model": self.model,
-                "messages": transformed_messages,
                 "max_tokens": max_tokens,
                 "temperature": temperature,
                 "top_p": top_p,
                 "reasoning_effort": normalized_reasoning_level,
                 "tools": openai_tools,
                 "tool_choice": openai_tool_choice,
-                "parallel_tool_calls": parallel_tool_calls,
             }
+
+            if use_responses_api:
+                params["input"] = transformed_messages
+                if instructions is not None:
+                    params["instructions"] = instructions
+                if previous_response_id is not None:
+                    params["previous_response_id"] = previous_response_id
+            else:
+                params["messages"] = transformed_messages
+                params["parallel_tool_calls"] = parallel_tool_calls
+
             params = {k: v for k, v in params.items() if v is not None}
-            response = client.chat_completion(timeout=timeout_s, **params)
-            chat_response = ChatResponse.from_openai_response(response)
+            response = client.complete(timeout=timeout_s, **params)
+
+            if use_responses_api:
+                chat_response = ChatResponse.from_openai_responses_response(response)
+            else:
+                chat_response = ChatResponse.from_openai_response(response)
+
             if self.pricing:
                 chat_response.apply_pricing(
                     price_input_per_token=self.pricing.in_per_token,
                     price_output_per_token=self.pricing.out_per_token,
                     currency=self.pricing.currency,
                 )
+
             return chat_response
+
         except LLMAPIError as e:
             self.handle_error(e)
         except Exception as e:
@@ -127,3 +167,38 @@ class OpenAIAdapter(LLMAdapterBase):
             "Invalid type for level: expected int or str, "
             f"got {type(level).__name__!r}"
         )
+    
+    def _map_tools_to_openai_responses(
+        self,
+        tools: Optional[List[ToolSpec]],
+    ) -> Optional[List[Dict[str, Any]]]:
+        if not tools:
+            return None
+
+        result: List[Dict[str, Any]] = []
+        for tool in tools:
+            result.append(
+                {
+                    "type": "function",
+                    "name": tool.name,
+                    "description": tool.description,
+                    "parameters": tool.json_schema,
+                }
+            )
+        return result
+    
+    def _map_tool_choice_to_openai_responses(self, tool_choice: Any) -> Any:
+        if tool_choice is None:
+            return None
+        if tool_choice == "auto":
+            return "auto"
+        if tool_choice == "none":
+            return "none"
+        if tool_choice == "any":
+            return "required"
+        if isinstance(tool_choice, str):
+            return {
+                "type": "function",
+                "name": tool_choice,
+            }
+        return tool_choice

--- a/src/llm_api_adapter/errors/llm_api_error.py
+++ b/src/llm_api_adapter/errors/llm_api_error.py
@@ -80,3 +80,21 @@ class LLMAPIUsageLimitError(LLMAPIError):
     openai_api_errors = ["UsageLimitError", "QuotaExceededError"]
     google_api_errors = []
     anthropic_api_errors = []
+
+
+@dataclass
+class InvalidToolSchemaError(LLMAPIClientError):
+    """Raised when a provided tool schema is invalid."""
+    message: str = "Invalid tool schema."
+
+
+@dataclass
+class InvalidToolArgumentsError(LLMAPIClientError):
+    """Raised when tool arguments cannot be parsed or validated."""
+    message: str = "Invalid tool arguments."
+
+
+@dataclass
+class ToolChoiceError(LLMAPIClientError):
+    """Raised when tool_choice is invalid or references unknown tool."""
+    message: str = "Invalid tool_choice configuration."

--- a/src/llm_api_adapter/llm_registry/llm_registry.json
+++ b/src/llm_api_adapter/llm_registry/llm_registry.json
@@ -1,10 +1,14 @@
 {
-  "schema_version": 4,
-  "effective_date": "2025-11-28",
+  "schema_version": 5,
+  "effective_date": "2026-03-08",
   "providers": {
     "openai": {
       "currency": "USD",
       "models": {
+        "gpt-5.4": {
+          "pricing": {"in_per_1m": 2.5, "out_per_1m": 15.0},
+          "is_reasoning": true
+        },
         "gpt-5.2": {
           "pricing": {"in_per_1m": 1.75, "out_per_1m": 14.0},
           "is_reasoning": true
@@ -35,6 +39,14 @@
     "anthropic": {
       "currency": "USD",
       "models": {
+        "claude-opus-4-6": {
+          "pricing": {"in_per_1m": 5.0, "out_per_1m": 25.0},
+          "is_reasoning": true
+        },
+        "claude-sonnet-4-6": {
+          "pricing": {"in_per_1m": 3.0, "out_per_1m": 15.0},
+          "is_reasoning": true
+        },
         "claude-opus-4-5": {
           "pricing": {"in_per_1m": 5.0, "out_per_1m": 25.0},
           "is_reasoning": true
@@ -70,8 +82,12 @@
     "google": {
       "currency": "USD",
       "models": {
-        "gemini-3-pro-preview": {
+        "gemini-3.1-pro-preview": {
           "pricing": {"in_per_1m": 2.0, "out_per_1m": 12.0},
+          "is_reasoning": true
+        },
+        "gemini-3.1-flash-lite-preview": {
+          "pricing": {"in_per_1m": 0.25, "out_per_1m": 1.5},
           "is_reasoning": true
         },
         "gemini-3-flash-preview": {

--- a/src/llm_api_adapter/llm_registry/llm_registry.json
+++ b/src/llm_api_adapter/llm_registry/llm_registry.json
@@ -71,11 +71,6 @@
           "pricing": {"in_per_1m": 3.0, "out_per_1m": 15.0},
           "is_reasoning": true
         },
-        "claude-3-7-sonnet-latest": {
-          "pricing": {"in_per_1m": 3.0, "out_per_1m": 15.0},
-          "is_reasoning": true
-        },
-        "claude-3-5-haiku-latest": {"pricing": {"in_per_1m": 0.8, "out_per_1m": 4.0}},
         "claude-3-haiku-20240307": {"pricing": {"in_per_1m": 0.25, "out_per_1m": 1.25}}
       }
     },
@@ -104,14 +99,6 @@
         },
         "gemini-2.5-flash-lite": {
           "pricing": {"in_per_1m": 0.1, "out_per_1m": 0.4},
-          "is_reasoning": true
-        },
-        "gemini-2.0-flash": {
-          "pricing": {"in_per_1m": 0.1, "out_per_1m": 0.4},
-          "is_reasoning": true
-        },
-        "gemini-2.0-flash-lite": {
-          "pricing": {"in_per_1m": 0.075, "out_per_1m": 0.3},
           "is_reasoning": true
         }
       }

--- a/src/llm_api_adapter/llms/anthropic/sync_client.py
+++ b/src/llm_api_adapter/llms/anthropic/sync_client.py
@@ -35,7 +35,8 @@ class ClaudeSyncClient:
 
     def _prepare_chat_payload_for_model(self, model: str, kwargs: dict) -> dict:
         if model.startswith(
-            ("claude-sonnet-4-5", "claude-opus-4-1", "claude-haiku-4-5", "claude-opus-4-5")
+            ("claude-sonnet-4-5", "claude-opus-4-1", "claude-haiku-4-5", "claude-opus-4-5",
+             "claude-opus-4-6", "claude-sonnet-4-6")
         ):
             kwargs.pop("top_p", None)
         return {"model": model, **kwargs}

--- a/src/llm_api_adapter/llms/openai/sync_client.py
+++ b/src/llm_api_adapter/llms/openai/sync_client.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 import logging
-
 import requests
 
 from ...errors.llm_api_error import (
@@ -23,8 +22,13 @@ class OpenAISyncClient:
     def _headers(self):
         return {
             "Authorization": f"Bearer {self.api_key}",
-            "Content-Type": "application/json"
+            "Content-Type": "application/json",
         }
+
+    def complete(self, model: str, timeout: float | None = None, **kwargs):
+        if self._should_use_responses_api(model):
+            return self.responses(model=model, timeout=timeout, **kwargs)
+        return self.chat_completion(model=model, timeout=timeout, **kwargs)
 
     def chat_completion(self, model: str, timeout: float | None = None, **kwargs):
         url = f"{self.endpoint}/chat/completions"
@@ -32,7 +36,17 @@ class OpenAISyncClient:
         response = self._send_request(url, payload, timeout)
         return response.json()
 
+    def responses(self, model: str, timeout: float | None = None, **kwargs):
+        url = f"{self.endpoint}/responses"
+        payload = self._prepare_responses_payload_for_model(model, kwargs)
+        response = self._send_request(url, payload, timeout)
+        return response.json()
+
+    def _should_use_responses_api(self, model: str) -> bool:
+        return model.startswith("gpt-5")
+
     def _prepare_chat_payload_for_model(self, model: str, kwargs: dict) -> dict:
+        kwargs = dict(kwargs)
         if model.startswith(("gpt-4.1", "gpt-5", "o1")):
             if "max_tokens" in kwargs:
                 kwargs["max_completion_tokens"] = kwargs.pop("max_tokens")
@@ -40,6 +54,19 @@ class OpenAISyncClient:
             if kwargs["reasoning_effort"] == "none":
                 kwargs["reasoning_effort"] = "minimal"
         return {"model": model, **kwargs}
+
+    def _prepare_responses_payload_for_model(self, model: str, kwargs: dict) -> dict:
+        payload = {"model": model, **dict(kwargs)}
+        if "messages" in payload:
+            payload["input"] = payload.pop("messages")
+        if "max_tokens" in payload:
+            payload["max_output_tokens"] = payload.pop("max_tokens")
+        reasoning_effort = payload.pop("reasoning_effort", None)
+        if reasoning_effort is not None:
+            if model in ("gpt-5-mini", "gpt-5-nano") and reasoning_effort == "none":
+                reasoning_effort = "minimal"
+            payload["reasoning"] = {"effort": reasoning_effort}
+        return payload
 
     def _send_request(self, url: str, payload: dict, timeout: float | None = None):
         try:

--- a/src/llm_api_adapter/llms/openai/sync_client.py
+++ b/src/llm_api_adapter/llms/openai/sync_client.py
@@ -36,7 +36,7 @@ class OpenAISyncClient:
         if model.startswith(("gpt-4.1", "gpt-5", "o1")):
             if "max_tokens" in kwargs:
                 kwargs["max_completion_tokens"] = kwargs.pop("max_tokens")
-        if "reasoning_effort" in kwargs and model in ("gpt-5-nano, gpt-5-mini"):
+        if "reasoning_effort" in kwargs and model in ("gpt-5-nano", "gpt-5-mini"):
             if kwargs["reasoning_effort"] == "none":
                 kwargs["reasoning_effort"] = "minimal"
         return {"model": model, **kwargs}

--- a/src/llm_api_adapter/llms/openai/sync_client.py
+++ b/src/llm_api_adapter/llms/openai/sync_client.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 import logging
 import requests
+import warnings
 
 from ...errors.llm_api_error import (
     LLMAPIAuthorizationError,
@@ -47,12 +48,9 @@ class OpenAISyncClient:
 
     def _prepare_chat_payload_for_model(self, model: str, kwargs: dict) -> dict:
         kwargs = dict(kwargs)
-        if model.startswith(("gpt-4.1", "gpt-5", "o1")):
+        if model.startswith(("gpt-4.1", "o1")):
             if "max_tokens" in kwargs:
                 kwargs["max_completion_tokens"] = kwargs.pop("max_tokens")
-        if "reasoning_effort" in kwargs and model in ("gpt-5-nano", "gpt-5-mini"):
-            if kwargs["reasoning_effort"] == "none":
-                kwargs["reasoning_effort"] = "minimal"
         return {"model": model, **kwargs}
 
     def _prepare_responses_payload_for_model(self, model: str, kwargs: dict) -> dict:
@@ -63,9 +61,16 @@ class OpenAISyncClient:
             payload["max_output_tokens"] = payload.pop("max_tokens")
         reasoning_effort = payload.pop("reasoning_effort", None)
         if reasoning_effort is not None:
-            if model in ("gpt-5-mini", "gpt-5-nano") and reasoning_effort == "none":
+            if model in ("gpt-5", "gpt-5-nano", "gpt-5-mini") and reasoning_effort == "none":
                 reasoning_effort = "minimal"
             payload["reasoning"] = {"effort": reasoning_effort}
+        if model.startswith("gpt-5") and "top_p" in payload:
+            warning_message = (
+                f"Parameter 'top_p' is not supported for model '{model}' and will be ignored."
+            )
+            warnings.warn(warning_message, stacklevel=2)
+            logger.warning(warning_message)
+            payload.pop("top_p")
         return payload
 
     def _send_request(self, url: str, payload: dict, timeout: float | None = None):

--- a/src/llm_api_adapter/models/messages/chat_message.py
+++ b/src/llm_api_adapter/models/messages/chat_message.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 import json
-from typing import Any, Dict, List, Optional, Tuple, Type
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 from ..tools import ToolCall
 
@@ -42,7 +42,9 @@ class UserMessage(Message):
 class AIMessage(Message):
     """
     Assistant message.
-    For OpenAI tool loop, it may carry tool_calls (assistant turn that requested tools).
+
+    - OpenAI tool loop: may include tool_calls (assistant turn that requested tools).
+    - Anthropic tool loop: may include tool_calls -> rendered as content blocks type="tool_use".
     """
     role: str = field(default="assistant", init=False)
     tool_calls: Optional[List[ToolCall]] = None
@@ -63,6 +65,27 @@ class AIMessage(Message):
             ]
         return msg
 
+    def to_anthropic(self) -> Dict[str, Any]:
+        if not self.tool_calls:
+            return {"role": "assistant", "content": self.content}
+        blocks: List[Dict[str, Any]] = []
+        if self.content:
+            blocks.append({"type": "text", "text": self.content})
+        for tc in self.tool_calls:
+            if not tc.call_id:
+                raise ValueError(
+                    "Anthropic tool_use requires a non-empty call_id (tool_use id)."
+                )
+            blocks.append(
+                {
+                    "type": "tool_use",
+                    "id": tc.call_id,
+                    "name": tc.name,
+                    "input": tc.arguments or {},
+                }
+            )
+        return {"role": "assistant", "content": blocks}
+
     def to_google(self) -> Dict[str, Any]:
         # Google expects role "model"
         return {"role": "model", "parts": [{"text": self.content}]}
@@ -71,14 +94,30 @@ class AIMessage(Message):
 @dataclass
 class ToolMessage(Message):
     """
-    Tool result message (OpenAI format).
-    Must reference preceding assistant tool call via tool_call_id.
+    Tool result message.
+
+    - OpenAI format: role="tool" + tool_call_id
+    - Anthropic format: rendered as a USER message with a tool_result content block referencing tool_use_id
     """
     tool_call_id: str
     role: str = field(default="tool", init=False)
 
     def to_openai(self) -> Dict[str, Any]:
         return {"role": "tool", "tool_call_id": self.tool_call_id, "content": self.content}
+
+    def to_anthropic(self) -> Dict[str, Any]:
+        if not self.tool_call_id:
+            raise ValueError("Anthropic tool_result requires tool_call_id (tool_use_id).")
+        return {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": self.tool_call_id,
+                    "content": self.content,
+                }
+            ],
+        }
 
 
 @dataclass
@@ -167,7 +206,11 @@ class Messages:
                 prompt = m.to_anthropic()
                 continue
             if isinstance(m, ToolMessage):
-                raise ValueError("ToolMessage is not supported for Anthropic in this version.")
+                messages.append(m.to_anthropic())
+                continue
+            if isinstance(m, AIMessage):
+                messages.append(m.to_anthropic())
+                continue
             messages.append(m.to_anthropic())
         return prompt, messages
 

--- a/src/llm_api_adapter/models/messages/chat_message.py
+++ b/src/llm_api_adapter/models/messages/chat_message.py
@@ -14,6 +14,9 @@ class Message:
 
     def to_openai(self) -> Dict[str, Any]:
         return {"role": self.role, "content": self.content}
+    
+    def to_openai_responses_input(self) -> List[Dict[str, Any]]:
+        return [{"role": self.role, "content": self.content}]
 
     def to_anthropic(self) -> Dict[str, Any]:
         return {"role": self.role, "content": self.content}
@@ -68,6 +71,12 @@ class AIMessage(Message):
                 for tc in self.tool_calls
             ]
         return msg
+    
+    def to_openai_responses_input(self) -> List[Dict[str, Any]]:
+        items: List[Dict[str, Any]] = []
+        if self.content:
+            items.append({"role": "assistant", "content": self.content})
+        return items
 
     def to_anthropic(self) -> Dict[str, Any]:
         if not self.tool_calls:
@@ -124,6 +133,15 @@ class ToolMessage(Message):
 
     def to_openai(self) -> Dict[str, Any]:
         return {"role": "tool", "tool_call_id": self.tool_call_id, "content": self.content}
+
+    def to_openai_responses_input(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "type": "function_call_output",
+                "call_id": self.tool_call_id,
+                "output": self.content,
+            }
+        ]
 
     def to_anthropic(self) -> Dict[str, Any]:
         if not self.tool_call_id:
@@ -291,6 +309,25 @@ class Messages:
    
     def to_openai(self) -> List[Dict[str, Any]]:
         return [m.to_openai() for m in self.items]
+    
+    def to_openai_responses_input(self) -> List[Dict[str, Any]]:
+        items: List[Dict[str, Any]] = []
+        for m in self.items:
+            if isinstance(m, Prompt):
+                continue
+            items.extend(m.to_openai_responses_input())
+        return items
+
+    def to_openai_responses_instructions(self) -> Optional[str]:
+        instructions: Optional[str] = None
+        for m in self.items:
+            if isinstance(m, Prompt):
+                if instructions is not None:
+                    raise ValueError(
+                        "Multiple system prompts are not allowed for OpenAI Responses."
+                    )
+                instructions = m.content
+        return instructions
 
     def to_anthropic(self) -> Tuple[str | None, List[Dict[str, Any]]]:
         prompt: Optional[str] = None

--- a/src/llm_api_adapter/models/messages/chat_message.py
+++ b/src/llm_api_adapter/models/messages/chat_message.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 import json
-from typing import Any, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, Dict, List, Optional, Tuple, Type
 
 from ..tools import ToolCall
 
@@ -17,6 +17,9 @@ class Message:
 
     def to_anthropic(self) -> Dict[str, Any]:
         return {"role": self.role, "content": self.content}
+
+    def to_google(self) -> Dict[str, Any]:
+        return {"role": self.role, "parts": [{"text": self.content}]}
 
 
 @dataclass
@@ -35,7 +38,7 @@ class UserMessage(Message):
     role: str = field(default="user", init=False)
 
     def to_google(self) -> Dict[str, Any]:
-        return {"role": self.role, "parts": [{"text": self.content}]}
+        return {"role": "user", "parts": [{"text": self.content}]}
 
 
 @dataclass
@@ -44,7 +47,8 @@ class AIMessage(Message):
     Assistant message.
 
     - OpenAI tool loop: may include tool_calls (assistant turn that requested tools).
-    - Anthropic tool loop: may include tool_calls -> rendered as content blocks type="tool_use".
+    - Anthropic tool loop: tool_calls -> content blocks type="tool_use".
+    - Google tool loop: tool_calls -> parts[].functionCall.
     """
     role: str = field(default="assistant", init=False)
     tool_calls: Optional[List[ToolCall]] = None
@@ -87,8 +91,22 @@ class AIMessage(Message):
         return {"role": "assistant", "content": blocks}
 
     def to_google(self) -> Dict[str, Any]:
-        # Google expects role "model"
-        return {"role": "model", "parts": [{"text": self.content}]}
+        parts: List[Dict[str, Any]] = []
+        if self.content:
+            parts.append({"text": self.content})
+        if self.tool_calls:
+            for tc in self.tool_calls:
+                parts.append(
+                    {
+                        "functionCall": {
+                            "name": tc.name,
+                            "args": tc.arguments or {},
+                        }
+                    }
+                )
+        if not parts:
+            parts = [{"text": ""}]
+        return {"role": "model", "parts": parts}
 
 
 @dataclass
@@ -97,7 +115,9 @@ class ToolMessage(Message):
     Tool result message.
 
     - OpenAI format: role="tool" + tool_call_id
-    - Anthropic format: rendered as a USER message with a tool_result content block referencing tool_use_id
+    - Anthropic format: user turn with tool_result block referencing tool_use_id
+    - Google format: user turn with functionResponse part (name + response object)
+      NOTE: Gemini doesn't have call_id; for Google tool loop we treat tool_call_id as function name.
     """
     tool_call_id: str
     role: str = field(default="tool", init=False)
@@ -115,6 +135,28 @@ class ToolMessage(Message):
                     "type": "tool_result",
                     "tool_use_id": self.tool_call_id,
                     "content": self.content,
+                }
+            ],
+        }
+
+    def to_google(self) -> Dict[str, Any]:
+        name = self.tool_call_id
+        if not name:
+            raise ValueError("Google functionResponse requires tool_call_id to be set (use tool name).")
+        response_obj: Any
+        try:
+            raw = self.content.strip()
+            response_obj = json.loads(raw) if raw else {}
+        except Exception:
+            response_obj = {"content": self.content}
+        return {
+            "role": "user",
+            "parts": [
+                {
+                    "functionResponse": {
+                        "name": name,
+                        "response": response_obj,
+                    }
                 }
             ],
         }
@@ -224,6 +266,13 @@ class Messages:
                 prompt = m.to_google()
                 continue
             if isinstance(m, ToolMessage):
-                raise ValueError("ToolMessage is not supported for Google in this version.")
-            messages.append(m.to_google())
+                messages.append(m.to_google())
+                continue
+            if isinstance(m, AIMessage):
+                messages.append(m.to_google())
+                continue
+            if isinstance(m, UserMessage):
+                messages.append(m.to_google())
+            else:
+                messages.append({"role": "user", "parts": [{"text": m.content}]})
         return prompt, messages

--- a/src/llm_api_adapter/models/messages/chat_message.py
+++ b/src/llm_api_adapter/models/messages/chat_message.py
@@ -203,25 +203,42 @@ class Messages:
                         for tc in tool_calls_raw:
                             if not isinstance(tc, dict):
                                 raise ValueError("assistant.tool_calls items must be dict")
-                            fn = tc.get("function") or {}
-                            name = fn.get("name")
-                            if not isinstance(name, str) or not name:
-                                raise ValueError("assistant.tool_calls.function.name must be non-empty str")
-                            raw_args = fn.get("arguments", "{}")
-                            if isinstance(raw_args, str):
-                                try:
-                                    args = json.loads(raw_args) if raw_args.strip() else {}
-                                except Exception as e:
-                                    raise ValueError(f"assistant.tool_calls.arguments JSON parse failed: {e}")
-                            elif isinstance(raw_args, dict):
-                                args = raw_args
+                            if "name" in tc:
+                                name = tc.get("name")
+                                if not isinstance(name, str) or not name:
+                                    raise ValueError("assistant.tool_calls.name must be non-empty str")
+                                args = tc.get("arguments", {})
+                                if args is None:
+                                    args = {}
+                                if not isinstance(args, dict):
+                                    raise ValueError("assistant.tool_calls.arguments must be dict")
+                                call_id = tc.get("call_id")
+                            # legacy OpenAI-shaped format
                             else:
-                                args = {}
+                                fn = tc.get("function") or {}
+                                name = fn.get("name")
+                                if not isinstance(name, str) or not name:
+                                    raise ValueError(
+                                        "assistant.tool_calls.function.name must be non-empty str"
+                                    )
+                                raw_args = fn.get("arguments", "{}")
+                                if isinstance(raw_args, str):
+                                    try:
+                                        args = json.loads(raw_args) if raw_args.strip() else {}
+                                    except Exception as e:
+                                        raise ValueError(
+                                            f"assistant.tool_calls.arguments JSON parse failed: {e}"
+                                        )
+                                elif isinstance(raw_args, dict):
+                                    args = raw_args
+                                else:
+                                    args = {}
+                                call_id = tc.get("id")
                             tool_calls.append(
                                 ToolCall(
                                     name=name,
                                     arguments=args,
-                                    call_id=tc.get("id"),
+                                    call_id=call_id,
                                 )
                             )
                     normalized.append(AIMessage(content=str(content), tool_calls=tool_calls))

--- a/src/llm_api_adapter/models/messages/chat_message.py
+++ b/src/llm_api_adapter/models/messages/chat_message.py
@@ -167,91 +167,128 @@ class Messages:
     items: List[Any]
 
     def __post_init__(self) -> None:
-        role_to_cls: Dict[str, Type[Message]] = {cls.role: cls for cls in Message.__subclasses__()}
-        normalized: List[Message] = []
-        for item in self.items:
-            if isinstance(item, Message):
-                normalized.append(item)
-                continue
-            if isinstance(item, dict):
-                role = item.get("role")
-                if not role:
-                    raise ValueError("Missing 'role' in message data")
-                if role not in role_to_cls:
-                    raise ValueError(f"Unsupported role: {role}")
-                if role == "tool":
-                    tool_call_id = item.get("tool_call_id")
-                    if not tool_call_id:
-                        raise ValueError("Missing 'tool_call_id' for tool message")
-                    content = item.get("content")
-                    if content is None:
-                        raise ValueError("Missing 'content' in message data")
-                    normalized.append(
-                        ToolMessage(content=str(content), tool_call_id=str(tool_call_id))
-                    )
-                    continue
-                if role == "assistant":
-                    tool_calls_raw = item.get("tool_calls")
-                    content = item.get("content")
-                    if content is None:
-                        content = ""
-                    tool_calls: Optional[List[ToolCall]] = None
-                    if tool_calls_raw is not None:
-                        if not isinstance(tool_calls_raw, list):
-                            raise ValueError("assistant.tool_calls must be a list")
-                        tool_calls = []
-                        for tc in tool_calls_raw:
-                            if not isinstance(tc, dict):
-                                raise ValueError("assistant.tool_calls items must be dict")
-                            if "name" in tc:
-                                name = tc.get("name")
-                                if not isinstance(name, str) or not name:
-                                    raise ValueError("assistant.tool_calls.name must be non-empty str")
-                                args = tc.get("arguments", {})
-                                if args is None:
-                                    args = {}
-                                if not isinstance(args, dict):
-                                    raise ValueError("assistant.tool_calls.arguments must be dict")
-                                call_id = tc.get("call_id")
-                            # legacy OpenAI-shaped format
-                            else:
-                                fn = tc.get("function") or {}
-                                name = fn.get("name")
-                                if not isinstance(name, str) or not name:
-                                    raise ValueError(
-                                        "assistant.tool_calls.function.name must be non-empty str"
-                                    )
-                                raw_args = fn.get("arguments", "{}")
-                                if isinstance(raw_args, str):
-                                    try:
-                                        args = json.loads(raw_args) if raw_args.strip() else {}
-                                    except Exception as e:
-                                        raise ValueError(
-                                            f"assistant.tool_calls.arguments JSON parse failed: {e}"
-                                        )
-                                elif isinstance(raw_args, dict):
-                                    args = raw_args
-                                else:
-                                    args = {}
-                                call_id = tc.get("id")
-                            tool_calls.append(
-                                ToolCall(
-                                    name=name,
-                                    arguments=args,
-                                    call_id=call_id,
-                                )
-                            )
-                    normalized.append(AIMessage(content=str(content), tool_calls=tool_calls))
-                    continue
-                content = item.get("content")
-                if content is None or content == "":
-                    raise ValueError("Missing 'content' in message data")
-                cls = role_to_cls[role]
-                normalized.append(cls(content=str(content)))
-                continue
-            raise TypeError(f"Unsupported message type: {type(item)}")
-        self.items = normalized
+        role_to_cls = self._build_role_to_cls_map()
+        self.items = [self._normalize_item(item, role_to_cls) for item in self.items]
 
+    def _build_role_to_cls_map(self) -> Dict[str, Type[Message]]:
+        return {cls.role: cls for cls in Message.__subclasses__()}
+
+    def _normalize_item(
+        self,
+        item: Any,
+        role_to_cls: Dict[str, Type[Message]],
+    ) -> Message:
+        if isinstance(item, Message):
+            return item
+        if isinstance(item, dict):
+            return self._normalize_dict_item(item, role_to_cls)
+        raise TypeError(f"Unsupported message type: {type(item)}")
+
+    def _normalize_dict_item(
+        self,
+        item: Dict[str, Any],
+        role_to_cls: Dict[str, Type[Message]],
+    ) -> Message:
+        role = item.get("role")
+        if not role:
+            raise ValueError("Missing 'role' in message data")
+        if role not in role_to_cls:
+            raise ValueError(f"Unsupported role: {role}")
+        if role == "tool":
+            return self._normalize_tool_message(item)
+        if role == "assistant":
+            return self._normalize_assistant_message(item)
+        return self._normalize_simple_message(item, role_to_cls[role])
+
+    def _normalize_tool_message(self, item: Dict[str, Any]) -> ToolMessage:
+        tool_call_id = item.get("tool_call_id")
+        if not tool_call_id:
+            raise ValueError("Missing 'tool_call_id' for tool message")
+        content = item.get("content")
+        if content is None:
+            raise ValueError("Missing 'content' in message data")
+        return ToolMessage(content=str(content), tool_call_id=str(tool_call_id))
+
+    def _normalize_assistant_message(self, item: Dict[str, Any]) -> AIMessage:
+        content = item.get("content")
+        if content is None:
+            content = ""
+        tool_calls_raw = item.get("tool_calls")
+        tool_calls = self._parse_assistant_tool_calls(tool_calls_raw)
+        return AIMessage(content=str(content), tool_calls=tool_calls)
+
+    def _parse_assistant_tool_calls(
+        self,
+        tool_calls_raw: Any,
+    ) -> Optional[List[ToolCall]]:
+        if tool_calls_raw is None:
+            return None
+        if not isinstance(tool_calls_raw, list):
+            raise ValueError("assistant.tool_calls must be a list")
+        return [self._parse_single_tool_call(tc) for tc in tool_calls_raw]
+
+    def _parse_single_tool_call(self, tool_call_raw: Any) -> ToolCall:
+        if not isinstance(tool_call_raw, dict):
+            raise ValueError("assistant.tool_calls items must be dict")
+        if "name" in tool_call_raw:
+            return self._parse_normalized_tool_call(tool_call_raw)
+        return self._parse_legacy_openai_tool_call(tool_call_raw)
+
+    def _parse_normalized_tool_call(self, tool_call_raw: Dict[str, Any]) -> ToolCall:
+        name = tool_call_raw.get("name")
+        if not isinstance(name, str) or not name:
+            raise ValueError("assistant.tool_calls.name must be non-empty str")
+        arguments = tool_call_raw.get("arguments", {})
+        if arguments is None:
+            arguments = {}
+        if not isinstance(arguments, dict):
+            raise ValueError("assistant.tool_calls.arguments must be dict")
+        call_id = tool_call_raw.get("call_id")
+        return ToolCall(
+            name=name,
+            arguments=arguments,
+            call_id=call_id,
+        )
+
+    def _parse_legacy_openai_tool_call(self, tool_call_raw: Dict[str, Any]) -> ToolCall:
+        function_payload = tool_call_raw.get("function") or {}
+        name = function_payload.get("name")
+        if not isinstance(name, str) or not name:
+            raise ValueError(
+                "assistant.tool_calls.function.name must be non-empty str"
+            )
+        arguments = self._parse_legacy_openai_tool_arguments(
+            function_payload.get("arguments", "{}")
+        )
+        call_id = tool_call_raw.get("id")
+        return ToolCall(
+            name=name,
+            arguments=arguments,
+            call_id=call_id,
+        )
+
+    def _parse_legacy_openai_tool_arguments(self, raw_args: Any) -> Dict[str, Any]:
+        if isinstance(raw_args, str):
+            try:
+                return json.loads(raw_args) if raw_args.strip() else {}
+            except Exception as e:
+                raise ValueError(
+                    f"assistant.tool_calls.arguments JSON parse failed: {e}"
+                )
+        if isinstance(raw_args, dict):
+            return raw_args
+        return {}
+
+    def _normalize_simple_message(
+        self,
+        item: Dict[str, Any],
+        message_cls: Type[Message],
+    ) -> Message:
+        content = item.get("content")
+        if content is None or content == "":
+            raise ValueError("Missing 'content' in message data")
+        return message_cls(content=str(content))
+   
     def to_openai(self) -> List[Dict[str, Any]]:
         return [m.to_openai() for m in self.items]
 

--- a/src/llm_api_adapter/models/messages/chat_message.py
+++ b/src/llm_api_adapter/models/messages/chat_message.py
@@ -1,15 +1,21 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
-from typing import Any, Dict, List
+import json
+from typing import Any, Dict, List, Optional, Tuple, Type
+
+from ..tools import ToolCall
 
 
 @dataclass
 class Message:
     content: str
+    role: str = field(init=False)
 
-    def to_openai(self) -> Dict:
+    def to_openai(self) -> Dict[str, Any]:
         return {"role": self.role, "content": self.content}
-    
-    def to_anthropic(self) -> Dict:
+
+    def to_anthropic(self) -> Dict[str, Any]:
         return {"role": self.role, "content": self.content}
 
 
@@ -19,7 +25,7 @@ class Prompt(Message):
 
     def to_anthropic(self) -> str:
         return self.content
-    
+
     def to_google(self) -> str:
         return self.content
 
@@ -28,69 +34,153 @@ class Prompt(Message):
 class UserMessage(Message):
     role: str = field(default="user", init=False)
 
-    def to_google(self) -> str:
+    def to_google(self) -> Dict[str, Any]:
         return {"role": self.role, "parts": [{"text": self.content}]}
 
 
 @dataclass
 class AIMessage(Message):
+    """
+    Assistant message.
+    For OpenAI tool loop, it may carry tool_calls (assistant turn that requested tools).
+    """
     role: str = field(default="assistant", init=False)
+    tool_calls: Optional[List[ToolCall]] = None
 
-    def to_google(self) -> str:
+    def to_openai(self) -> Dict[str, Any]:
+        msg: Dict[str, Any] = {"role": "assistant", "content": self.content}
+        if self.tool_calls:
+            msg["tool_calls"] = [
+                {
+                    "id": tc.call_id,
+                    "type": "function",
+                    "function": {
+                        "name": tc.name,
+                        "arguments": json.dumps(tc.arguments, ensure_ascii=False),
+                    },
+                }
+                for tc in self.tool_calls
+            ]
+        return msg
+
+    def to_google(self) -> Dict[str, Any]:
+        # Google expects role "model"
         return {"role": "model", "parts": [{"text": self.content}]}
+
+
+@dataclass
+class ToolMessage(Message):
+    """
+    Tool result message (OpenAI format).
+    Must reference preceding assistant tool call via tool_call_id.
+    """
+    tool_call_id: str
+    role: str = field(default="tool", init=False)
+
+    def to_openai(self) -> Dict[str, Any]:
+        return {"role": "tool", "tool_call_id": self.tool_call_id, "content": self.content}
 
 
 @dataclass
 class Messages:
     items: List[Any]
 
-    def __post_init__(self):
-        allowed_roles = {cls.role: cls for cls in Message.__subclasses__()}
-        normalized = []
+    def __post_init__(self) -> None:
+        role_to_cls: Dict[str, Type[Message]] = {cls.role: cls for cls in Message.__subclasses__()}
+        normalized: List[Message] = []
         for item in self.items:
             if isinstance(item, Message):
                 normalized.append(item)
-            elif isinstance(item, dict):
-                role, content = item.get("role"), item.get("content")
+                continue
+            if isinstance(item, dict):
+                role = item.get("role")
                 if not role:
                     raise ValueError("Missing 'role' in message data")
-                if not content:
-                    raise ValueError("Missing 'content' in message data")
-                if role not in allowed_roles:
+                if role not in role_to_cls:
                     raise ValueError(f"Unsupported role: {role}")
-                normalized.append(allowed_roles[role](content=content))
-            else:
-                raise TypeError(f"Unsupported message type: {type(item)}")
-        self.items = normalized
-    
-    def to_openai(self) -> list[dict]:
-        messages = [message.to_openai() for message in self.items]
-        return messages
-    
-    def to_anthropic(self) -> tuple[str | None, list[dict]]:
-        prompt = None
-        messages = []
-        for message in self.items:
-            if isinstance(message, Prompt):
-                if prompt is not None:
-                    raise ValueError(
-                        "Multiple system prompts are not allowed for Anthropic."
+                if role == "tool":
+                    tool_call_id = item.get("tool_call_id")
+                    if not tool_call_id:
+                        raise ValueError("Missing 'tool_call_id' for tool message")
+                    content = item.get("content")
+                    if content is None:
+                        raise ValueError("Missing 'content' in message data")
+                    normalized.append(
+                        ToolMessage(content=str(content), tool_call_id=str(tool_call_id))
                     )
-                prompt = message.to_anthropic()
-            else:
-                messages.append(message.to_anthropic())
+                    continue
+                if role == "assistant":
+                    tool_calls_raw = item.get("tool_calls")
+                    content = item.get("content")
+                    if content is None:
+                        content = ""
+                    tool_calls: Optional[List[ToolCall]] = None
+                    if tool_calls_raw is not None:
+                        if not isinstance(tool_calls_raw, list):
+                            raise ValueError("assistant.tool_calls must be a list")
+                        tool_calls = []
+                        for tc in tool_calls_raw:
+                            if not isinstance(tc, dict):
+                                raise ValueError("assistant.tool_calls items must be dict")
+                            fn = tc.get("function") or {}
+                            name = fn.get("name")
+                            if not isinstance(name, str) or not name:
+                                raise ValueError("assistant.tool_calls.function.name must be non-empty str")
+                            raw_args = fn.get("arguments", "{}")
+                            if isinstance(raw_args, str):
+                                try:
+                                    args = json.loads(raw_args) if raw_args.strip() else {}
+                                except Exception as e:
+                                    raise ValueError(f"assistant.tool_calls.arguments JSON parse failed: {e}")
+                            elif isinstance(raw_args, dict):
+                                args = raw_args
+                            else:
+                                args = {}
+                            tool_calls.append(
+                                ToolCall(
+                                    name=name,
+                                    arguments=args,
+                                    call_id=tc.get("id"),
+                                )
+                            )
+                    normalized.append(AIMessage(content=str(content), tool_calls=tool_calls))
+                    continue
+                content = item.get("content")
+                if content is None or content == "":
+                    raise ValueError("Missing 'content' in message data")
+                cls = role_to_cls[role]
+                normalized.append(cls(content=str(content)))
+                continue
+            raise TypeError(f"Unsupported message type: {type(item)}")
+        self.items = normalized
+
+    def to_openai(self) -> List[Dict[str, Any]]:
+        return [m.to_openai() for m in self.items]
+
+    def to_anthropic(self) -> Tuple[str | None, List[Dict[str, Any]]]:
+        prompt: Optional[str] = None
+        messages: List[Dict[str, Any]] = []
+        for m in self.items:
+            if isinstance(m, Prompt):
+                if prompt is not None:
+                    raise ValueError("Multiple system prompts are not allowed for Anthropic.")
+                prompt = m.to_anthropic()
+                continue
+            if isinstance(m, ToolMessage):
+                raise ValueError("ToolMessage is not supported for Anthropic in this version.")
+            messages.append(m.to_anthropic())
         return prompt, messages
 
-    def to_google(self) -> tuple[str | None, list[dict]]:
-        prompt = None
-        messages = []
-        for message in self.items:
-            if isinstance(message, Prompt):
+    def to_google(self) -> Tuple[str | None, List[Dict[str, Any]]]:
+        prompt: Optional[str] = None
+        messages: List[Dict[str, Any]] = []
+        for m in self.items:
+            if isinstance(m, Prompt):
                 if prompt is not None:
-                    raise ValueError(
-                        "Multiple system prompts are not allowed for Google."
-                    )
-                prompt = message.to_google()
-            else:
-                messages.append(message.to_google())
+                    raise ValueError("Multiple system prompts are not allowed for Google.")
+                prompt = m.to_google()
+                continue
+            if isinstance(m, ToolMessage):
+                raise ValueError("ToolMessage is not supported for Google in this version.")
+            messages.append(m.to_google())
         return prompt, messages

--- a/src/llm_api_adapter/models/responses/chat_response.py
+++ b/src/llm_api_adapter/models/responses/chat_response.py
@@ -160,7 +160,7 @@ class ChatResponse:
         if not isinstance(parts, list):
             raise LLMAPIError(
                 "Google API returned malformed response",
-                detail="content.parts is not a list"
+                detail="content.parts is not a list",
             )
         parsed_tool_calls: Optional[List[ToolCall]] = None
         text_content: Optional[str] = None
@@ -174,11 +174,11 @@ class ChatResponse:
                 if parsed_tool_calls is None:
                     parsed_tool_calls = []
                 name = fc.get("name")
-                args = (
-                    fc.get("args")
-                    if "args" in fc
-                    else fc.get("arguments", {})
-                )
+                if not isinstance(name, str) or not name:
+                    raise InvalidToolArgumentsError(
+                        detail="Google functionCall.name must be non-empty str"
+                    )
+                args = fc.get("args") if "args" in fc else fc.get("arguments", {})
                 if args is None:
                     args = {}
                 if not isinstance(args, dict):
@@ -189,7 +189,7 @@ class ChatResponse:
                     ToolCall(
                         name=name,
                         arguments=args,
-                        call_id=None,
+                        call_id=name,
                     )
                 )
         return cls(

--- a/src/llm_api_adapter/models/responses/chat_response.py
+++ b/src/llm_api_adapter/models/responses/chat_response.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
+import json
 from typing import List, Optional
 import warnings
 
-from ...errors.llm_api_error import LLMAPIError
+from ...errors.llm_api_error import InvalidToolArgumentsError, LLMAPIError
 from ...models.tools import ToolCall
 
 
@@ -29,26 +30,77 @@ class ChatResponse:
 
     @classmethod
     def from_openai_response(cls, api_response: dict) -> "ChatResponse":
-        u = api_response.get("usage", {})
+        u = api_response.get("usage", {}) or {}
         usage = Usage(
             input_tokens=u.get("prompt_tokens", 0),
             output_tokens=u.get("completion_tokens", 0),
             total_tokens=u.get("total_tokens", 0),
         )
-        text = api_response["choices"][0]["message"]["content"]
-        if not text or not text.strip():
-            warnings.warn(
-                "OpenAI returned empty content. "
-                "The model may have stopped early due to a low max_tokens value.",
-                UserWarning,
-            )
+        choice0 = (api_response.get("choices") or [None])[0] or {}
+        message = choice0.get("message") or {}
+        text = message.get("content")
+        parsed_tool_calls: Optional[List[ToolCall]] = None
+        raw_tool_calls = message.get("tool_calls")
+        if isinstance(raw_tool_calls, list) and raw_tool_calls:
+            parsed_tool_calls = []
+            for tc in raw_tool_calls:
+                tc = tc or {}
+                fn = tc.get("function") or {}
+                name = fn.get("name")
+                raw_args = fn.get("arguments", "{}")
+                try:
+                    if isinstance(raw_args, str):
+                        arguments = json.loads(raw_args) if raw_args.strip() else {}
+                    elif isinstance(raw_args, dict):
+                        arguments = raw_args
+                    else:
+                        arguments = {}
+                except Exception as e:
+                    raise InvalidToolArgumentsError(
+                        detail=f"OpenAI tool arguments JSON parse failed for tool={name!r}: {e}"
+                    )
+                parsed_tool_calls.append(
+                    ToolCall(
+                        name=name,
+                        arguments=arguments,
+                        call_id=tc.get("id"),
+                    )
+                )
+
+        # Legacy function_call (older format)
+        legacy_fc = message.get("function_call")
+        if (not parsed_tool_calls) and isinstance(legacy_fc, dict) and legacy_fc:
+            name = legacy_fc.get("name")
+            raw_args = legacy_fc.get("arguments", "{}")
+            try:
+                if isinstance(raw_args, str):
+                    arguments = json.loads(raw_args) if raw_args.strip() else {}
+                elif isinstance(raw_args, dict):
+                    arguments = raw_args
+                else:
+                    arguments = {}
+            except Exception as e:
+                raise InvalidToolArgumentsError(
+                    detail=f"OpenAI function_call arguments JSON parse failed for tool={name!r}: {e}"
+                )
+            parsed_tool_calls = [ToolCall(name=name, arguments=arguments, call_id=None)]
+
+        if not parsed_tool_calls:
+            if not text or not str(text).strip():
+                warnings.warn(
+                    "OpenAI returned empty content. "
+                    "The model may have stopped early due to a low max_tokens value.",
+                    UserWarning,
+                )
+
         return cls(
             model=api_response.get("model"),
             response_id=api_response.get("id"),
             timestamp=api_response.get("created"),
             usage=usage,
             content=text,
-            finish_reason=api_response["choices"][0].get("finish_reason"),
+            tool_calls=parsed_tool_calls,
+            finish_reason=choice0.get("finish_reason"),
         )
 
     @classmethod

--- a/src/llm_api_adapter/models/responses/chat_response.py
+++ b/src/llm_api_adapter/models/responses/chat_response.py
@@ -105,22 +105,42 @@ class ChatResponse:
 
     @classmethod
     def from_anthropic_response(cls, api_response: dict) -> "ChatResponse":
-        u = api_response.get("usage", {})
+        u = api_response.get("usage", {}) or {}
         usage = Usage(
             input_tokens=u.get("input_tokens", 0),
             output_tokens=u.get("output_tokens", 0),
             total_tokens=u.get("input_tokens", 0) + u.get("output_tokens", 0),
         )
-        content = api_response.get("content", [])
-        first_text = next(
-            (block.get("text") for block in content if block.get("type") == "text"),
-            None
-        )
+        blocks = api_response.get("content", []) or []
+        parsed_tool_calls: Optional[List[ToolCall]] = None
+        text_content: Optional[str] = None
+        for block in blocks:
+            block_type = block.get("type")
+            if block_type == "text" and text_content is None:
+                text_content = block.get("text")
+            elif block_type == "tool_use":
+                if parsed_tool_calls is None:
+                    parsed_tool_calls = []
+                name = block.get("name")
+                arguments = block.get("input")
+                if not isinstance(arguments, dict):
+                    from ...errors.llm_api_error import InvalidToolArgumentsError
+                    raise InvalidToolArgumentsError(
+                        detail=f"Anthropic tool input must be dict for tool={name!r}"
+                    )
+                parsed_tool_calls.append(
+                    ToolCall(
+                        name=name,
+                        arguments=arguments,
+                        call_id=block.get("id"),
+                    )
+                )
         return cls(
             model=api_response.get("model"),
             response_id=api_response.get("id"),
             usage=usage,
-            content=first_text,
+            content=text_content,
+            tool_calls=parsed_tool_calls,
             finish_reason=api_response.get("stop_reason"),
         )
 

--- a/src/llm_api_adapter/models/responses/chat_response.py
+++ b/src/llm_api_adapter/models/responses/chat_response.py
@@ -1,8 +1,9 @@
-from dataclasses import dataclass, field
-from typing import Optional
+from dataclasses import dataclass
+from typing import List, Optional
 import warnings
 
 from ...errors.llm_api_error import LLMAPIError
+from ...models.tools import ToolCall
 
 
 @dataclass
@@ -22,7 +23,8 @@ class ChatResponse:
     cost_input: Optional[float] = None
     cost_output: Optional[float] = None
     cost_total: Optional[float] = None
-    content: str = field(default_factory=str)
+    content: Optional[str] = None
+    tool_calls: Optional[List[ToolCall]] = None
     finish_reason: Optional[str] = None
 
     @classmethod

--- a/src/llm_api_adapter/models/responses/chat_response.py
+++ b/src/llm_api_adapter/models/responses/chat_response.py
@@ -124,7 +124,6 @@ class ChatResponse:
                 name = block.get("name")
                 arguments = block.get("input")
                 if not isinstance(arguments, dict):
-                    from ...errors.llm_api_error import InvalidToolArgumentsError
                     raise InvalidToolArgumentsError(
                         detail=f"Anthropic tool input must be dict for tool={name!r}"
                     )
@@ -146,26 +145,58 @@ class ChatResponse:
 
     @classmethod
     def from_google_response(cls, api_response: dict) -> "ChatResponse":
-        u = api_response.get("usageMetadata", {})
+        u = api_response.get("usageMetadata", {}) or {}
         thoughts_tokens = u.get("thoughtsTokenCount", 0)
         usage = Usage(
             input_tokens=u.get("promptTokenCount", 0),
             output_tokens=u.get("candidatesTokenCount", 0) + thoughts_tokens,
             total_tokens=u.get("totalTokenCount", 0),
         )
-        first_candidate = api_response["candidates"][0]
-        content = first_candidate.get("content", {})
-        parts = content.get("parts")
-        if not parts or not isinstance(parts, list):
+        first_candidate = (api_response.get("candidates") or [None])[0] or {}
+        finish_reason = first_candidate.get("finishReason")
+        finish_reason_str = str(finish_reason) if finish_reason is not None else None
+        content_obj = first_candidate.get("content") or {}
+        parts = content_obj.get("parts") or []
+        if not isinstance(parts, list):
             raise LLMAPIError(
                 "Google API returned malformed response",
-                detail="content.parts missing — likely max_output_tokens too small"
+                detail="content.parts is not a list"
             )
-        text = parts[0].get("text")
+        parsed_tool_calls: Optional[List[ToolCall]] = None
+        text_content: Optional[str] = None
+        for part in parts:
+            if not isinstance(part, dict):
+                continue
+            if text_content is None and "text" in part:
+                text_content = part.get("text")
+            fc = part.get("functionCall") or part.get("function_call")
+            if isinstance(fc, dict) and fc:
+                if parsed_tool_calls is None:
+                    parsed_tool_calls = []
+                name = fc.get("name")
+                args = (
+                    fc.get("args")
+                    if "args" in fc
+                    else fc.get("arguments", {})
+                )
+                if args is None:
+                    args = {}
+                if not isinstance(args, dict):
+                    raise InvalidToolArgumentsError(
+                        detail=f"Google functionCall args must be dict for tool={name!r}"
+                    )
+                parsed_tool_calls.append(
+                    ToolCall(
+                        name=name,
+                        arguments=args,
+                        call_id=None,
+                    )
+                )
         return cls(
             usage=usage,
-            content=text,
-            finish_reason=str(first_candidate.get("finishReason")),
+            content=text_content,
+            tool_calls=parsed_tool_calls,
+            finish_reason=finish_reason_str,
         )
 
     def apply_pricing(

--- a/src/llm_api_adapter/models/responses/chat_response.py
+++ b/src/llm_api_adapter/models/responses/chat_response.py
@@ -104,6 +104,74 @@ class ChatResponse:
         )
 
     @classmethod
+    def from_openai_responses_response(cls, api_response: dict) -> "ChatResponse":
+        u = api_response.get("usage", {}) or {}
+        usage = Usage(
+            input_tokens=u.get("input_tokens", 0),
+            output_tokens=u.get("output_tokens", 0),
+            total_tokens=u.get("total_tokens", 0),
+        )
+        parsed_tool_calls: Optional[List[ToolCall]] = None
+        text_parts: List[str] = []
+        output_items = api_response.get("output") or []
+        if not isinstance(output_items, list):
+            output_items = []
+        for item in output_items:
+            if not isinstance(item, dict):
+                continue
+            item_type = item.get("type")
+            if item_type == "message":
+                content_items = item.get("content") or []
+                if not isinstance(content_items, list):
+                    continue
+                for content_item in content_items:
+                    if not isinstance(content_item, dict):
+                        continue
+                    content_type = content_item.get("type")
+                    if content_type in ("output_text", "text"):
+                        text_value = content_item.get("text")
+                        if isinstance(text_value, str) and text_value.strip():
+                            text_parts.append(text_value)
+            elif item_type in ("function_call", "tool_call"):
+                if parsed_tool_calls is None:
+                    parsed_tool_calls = []
+                name = item.get("name")
+                raw_args = item.get("arguments", "{}")
+                try:
+                    if isinstance(raw_args, str):
+                        arguments = json.loads(raw_args) if raw_args.strip() else {}
+                    elif isinstance(raw_args, dict):
+                        arguments = raw_args
+                    else:
+                        arguments = {}
+                except Exception as e:
+                    raise InvalidToolArgumentsError(
+                        detail=f"OpenAI responses tool arguments JSON parse failed for tool={name!r}: {e}"
+                    )
+                parsed_tool_calls.append(
+                    ToolCall(
+                        name=name,
+                        arguments=arguments,
+                        call_id=item.get("call_id") or item.get("id"),
+                    )
+                )
+        text = "\n".join(text_parts) if text_parts else None
+        if not parsed_tool_calls and (not text or not text.strip()):
+            warnings.warn(
+                "OpenAI Responses API returned empty content and no tool calls.",
+                UserWarning,
+            )
+        return cls(
+            model=api_response.get("model"),
+            response_id=api_response.get("id"),
+            timestamp=api_response.get("created_at"),
+            usage=usage,
+            content=text,
+            tool_calls=parsed_tool_calls,
+            finish_reason=api_response.get("status"),
+        )
+
+    @classmethod
     def from_anthropic_response(cls, api_response: dict) -> "ChatResponse":
         u = api_response.get("usage", {}) or {}
         usage = Usage(

--- a/src/llm_api_adapter/models/tools/__init__.py
+++ b/src/llm_api_adapter/models/tools/__init__.py
@@ -1,0 +1,4 @@
+from .tool_spec import ToolSpec
+from .tool_call import ToolCall
+
+__all__ = ["ToolSpec", "ToolCall"]

--- a/src/llm_api_adapter/models/tools/tool_call.py
+++ b/src/llm_api_adapter/models/tools/tool_call.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+
+@dataclass(frozen=True, slots=True)
+class ToolCall:
+    """
+    Normalized tool call emitted by the model.
+
+    arguments must be a parsed dict (provider parsing converts JSON -> dict).
+    """
+    name: str
+    arguments: Dict[str, Any]
+    call_id: Optional[str] = None

--- a/src/llm_api_adapter/models/tools/tool_spec.py
+++ b/src/llm_api_adapter/models/tools/tool_spec.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+
+@dataclass(frozen=True, slots=True)
+class ToolSpec:
+    """
+    Provider-agnostic tool/function specification.
+
+    json_schema: JSON Schema object (dict). Validation is performed in adapters.
+    """
+    name: str
+    json_schema: Dict[str, Any]
+    description: Optional[str] = None

--- a/tests/integration/test_llm_adapter_chat.py
+++ b/tests/integration/test_llm_adapter_chat.py
@@ -2,48 +2,114 @@ import pytest
 import requests_mock
 
 from src.llm_api_adapter.models.messages.chat_message import (
-    Prompt, UserMessage, AIMessage
+    Prompt,
+    UserMessage,
+    AIMessage,
 )
 from src.llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
 
+
 @pytest.fixture
-def openai_client_mock():
+def openai_responses_mock():
     with requests_mock.Mocker() as mock:
-        mock.post("https://api.openai.com/v1/chat/completions", json={
-            "choices": [{"message": {"content": "Hello from mocked OpenAI!"}}]
-        })
+        mock.post(
+            "https://api.openai.com/v1/responses",
+            json={
+                "id": "resp_123",
+                "object": "response",
+                "model": "gpt-5",
+                "output": [
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": "Hello from mocked OpenAI!",
+                            }
+                        ],
+                    }
+                ],
+                "usage": {
+                    "input_tokens": 5,
+                    "output_tokens": 7,
+                    "total_tokens": 12,
+                },
+            },
+        )
         yield mock
+
+
+@pytest.fixture
+def openai_chat_completions_mock():
+    with requests_mock.Mocker() as mock:
+        mock.post(
+            "https://api.openai.com/v1/chat/completions",
+            json={
+                "id": "chatcmpl_123",
+                "object": "chat.completion",
+                "model": "gpt-4o",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "Hello from mocked OpenAI legacy!",
+                        },
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 5,
+                    "completion_tokens": 7,
+                    "total_tokens": 12,
+                },
+            },
+        )
+        yield mock
+
 
 @pytest.fixture
 def google_client_mock():
     with requests_mock.Mocker() as mock:
         mock_endpoint = "https://generativelanguage.googleapis.com/v1beta"
-        mock.post(f"{mock_endpoint}/models/gemini-2.5-pro:generateContent",
+        mock.post(
+            f"{mock_endpoint}/models/gemini-2.5-pro:generateContent",
             json={
-                "candidates": [{
-                    "content": {
-                        "parts": [{"text": "Hello from mocked Google!"}]
-                    },
-                    "finishReason": "stop"
-                }],
-                "usageMetadata": {"totalTokenCount": 42}
-            })
+                "candidates": [
+                    {
+                        "content": {
+                            "parts": [{"text": "Hello from mocked Google!"}]
+                        },
+                        "finishReason": "stop",
+                    }
+                ],
+                "usageMetadata": {"totalTokenCount": 42},
+            },
+        )
         yield mock
+
 
 @pytest.fixture
 def anthropic_client_mock():
     with requests_mock.Mocker() as mock:
-        mock.post("https://api.anthropic.com/v1/messages", json={
-            "model": "claude-sonnet-4-5",
-            "id": "response123",
-            "usage": {"input_tokens": 5, "output_tokens": 7},
-            "content": [{"type": "text", "text": "Hello from mocked Anthropic!"}],
-            "stop_reason": "stop"
-        })
+        mock.post(
+            "https://api.anthropic.com/v1/messages",
+            json={
+                "model": "claude-sonnet-4-5",
+                "id": "response123",
+                "usage": {"input_tokens": 5, "output_tokens": 7},
+                "content": [
+                    {"type": "text", "text": "Hello from mocked Anthropic!"}
+                ],
+                "stop_reason": "stop",
+            },
+        )
         yield mock
 
+
 @pytest.mark.integration
-def test_openai_chat(openai_client_mock):
+def test_openai_chat_gpt5_responses_api(openai_responses_mock):
     messages = [
         Prompt("You are an assistant."),
         UserMessage("Hi! Can you explain?"),
@@ -53,33 +119,63 @@ def test_openai_chat(openai_client_mock):
     adapter = UniversalLLMAPIAdapter(
         organization="openai",
         model="gpt-5",
-        api_key="dummy_key"
+        api_key="dummy_key",
     )
+
     response = adapter.chat(messages=messages)
+
     assert response.content == "Hello from mocked OpenAI!"
 
+
 @pytest.mark.integration
-def test_openai_chat_with_raw_dict_messages(openai_client_mock):
+def test_openai_chat_with_raw_dict_messages_gpt5_responses_api(
+    openai_responses_mock,
+):
     messages = [
-        {"role": "system", "content": "You are a friendly assistant who answers only yes or no."},
+        {
+            "role": "system",
+            "content": "You are a friendly assistant who answers only yes or no.",
+        },
         {"role": "user", "content": "Do you know how AI learns?"},
         {"role": "assistant", "content": "Yes."},
-        {"role": "user", "content": "Can you explain it in one sentence?"}
+        {"role": "user", "content": "Can you explain it in one sentence?"},
     ]
     adapter = UniversalLLMAPIAdapter(
         organization="openai",
         model="gpt-5",
-        api_key="dummy_key"
+        api_key="dummy_key",
     )
+
     resp = adapter.chat(messages=messages)
+
     assert resp.content == "Hello from mocked OpenAI!"
+
+
+@pytest.mark.integration
+def test_openai_chat_legacy_chat_completions(openai_chat_completions_mock):
+    messages = [
+        Prompt("You are an assistant."),
+        UserMessage("Hi! Can you explain?"),
+        AIMessage("Sure!"),
+        UserMessage("How does AI learn?"),
+    ]
+    adapter = UniversalLLMAPIAdapter(
+        organization="openai",
+        model="gpt-4o",
+        api_key="dummy_key",
+    )
+
+    response = adapter.chat(messages=messages)
+
+    assert response.content == "Hello from mocked OpenAI legacy!"
+
 
 @pytest.mark.integration
 def test_google_chat(google_client_mock):
     adapter = UniversalLLMAPIAdapter(
         organization="google",
         model="gemini-2.5-pro",
-        api_key="dummy_key"
+        api_key="dummy_key",
     )
     messages = [
         Prompt("You are an assistant."),
@@ -87,31 +183,40 @@ def test_google_chat(google_client_mock):
         AIMessage("Sure!"),
         UserMessage("How does AI learn?"),
     ]
+
     resp = adapter.chat(messages=messages)
+
     assert resp.content == "Hello from mocked Google!"
+
 
 @pytest.mark.integration
 def test_google_chat_with_raw_dict_messages(google_client_mock):
     messages = [
-        {"role": "system", "content": "You are a friendly assistant who answers only yes or no."},
+        {
+            "role": "system",
+            "content": "You are a friendly assistant who answers only yes or no.",
+        },
         {"role": "user", "content": "Do you know how AI learns?"},
         {"role": "assistant", "content": "Yes."},
-        {"role": "user", "content": "Can you explain it in one sentence?"}
+        {"role": "user", "content": "Can you explain it in one sentence?"},
     ]
     adapter = UniversalLLMAPIAdapter(
         organization="google",
         model="gemini-2.5-pro",
-        api_key="dummy_key"
+        api_key="dummy_key",
     )
+
     resp = adapter.chat(messages=messages)
+
     assert resp.content == "Hello from mocked Google!"
+
 
 @pytest.mark.integration
 def test_anthropic_chat(anthropic_client_mock):
     adapter = UniversalLLMAPIAdapter(
         organization="anthropic",
         model="claude-sonnet-4-5",
-        api_key="dummy_key"
+        api_key="dummy_key",
     )
     messages = [
         Prompt("You are an assistant."),
@@ -119,33 +224,41 @@ def test_anthropic_chat(anthropic_client_mock):
         AIMessage("Sure!"),
         UserMessage("How does AI learn?"),
     ]
+
     resp = adapter.chat(messages=messages, max_tokens=2000)
+
     assert resp.content == "Hello from mocked Anthropic!"
+
 
 @pytest.mark.integration
 def test_anthropic_chat_with_raw_dict_messages(anthropic_client_mock):
     messages = [
-        {"role": "system", "content": "You are a friendly assistant who answers only yes or no."},
+        {
+            "role": "system",
+            "content": "You are a friendly assistant who answers only yes or no.",
+        },
         {"role": "user", "content": "Do you know how AI learns?"},
         {"role": "assistant", "content": "Yes."},
-        {"role": "user", "content": "Can you explain it in one sentence?"}
+        {"role": "user", "content": "Can you explain it in one sentence?"},
     ]
     adapter = UniversalLLMAPIAdapter(
         organization="anthropic",
         model="claude-sonnet-4-5",
-        api_key="dummy_key"
+        api_key="dummy_key",
     )
+
     resp = adapter.chat(messages=messages, max_tokens=2000)
+
     assert resp.content == "Hello from mocked Anthropic!"
+
 
 @pytest.mark.integration
 def test_google_usage_and_pricing(google_client_mock):
     adapter = UniversalLLMAPIAdapter(
         organization="google",
         model="gemini-2.5-pro",
-        api_key="dummy_key"
+        api_key="dummy_key",
     )
-    # Set pricing to zero so cost_total is deterministic (0) while usage.total_tokens should map from response
     adapter.pricing.set_in_per_1m(0)
     adapter.pricing.set_out_per_1m(0)
     adapter.pricing.set_currency("EUR")
@@ -153,32 +266,29 @@ def test_google_usage_and_pricing(google_client_mock):
     messages = [UserMessage("Hello")]
     resp = adapter.chat(messages=messages)
 
-    # The mocked Google response provides totalTokenCount = 42
     assert resp.usage.total_tokens == 42
     assert resp.cost_total == 0
     assert resp.currency == "EUR"
+
 
 @pytest.mark.integration
 def test_anthropic_tokens_and_pricing(anthropic_client_mock):
     adapter = UniversalLLMAPIAdapter(
         organization="anthropic",
         model="claude-sonnet-4-5",
-        api_key="dummy_key"
+        api_key="dummy_key",
     )
-    # Set pricing so cost per token = 1 unit (per_1m = 1_000_000 -> 1_000_000/1_000_000 = 1)
     adapter.pricing.set_in_per_1m(1_000_000)
     adapter.pricing.set_out_per_1m(1_000_000)
     adapter.pricing.set_currency("USD")
 
     messages = [UserMessage("Hello")]
-    resp = adapter.chat(messages=messages, max_tokens="2000")
+    resp = adapter.chat(messages=messages, max_tokens=2000)
 
-    # The mocked Anthropic response provides input_tokens=5 and output_tokens=7
     assert resp.usage.input_tokens == 5
     assert resp.usage.output_tokens == 7
     assert resp.usage.total_tokens == 12
 
-    # With per-token cost of 1 unit, costs should equal the token counts
     assert resp.cost_input == 5
     assert resp.cost_output == 7
     assert resp.cost_total == 12

--- a/tests/integration/test_tools.py
+++ b/tests/integration/test_tools.py
@@ -1,0 +1,499 @@
+import json
+
+import pytest
+import requests_mock
+
+from src.llm_api_adapter.models.messages.chat_message import (
+    AIMessage,
+    Prompt,
+    ToolMessage,
+    UserMessage,
+)
+from src.llm_api_adapter.models.tools import ToolSpec
+from src.llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
+
+
+TOOLS = [
+    ToolSpec(
+        name="get_weather",
+        description="Get current weather for a city",
+        json_schema={
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+            "additionalProperties": False,
+        },
+    )
+]
+
+
+@pytest.fixture
+def openai_tools_mock():
+    with requests_mock.Mocker() as mock:
+        mock.post(
+            "https://api.openai.com/v1/responses",
+            [
+                {
+                    "json": {
+                        "id": "resp_1",
+                        "model": "gpt-5.2-pro",
+                        "status": "completed",
+                        "output": [
+                            {
+                                "type": "function_call",
+                                "name": "get_weather",
+                                "arguments": "{\"city\":\"Tel Aviv\"}",
+                                "call_id": "call_123",
+                            }
+                        ],
+                        "usage": {
+                            "input_tokens": 10,
+                            "output_tokens": 5,
+                            "total_tokens": 15,
+                        },
+                    }
+                },
+                {
+                    "json": {
+                        "id": "resp_2",
+                        "model": "gpt-5.2-pro",
+                        "status": "completed",
+                        "output": [
+                            {
+                                "type": "message",
+                                "role": "assistant",
+                                "content": [
+                                    {
+                                        "type": "output_text",
+                                        "text": "The weather in Tel Aviv is 22 C.",
+                                    }
+                                ],
+                            }
+                        ],
+                        "usage": {
+                            "input_tokens": 12,
+                            "output_tokens": 8,
+                            "total_tokens": 20,
+                        },
+                    }
+                },
+            ],
+        )
+        yield mock
+
+
+@pytest.fixture
+def anthropic_tools_mock():
+    with requests_mock.Mocker() as mock:
+        mock.post(
+            "https://api.anthropic.com/v1/messages",
+            [
+                {
+                    "json": {
+                        "id": "msg_1",
+                        "model": "claude-sonnet-4-5",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "toolu_123",
+                                "name": "get_weather",
+                                "input": {"city": "Tel Aviv"},
+                            }
+                        ],
+                        "usage": {"input_tokens": 5, "output_tokens": 7},
+                        "stop_reason": "tool_use",
+                    }
+                },
+                {
+                    "json": {
+                        "id": "msg_2",
+                        "model": "claude-sonnet-4-5",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "The weather in Tel Aviv is 22 C.",
+                            }
+                        ],
+                        "usage": {"input_tokens": 6, "output_tokens": 8},
+                        "stop_reason": "end_turn",
+                    }
+                },
+            ],
+        )
+        yield mock
+
+
+@pytest.fixture
+def google_tools_mock():
+    with requests_mock.Mocker() as mock:
+        mock.post(
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent",
+            [
+                {
+                    "json": {
+                        "candidates": [
+                            {
+                                "content": {
+                                    "parts": [
+                                        {
+                                            "functionCall": {
+                                                "name": "get_weather",
+                                                "args": {"city": "Tel Aviv"},
+                                            }
+                                        }
+                                    ]
+                                },
+                                "finishReason": "STOP",
+                            }
+                        ],
+                        "usageMetadata": {"totalTokenCount": 42},
+                    }
+                },
+                {
+                    "json": {
+                        "candidates": [
+                            {
+                                "content": {
+                                    "parts": [
+                                        {
+                                            "text": "The weather in Tel Aviv is 22 C."
+                                        }
+                                    ]
+                                },
+                                "finishReason": "STOP",
+                            }
+                        ],
+                        "usageMetadata": {"totalTokenCount": 50},
+                    }
+                },
+            ],
+        )
+        yield mock
+
+
+@pytest.mark.integration
+def test_openai_gpt5_tool_call_parsing_and_request_mapping(openai_tools_mock):
+    adapter = UniversalLLMAPIAdapter(
+        organization="openai",
+        model="gpt-5.2-pro",
+        api_key="dummy_key",
+    )
+    messages = [
+        Prompt("You are a helpful assistant. If user asks about weather, call get_weather."),
+        UserMessage("What's the weather in Tel Aviv today?"),
+    ]
+
+    response = adapter.chat(
+        messages=messages,
+        tools=TOOLS,
+        tool_choice="auto",
+        max_tokens=128,
+    )
+
+    assert response.content is None
+    assert response.finish_reason == "completed"
+    assert response.response_id == "resp_1"
+    assert response.tool_calls is not None
+    assert len(response.tool_calls) == 1
+    assert response.tool_calls[0].name == "get_weather"
+    assert response.tool_calls[0].arguments == {"city": "Tel Aviv"}
+    assert response.tool_calls[0].call_id == "call_123"
+
+    first_request = openai_tools_mock.request_history[0]
+    payload = first_request.json()
+
+    assert payload["model"] == "gpt-5.2-pro"
+    assert payload["input"] == [{"role": "user", "content": "What's the weather in Tel Aviv today?"}]
+    assert payload["instructions"] == "You are a helpful assistant. If user asks about weather, call get_weather."
+    assert payload["tool_choice"] == "auto"
+    assert payload["max_output_tokens"] == 128
+
+    assert payload["tools"] == [
+        {
+            "type": "function",
+            "name": "get_weather",
+            "description": "Get current weather for a city",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+                "additionalProperties": False,
+            },
+        }
+    ]
+
+
+@pytest.mark.integration
+def test_openai_gpt5_tool_loop_with_previous_response_id(openai_tools_mock):
+    adapter = UniversalLLMAPIAdapter(
+        organization="openai",
+        model="gpt-5.2-pro",
+        api_key="dummy_key",
+    )
+    messages = [
+        Prompt("You are a helpful assistant. If user asks about weather, call get_weather."),
+        UserMessage("What's the weather in Tel Aviv today?"),
+    ]
+
+    first = adapter.chat(
+        messages=messages,
+        tools=TOOLS,
+        tool_choice="auto",
+        max_tokens=128,
+    )
+
+    assert first.tool_calls is not None
+    messages.append(AIMessage(content="", tool_calls=first.tool_calls))
+    messages.append(
+        ToolMessage(
+            tool_call_id=first.tool_calls[0].call_id,
+            content=json.dumps(
+                {"city": "Tel Aviv", "temperature": 22, "unit": "C"},
+                ensure_ascii=False,
+            ),
+        )
+    )
+
+    final = adapter.chat(
+        messages=messages,
+        max_tokens=256,
+        previous_response_id=first.response_id,
+    )
+
+    assert final.content == "The weather in Tel Aviv is 22 C."
+    assert final.tool_calls is None
+    assert final.response_id == "resp_2"
+
+    second_request = openai_tools_mock.request_history[1]
+    payload = second_request.json()
+
+    assert payload["previous_response_id"] == "resp_1"
+    assert payload["max_output_tokens"] == 256
+    assert payload["input"] == [
+        {
+            "role": "user",
+            "content": "What's the weather in Tel Aviv today?",
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_123",
+            "output": json.dumps(
+                {"city": "Tel Aviv", "temperature": 22, "unit": "C"},
+                ensure_ascii=False,
+            ),
+        },
+    ]
+
+
+@pytest.mark.integration
+def test_anthropic_tool_call_parsing_and_request_mapping(anthropic_tools_mock):
+    adapter = UniversalLLMAPIAdapter(
+        organization="anthropic",
+        model="claude-sonnet-4-5",
+        api_key="dummy_key",
+    )
+    messages = [
+        Prompt("You are a helpful assistant. If user asks about weather, call get_weather."),
+        UserMessage("What's the weather in Tel Aviv today?"),
+    ]
+
+    response = adapter.chat(
+        messages=messages,
+        max_tokens=256,
+        tools=TOOLS,
+        tool_choice="auto",
+    )
+
+    assert response.content is None
+    assert response.finish_reason == "tool_use"
+    assert response.response_id == "msg_1"
+    assert response.tool_calls is not None
+    assert len(response.tool_calls) == 1
+    assert response.tool_calls[0].name == "get_weather"
+    assert response.tool_calls[0].arguments == {"city": "Tel Aviv"}
+    assert response.tool_calls[0].call_id == "toolu_123"
+
+    first_request = anthropic_tools_mock.request_history[0]
+    payload = first_request.json()
+
+    assert payload["model"] == "claude-sonnet-4-5"
+    assert payload["system"] == "You are a helpful assistant. If user asks about weather, call get_weather."
+    assert payload["tool_choice"] == {"type": "auto"}
+    assert payload["tools"] == [
+        {
+            "name": "get_weather",
+            "description": "Get current weather for a city",
+            "input_schema": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+                "additionalProperties": False,
+            },
+        }
+    ]
+
+
+@pytest.mark.integration
+def test_anthropic_tool_loop_message_protocol(anthropic_tools_mock):
+    adapter = UniversalLLMAPIAdapter(
+        organization="anthropic",
+        model="claude-sonnet-4-5",
+        api_key="dummy_key",
+    )
+    messages = [
+        Prompt("You are a helpful assistant. If user asks about weather, call get_weather."),
+        UserMessage("What's the weather in Tel Aviv today?"),
+    ]
+
+    first = adapter.chat(
+        messages=messages,
+        max_tokens=256,
+        tools=TOOLS,
+        tool_choice="auto",
+    )
+
+    assert first.tool_calls is not None
+    messages.append(AIMessage(content="", tool_calls=first.tool_calls))
+    messages.append(
+        ToolMessage(
+            tool_call_id=first.tool_calls[0].call_id,
+            content=json.dumps(
+                {"city": "Tel Aviv", "temperature": 22, "unit": "C"},
+                ensure_ascii=False,
+            ),
+        )
+    )
+
+    final = adapter.chat(
+        messages=messages,
+        max_tokens=256,
+    )
+
+    assert final.content == "The weather in Tel Aviv is 22 C."
+
+    second_request = anthropic_tools_mock.request_history[1]
+    payload = second_request.json()
+    request_messages = payload["messages"]
+
+    assert request_messages[1] == {
+        "role": "assistant",
+        "content": [
+            {
+                "type": "tool_use",
+                "id": "toolu_123",
+                "name": "get_weather",
+                "input": {"city": "Tel Aviv"},
+            }
+        ],
+    }
+    assert request_messages[2] == {
+        "role": "user",
+        "content": [
+            {
+                "type": "tool_result",
+                "tool_use_id": "toolu_123",
+                "content": json.dumps(
+                    {"city": "Tel Aviv", "temperature": 22, "unit": "C"},
+                    ensure_ascii=False,
+                ),
+            }
+        ],
+    }
+
+
+@pytest.mark.integration
+def test_google_tool_call_and_tool_result_protocol(google_tools_mock):
+    adapter = UniversalLLMAPIAdapter(
+        organization="google",
+        model="gemini-2.5-pro",
+        api_key="dummy_key",
+    )
+    messages = [
+        Prompt("You are a helpful assistant. If user asks about weather, call get_weather."),
+        UserMessage("What's the weather in Tel Aviv today?"),
+    ]
+
+    first = adapter.chat(
+        messages=messages,
+        tools=TOOLS,
+        tool_choice="auto",
+        max_tokens=128,
+    )
+
+    assert first.tool_calls is not None
+    assert len(first.tool_calls) == 1
+    assert first.tool_calls[0].name == "get_weather"
+    assert first.tool_calls[0].arguments == {"city": "Tel Aviv"}
+    assert first.tool_calls[0].call_id == "get_weather"
+
+    first_request = google_tools_mock.request_history[0]
+    first_payload = first_request.json()
+
+    assert first_payload["system_instruction"] == {
+        "parts": [{"text": "You are a helpful assistant. If user asks about weather, call get_weather."}]
+    }
+    assert first_payload["toolConfig"] == {
+        "functionCallingConfig": {"mode": "AUTO"}
+    }
+    assert first_payload["tools"] == [
+        {
+            "functionDeclarations": [
+                {
+                    "name": "get_weather",
+                    "description": "Get current weather for a city",
+                    "parametersJsonSchema": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"],
+                        "additionalProperties": False,
+                    },
+                }
+            ]
+        }
+    ]
+
+    messages.append(AIMessage(content="", tool_calls=first.tool_calls))
+    messages.append(
+        ToolMessage(
+            tool_call_id=first.tool_calls[0].call_id,
+            content=json.dumps(
+                {"city": "Tel Aviv", "temperature": 22, "unit": "C"},
+                ensure_ascii=False,
+            ),
+        )
+    )
+
+    final = adapter.chat(messages=messages, max_tokens=256)
+
+    assert final.content == "The weather in Tel Aviv is 22 C."
+
+    second_request = google_tools_mock.request_history[1]
+    second_payload = second_request.json()
+    contents = second_payload["contents"]
+
+    assert contents[1] == {
+        "role": "model",
+        "parts": [
+            {
+                "functionCall": {
+                    "name": "get_weather",
+                    "args": {"city": "Tel Aviv"},
+                }
+            }
+        ],
+    }
+    assert contents[2] == {
+        "role": "user",
+        "parts": [
+            {
+                "functionResponse": {
+                    "name": "get_weather",
+                    "response": {
+                        "city": "Tel Aviv",
+                        "temperature": 22,
+                        "unit": "C",
+                    },
+                }
+            }
+        ],
+    }

--- a/tests/unit/adapters/test_base_adapter.py
+++ b/tests/unit/adapters/test_base_adapter.py
@@ -1,15 +1,22 @@
-from unittest.mock import patch
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
 from src.llm_api_adapter.adapters.base_adapter import LLMAdapterBase
 from src.llm_api_adapter.adapters import base_adapter as base_module
-from src.llm_api_adapter.errors.llm_api_error import LLMAPIError
+from src.llm_api_adapter.errors.llm_api_error import (
+    InvalidToolSchemaError,
+    LLMAPIError,
+    ToolChoiceError,
+)
 from src.llm_api_adapter.models.messages.chat_message import (
-    Messages, Prompt, UserMessage
+    Messages,
+    Prompt,
+    UserMessage,
 )
 from src.llm_api_adapter.models.responses.chat_response import ChatResponse
+from src.llm_api_adapter.models.tools import ToolSpec
 
 
 class DummyClient:
@@ -33,7 +40,7 @@ class _TestAdapter(LLMAdapterBase):
             return self.handle_error(e)
         except Exception as e:
             return self.handle_error(e)
-    
+
     def _normalize_reasoning_level(self, reasoning_level):
         return reasoning_level
 
@@ -49,20 +56,32 @@ def adapter():
     return adapter_instance
 
 
-@pytest.mark.parametrize("temperature,max_tokens,top_p,valid", [
-    (1.0, 256, 1.0, True),
-    (-0.1, 256, 1.0, False),
-    (2.1, 256, 1.0, False),
-    (0.0, 256, 1.0, True),
-    (1.0, 256, -0.1, False),
-    (1.0, 256, 1.1, False),
-])
+def make_tool(name="weather", schema=None, description="desc"):
+    if schema is None:
+        schema = {
+            "type": "object",
+            "properties": {
+                "city": {"type": "string"},
+            },
+        }
+    return ToolSpec(name=name, description=description, json_schema=schema)
+
+
+@pytest.mark.parametrize(
+    "temperature,max_tokens,top_p,valid",
+    [
+        (1.0, 256, 1.0, True),
+        (-0.1, 256, 1.0, False),
+        (2.1, 256, 1.0, False),
+        (0.0, 256, 1.0, True),
+        (1.0, 256, -0.1, False),
+        (1.0, 256, 1.1, False),
+    ],
+)
 @pytest.mark.unit
 def test_parameter_validation(adapter, temperature, max_tokens, top_p, valid):
     if valid:
-        temp_result = adapter._validate_parameter(
-            "temperature", temperature, 0, 2
-        )
+        temp_result = adapter._validate_parameter("temperature", temperature, 0, 2)
         top_p_result = adapter._validate_parameter("top_p", top_p, 0, 1)
         assert temp_result == temperature
         assert top_p_result == top_p
@@ -74,6 +93,7 @@ def test_parameter_validation(adapter, temperature, max_tokens, top_p, valid):
             with pytest.raises(ValueError):
                 adapter._validate_parameter("top_p", top_p, 0, 1)
 
+
 @pytest.mark.unit
 def test_chat_handles_llmapi_error(adapter):
     messages = [Prompt("system prompt"), UserMessage("hello")]
@@ -82,6 +102,7 @@ def test_chat_handles_llmapi_error(adapter):
     ), patch.object(adapter, "handle_error") as mock_handle_error:
         adapter.chat(messages)
         mock_handle_error.assert_called_once()
+
 
 @pytest.mark.unit
 def test_chat_handles_generic_exception(adapter):
@@ -92,10 +113,12 @@ def test_chat_handles_generic_exception(adapter):
         adapter.chat(messages)
         mock_handle_error.assert_called_once()
 
+
 @pytest.mark.unit
 def test_init_with_empty_api_key_raises():
     with pytest.raises(ValueError):
         _TestAdapter(company="any", api_key="", model="m1")
+
 
 @pytest.mark.unit
 def test_unverified_model_warns_and_leaves_pricing_none(monkeypatch):
@@ -103,51 +126,338 @@ def test_unverified_model_warns_and_leaves_pricing_none(monkeypatch):
         base_module,
         "LLM_REGISTRY",
         SimpleNamespace(providers={}),
-        raising=False
+        raising=False,
     )
     with pytest.warns(UserWarning):
         a = _TestAdapter(company="missing", api_key="k", model="unknown-model")
     assert a.pricing is None
 
+
 @pytest.mark.unit
 def test_pricing_copied_from_registry(monkeypatch):
     base_pricing = {"cost_per_token": 0.001}
     provider = SimpleNamespace(
-        models={"m-pro": SimpleNamespace(pricing=base_pricing)}
+        models={"m-pro": SimpleNamespace(pricing=base_pricing, is_reasoning=False)}
     )
     monkeypatch.setattr(
         base_module,
         "LLM_REGISTRY",
         SimpleNamespace(providers={"acme": provider}),
-        raising=False
+        raising=False,
     )
     adapter_instance = _TestAdapter(company="acme", api_key="k", model="m-pro")
     assert adapter_instance.pricing == base_pricing
     assert adapter_instance.pricing is not base_pricing
+
+
+@pytest.mark.unit
+def test_post_init_sets_reasoning_flag_from_registry(monkeypatch):
+    provider = SimpleNamespace(
+        models={"m-reason": SimpleNamespace(pricing=None, is_reasoning=True)}
+    )
+    monkeypatch.setattr(
+        base_module,
+        "LLM_REGISTRY",
+        SimpleNamespace(providers={"acme": provider}),
+        raising=False,
+    )
+    adapter_instance = _TestAdapter(company="acme", api_key="k", model="m-reason")
+    assert adapter_instance.is_reasoning is True
+
 
 @pytest.mark.unit
 def test_normalize_messages_accepts_list_and_messages(adapter):
     raw_messages = [UserMessage("hi")]
     normalized = adapter._normalize_messages(raw_messages)
     assert isinstance(normalized, Messages)
+
     same = adapter._normalize_messages(normalized)
     assert same is normalized
+
     with pytest.raises(TypeError):
         adapter._normalize_messages(123)
+
 
 @pytest.mark.unit
 def test_generate_chat_answer_emits_deprecation_warning(adapter):
     with pytest.warns(DeprecationWarning):
         adapter.generate_chat_answer(messages=[UserMessage("hi")])
 
+
 @pytest.mark.unit
 def test_handle_error_reraises_and_logs(adapter, caplog):
-    err = Exception("boom")
-    with pytest.raises(Exception) as excinfo:
-        adapter.handle_error(err, "some message")
-    assert isinstance(excinfo.value, Exception)
-    assert any(
-        sub in str(excinfo.value)
-        for sub in ("boom","No active exception to reraise")
+    with pytest.raises(ValueError, match="boom"):
+        try:
+            raise ValueError("boom")
+        except ValueError as err:
+            adapter.handle_error(err, "some message")
+
+    assert adapter.company in caplog.text
+    assert adapter.model in caplog.text
+    assert "some message" in caplog.text
+
+
+@pytest.mark.unit
+def test_base_abstract_chat_method_raises_not_implemented(adapter):
+    with pytest.raises(NotImplementedError):
+        LLMAdapterBase.chat(adapter)
+
+
+@pytest.mark.unit
+def test_base_abstract_normalize_reasoning_level_raises_not_implemented(adapter):
+    with pytest.raises(NotImplementedError):
+        LLMAdapterBase._normalize_reasoning_level(adapter, "low")
+
+
+# ---------------------------
+# _validate_tools
+# ---------------------------
+
+@pytest.mark.unit
+def test_validate_tools_accepts_none(adapter):
+    adapter._validate_tools(None)
+
+
+@pytest.mark.unit
+def test_validate_tools_rejects_non_list(adapter):
+    with pytest.raises(InvalidToolSchemaError, match="tools must be a list\\[ToolSpec\\] or None"):
+        adapter._validate_tools("not-a-list")
+
+
+@pytest.mark.unit
+def test_validate_tools_rejects_non_toolspec_items(adapter):
+    with pytest.raises(InvalidToolSchemaError, match="tools must contain ToolSpec items only"):
+        adapter._validate_tools([SimpleNamespace(name="x", json_schema={})])
+
+
+@pytest.mark.unit
+def test_validate_tools_rejects_empty_name(adapter):
+    tool = make_tool("ok_name")
+    object.__setattr__(tool, "name", "")
+    with pytest.raises(
+        InvalidToolSchemaError,
+        match="ToolSpec.name must be a non-empty string",
+    ):
+        adapter._validate_tools([tool])
+
+
+@pytest.mark.unit
+def test_validate_tools_rejects_non_string_name(adapter):
+    tool = make_tool("ok_name")
+    object.__setattr__(tool, "name", 123)
+    with pytest.raises(
+        InvalidToolSchemaError,
+        match="ToolSpec.name must be a non-empty string",
+    ):
+        adapter._validate_tools([tool])
+
+
+@pytest.mark.unit
+def test_validate_tools_rejects_invalid_name_format(adapter):
+    tool = make_tool("bad name")
+    with pytest.raises(InvalidToolSchemaError, match="Invalid tool name"):
+        adapter._validate_tools([tool])
+
+
+@pytest.mark.unit
+def test_validate_tools_rejects_duplicate_names(adapter):
+    tools = [make_tool("weather"), make_tool("weather")]
+    with pytest.raises(InvalidToolSchemaError, match="Duplicate tool name"):
+        adapter._validate_tools(tools)
+
+
+@pytest.mark.unit
+def test_validate_tools_rejects_non_dict_json_schema(adapter):
+    tool = make_tool("weather")
+    object.__setattr__(tool, "json_schema", "not-a-dict")
+    with pytest.raises(
+        InvalidToolSchemaError,
+        match="json_schema must be a dict",
+    ):
+        adapter._validate_tools([tool])
+
+
+@pytest.mark.unit
+def test_validate_tools_accepts_valid_tools(adapter):
+    tools = [make_tool("weather"), make_tool("search")]
+    adapter._validate_tools(tools)
+
+
+# ---------------------------
+# _normalize_tool_choice
+# ---------------------------
+
+@pytest.mark.unit
+def test_normalize_tool_choice_none_returns_none(adapter):
+    assert adapter._normalize_tool_choice(None, None) is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("value", ["auto", "none"])
+def test_normalize_tool_choice_str_auto_none(adapter, value):
+    tools = [make_tool("weather")]
+    assert adapter._normalize_tool_choice(value, tools) == value
+
+
+@pytest.mark.unit
+def test_normalize_tool_choice_str_required_raises(adapter):
+    with pytest.raises(ToolChoiceError, match="tool_choice='required' is not supported; use 'any'"):
+        adapter._normalize_tool_choice("required", [make_tool("weather")])
+
+
+@pytest.mark.unit
+def test_normalize_tool_choice_str_any_requires_tools(adapter):
+    with pytest.raises(ToolChoiceError, match="tool_choice='any' requires tools to be provided"):
+        adapter._normalize_tool_choice("any", None)
+
+
+@pytest.mark.unit
+def test_normalize_tool_choice_str_any_ok(adapter):
+    assert adapter._normalize_tool_choice("any", [make_tool("weather")]) == "any"
+
+
+@pytest.mark.unit
+def test_normalize_tool_choice_str_named_tool_ok(adapter):
+    tools = [make_tool("weather"), make_tool("search")]
+    assert adapter._normalize_tool_choice("weather", tools) == "weather"
+
+
+@pytest.mark.unit
+def test_normalize_tool_choice_str_named_tool_requires_tools(adapter):
+    with pytest.raises(ToolChoiceError, match="tool_choice references a tool but tools=None"):
+        adapter._normalize_tool_choice("weather", None)
+
+
+@pytest.mark.unit
+def test_normalize_tool_choice_str_unknown_tool_raises(adapter):
+    with pytest.raises(ToolChoiceError, match="Unknown tool_choice string"):
+        adapter._normalize_tool_choice("missing_tool", [make_tool("weather")])
+
+
+@pytest.mark.unit
+def test_normalize_tool_choice_invalid_type_raises(adapter):
+    with pytest.raises(ToolChoiceError, match="Invalid tool_choice type: int"):
+        adapter._normalize_tool_choice(123, [make_tool("weather")])
+
+
+@pytest.mark.unit
+def test_get_tool_names_returns_set(adapter):
+    tools = [make_tool("weather"), make_tool("search")]
+    assert adapter._get_tool_names(tools) == {"weather", "search"}
+    assert adapter._get_tool_names(None) == set()
+
+
+@pytest.mark.unit
+def test_normalize_tool_choice_dict_required_raises(adapter):
+    with pytest.raises(ToolChoiceError, match="tool_choice='required' is not supported; use 'any'"):
+        adapter._normalize_tool_choice({"type": "required"}, [make_tool("weather")])
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("value", ["auto", "none"])
+def test_normalize_tool_choice_dict_auto_none(adapter, value):
+    assert (
+        adapter._normalize_tool_choice({"type": value}, [make_tool("weather")]) == value
     )
-    assert adapter.company in caplog.text or adapter.model in caplog.text
+
+
+@pytest.mark.unit
+def test_normalize_tool_choice_dict_any_requires_tools(adapter):
+    with pytest.raises(ToolChoiceError, match="tool_choice.type='any' requires tools to be provided"):
+        adapter._normalize_tool_choice({"type": "any"}, None)
+
+
+@pytest.mark.unit
+def test_normalize_tool_choice_dict_any_ok(adapter):
+    assert adapter._normalize_tool_choice({"type": "any"}, [make_tool("weather")]) == "any"
+
+
+@pytest.mark.unit
+def test_normalize_tool_choice_dict_tool_with_name_ok(adapter):
+    tools = [make_tool("weather"), make_tool("search")]
+    assert (
+        adapter._normalize_tool_choice({"type": "tool", "name": "search"}, tools)
+        == "search"
+    )
+
+
+@pytest.mark.unit
+def test_normalize_tool_choice_dict_tool_requires_non_empty_name(adapter):
+    with pytest.raises(ToolChoiceError, match="tool_choice.type='tool' requires non-empty name"):
+        adapter._normalize_tool_choice({"type": "tool", "name": ""}, [make_tool("weather")])
+
+
+@pytest.mark.unit
+def test_normalize_tool_choice_dict_tool_unknown_name_raises(adapter):
+    with pytest.raises(ToolChoiceError, match="tool_choice references unknown tool"):
+        adapter._normalize_tool_choice(
+            {"type": "tool", "name": "missing"},
+            [make_tool("weather")],
+        )
+
+
+@pytest.mark.unit
+def test_normalize_tool_choice_dict_name_fallback_ok(adapter):
+    tools = [make_tool("weather"), make_tool("search")]
+    assert adapter._normalize_tool_choice({"name": "weather"}, tools) == "weather"
+
+
+@pytest.mark.unit
+def test_normalize_tool_choice_dict_invalid_dict_raises(adapter):
+    with pytest.raises(ToolChoiceError, match="Invalid tool_choice dict"):
+        adapter._normalize_tool_choice({"foo": "bar"}, [make_tool("weather")])
+
+
+# ---------------------------
+# direct helper coverage
+# ---------------------------
+
+@pytest.mark.unit
+def test_normalize_named_tool_choice_requires_name_string(adapter):
+    with pytest.raises(ToolChoiceError, match="tool_choice.type='tool' requires non-empty name"):
+        adapter._normalize_named_tool_choice(None, [make_tool("weather")], {"weather"})
+
+
+@pytest.mark.unit
+def test_normalize_named_tool_choice_requires_tools(adapter):
+    with pytest.raises(ToolChoiceError, match="tool_choice references a tool but tools=None"):
+        adapter._normalize_named_tool_choice("weather", None, {"weather"})
+
+
+@pytest.mark.unit
+def test_normalize_named_tool_choice_unknown_tool(adapter):
+    with pytest.raises(ToolChoiceError, match="tool_choice references unknown tool"):
+        adapter._normalize_named_tool_choice(
+            "search",
+            [make_tool("weather")],
+            {"weather"},
+        )
+
+
+@pytest.mark.unit
+def test_normalize_named_tool_choice_ok(adapter):
+    assert (
+        adapter._normalize_named_tool_choice(
+            "weather",
+            [make_tool("weather")],
+            {"weather"},
+        )
+        == "weather"
+    )
+
+
+@pytest.mark.unit
+def test_ensure_tools_provided_raises(adapter):
+    with pytest.raises(ToolChoiceError, match="custom detail"):
+        adapter._ensure_tools_provided(None, detail="custom detail")
+
+
+@pytest.mark.unit
+def test_ensure_tools_provided_accepts_non_empty_tools(adapter):
+    adapter._ensure_tools_provided([make_tool("weather")], detail="unused")
+
+
+@pytest.mark.unit
+def test_raise_required_tool_choice_error(adapter):
+    with pytest.raises(ToolChoiceError, match="tool_choice='required' is not supported; use 'any'"):
+        adapter._raise_required_tool_choice_error()

--- a/tests/unit/adapters/test_openai_adapter.py
+++ b/tests/unit/adapters/test_openai_adapter.py
@@ -7,22 +7,36 @@ from src.llm_api_adapter.errors.llm_api_error import LLMAPIError
 from src.llm_api_adapter.llms.openai.sync_client import OpenAISyncClient
 from src.llm_api_adapter.models.messages.chat_message import Prompt, UserMessage
 from src.llm_api_adapter.models.responses.chat_response import ChatResponse
+from src.llm_api_adapter.models.tools import ToolSpec
+
 
 @pytest.fixture
 def adapter():
     return OpenAIAdapter(
         api_key="test_api_key",
-        model="gpt-5"
+        model="gpt-5",
     )
 
-@pytest.mark.parametrize("temperature,max_tokens,top_p,valid", [
-    (1.0, 256, 1.0, True),
-    (-0.1, 256, 1.0, False),
-    (2.1, 256, 1.0, False),
-    (0.0, 256, 1.0, True),
-    (1.0, 256, -0.1, False),
-    (1.0, 256, 1.1, False),
-])
+
+@pytest.fixture
+def legacy_adapter():
+    return OpenAIAdapter(
+        api_key="test_api_key",
+        model="gpt-4o",
+    )
+
+
+@pytest.mark.parametrize(
+    "temperature,max_tokens,top_p,valid",
+    [
+        (1.0, 256, 1.0, True),
+        (-0.1, 256, 1.0, False),
+        (2.1, 256, 1.0, False),
+        (0.0, 256, 1.0, True),
+        (1.0, 256, -0.1, False),
+        (1.0, 256, 1.1, False),
+    ],
+)
 @pytest.mark.unit
 def test_parameter_validation(adapter, temperature, max_tokens, top_p, valid):
     if valid:
@@ -40,48 +54,56 @@ def test_parameter_validation(adapter, temperature, max_tokens, top_p, valid):
             with pytest.raises(ValueError):
                 adapter._validate_parameter("top_p", top_p, 0, 1)
 
+
 @pytest.mark.unit
 def test_chat_handles_llmapi_error(adapter):
     messages = [Prompt("system prompt"), UserMessage("hello")]
-    method = "chat_completion"
     with patch.object(
-        OpenAISyncClient, method, side_effect=LLMAPIError("API error")
+        OpenAISyncClient,
+        "complete",
+        side_effect=LLMAPIError("API error"),
     ), patch.object(adapter, "handle_error") as mock_handle_error:
         adapter.chat(messages)
         mock_handle_error.assert_called_once()
+
 
 @pytest.mark.unit
 def test_chat_handles_generic_exception(adapter):
     messages = [Prompt("system prompt"), UserMessage("hello")]
-    method = "chat_completion"
     with patch.object(
-        OpenAISyncClient, method, side_effect=Exception("Generic error")
+        OpenAISyncClient,
+        "complete",
+        side_effect=Exception("Generic error"),
     ), patch.object(adapter, "handle_error") as mock_handle_error:
         adapter.chat(messages)
         mock_handle_error.assert_called_once()
 
+
 @pytest.mark.unit
-def test_pricing_is_applied_when_present(adapter):
-    adapter.pricing = type("P", (), {
-        "in_per_token": 0.001, "out_per_token": 0.002, "currency": "USD"
-    })()
+def test_pricing_is_applied_when_present_for_responses_api(adapter):
+    adapter.pricing = type(
+        "P",
+        (),
+        {
+            "in_per_token": 0.001,
+            "out_per_token": 0.002,
+            "currency": "USD",
+        },
+    )()
     fake_response = {"some": "openai response"}
     fake_chat_response = ChatResponse()
-    patch_chat_completion = patch.object(
-        OpenAISyncClient, "chat_completion", return_value=fake_response
-    )
-    patch_from_openai_response = patch.object(
-        ChatResponse, "from_openai_response", return_value=fake_chat_response
-    )
-    patch_apply_pricing = patch.object(ChatResponse, "apply_pricing")
+
     with (
-        patch_chat_completion as mock_client,
-        patch_from_openai_response as mock_from,
-        patch_apply_pricing as mock_apply
+        patch.object(OpenAISyncClient, "complete", return_value=fake_response) as mock_client,
+        patch.object(
+            ChatResponse,
+            "from_openai_responses_response",
+            return_value=fake_chat_response,
+        ) as mock_from,
+        patch.object(ChatResponse, "apply_pricing") as mock_apply,
     ):
-        result = adapter.chat([
-            UserMessage("hi")
-        ], max_tokens=10)
+        result = adapter.chat([UserMessage("hi")], max_tokens=10)
+
     mock_client.assert_called_once()
     mock_from.assert_called_once_with(fake_response)
     mock_apply.assert_called_once_with(
@@ -91,6 +113,278 @@ def test_pricing_is_applied_when_present(adapter):
     )
     assert result is fake_chat_response
 
+
+@pytest.mark.unit
+def test_pricing_is_applied_when_present_for_legacy_api(legacy_adapter):
+    legacy_adapter.pricing = type(
+        "P",
+        (),
+        {
+            "in_per_token": 0.001,
+            "out_per_token": 0.002,
+            "currency": "USD",
+        },
+    )()
+    fake_response = {"some": "openai response"}
+    fake_chat_response = ChatResponse()
+
+    with (
+        patch.object(OpenAISyncClient, "complete", return_value=fake_response) as mock_client,
+        patch.object(
+            ChatResponse,
+            "from_openai_response",
+            return_value=fake_chat_response,
+        ) as mock_from,
+        patch.object(ChatResponse, "apply_pricing") as mock_apply,
+    ):
+        result = legacy_adapter.chat([UserMessage("hi")], max_tokens=10)
+
+    mock_client.assert_called_once()
+    mock_from.assert_called_once_with(fake_response)
+    mock_apply.assert_called_once_with(
+        price_input_per_token=legacy_adapter.pricing.in_per_token,
+        price_output_per_token=legacy_adapter.pricing.out_per_token,
+        currency=legacy_adapter.pricing.currency,
+    )
+    assert result is fake_chat_response
+
+
+@pytest.mark.unit
+def test_chat_responses_api_builds_expected_params(adapter):
+    fake_response = {"id": "resp_123"}
+    fake_chat_response = ChatResponse()
+
+    with (
+        patch.object(OpenAISyncClient, "complete", return_value=fake_response) as mock_complete,
+        patch.object(
+            ChatResponse,
+            "from_openai_responses_response",
+            return_value=fake_chat_response,
+        ) as mock_from,
+    ):
+        result = adapter.chat(
+            [Prompt("system prompt"), UserMessage("hello")],
+            max_tokens=42,
+            temperature=0.7,
+            top_p=0.9,
+            previous_response_id="prev_123",
+        )
+
+    assert result is fake_chat_response
+    mock_from.assert_called_once_with(fake_response)
+
+    _, kwargs = mock_complete.call_args
+    assert kwargs["model"] == "gpt-5"
+    assert kwargs["max_tokens"] == 42
+    assert kwargs["temperature"] == 0.7
+    assert kwargs["top_p"] == 0.9
+    assert kwargs["previous_response_id"] == "prev_123"
+    assert "input" in kwargs
+    assert "instructions" in kwargs
+    assert "messages" not in kwargs
+    assert "parallel_tool_calls" not in kwargs
+
+
+@pytest.mark.unit
+def test_chat_legacy_api_builds_expected_params(legacy_adapter):
+    fake_response = {"id": "chatcmpl_123"}
+    fake_chat_response = ChatResponse()
+
+    with (
+        patch.object(OpenAISyncClient, "complete", return_value=fake_response) as mock_complete,
+        patch.object(
+            ChatResponse,
+            "from_openai_response",
+            return_value=fake_chat_response,
+        ) as mock_from,
+    ):
+        result = legacy_adapter.chat(
+            [Prompt("system prompt"), UserMessage("hello")],
+            max_tokens=33,
+            temperature=0.5,
+            top_p=0.8,
+            parallel_tool_calls=True,
+        )
+
+    assert result is fake_chat_response
+    mock_from.assert_called_once_with(fake_response)
+
+    _, kwargs = mock_complete.call_args
+    assert kwargs["model"] == "gpt-4o"
+    assert kwargs["max_tokens"] == 33
+    assert kwargs["temperature"] == 0.5
+    assert kwargs["top_p"] == 0.8
+    assert kwargs["parallel_tool_calls"] is True
+    assert "messages" in kwargs
+    assert "input" not in kwargs
+    assert "instructions" not in kwargs
+    assert "previous_response_id" not in kwargs
+
+
+@pytest.mark.unit
+def test_chat_responses_api_omits_instructions_when_none(adapter):
+    fake_response = {"id": "resp_123"}
+    fake_chat_response = ChatResponse()
+
+    with (
+        patch.object(
+            adapter,
+            "_normalize_messages",
+        ) as mock_normalize_messages,
+        patch.object(OpenAISyncClient, "complete", return_value=fake_response) as mock_complete,
+        patch.object(
+            ChatResponse,
+            "from_openai_responses_response",
+            return_value=fake_chat_response,
+        ),
+    ):
+        normalized_messages = mock_normalize_messages.return_value
+        normalized_messages.to_openai_responses_input.return_value = [{"role": "user", "content": "hi"}]
+        normalized_messages.to_openai_responses_instructions.return_value = None
+
+        adapter.chat([UserMessage("hi")])
+
+    _, kwargs = mock_complete.call_args
+    assert "instructions" not in kwargs
+
+
+@pytest.mark.unit
+def test_chat_without_pricing_does_not_call_apply_pricing(adapter):
+    adapter.pricing = None
+    fake_response = {"id": "resp_123"}
+    fake_chat_response = ChatResponse()
+
+    with (
+        patch.object(OpenAISyncClient, "complete", return_value=fake_response),
+        patch.object(
+            ChatResponse,
+            "from_openai_responses_response",
+            return_value=fake_chat_response,
+        ),
+        patch.object(ChatResponse, "apply_pricing") as mock_apply,
+    ):
+        result = adapter.chat([UserMessage("hi")])
+
+    assert result is fake_chat_response
+    mock_apply.assert_not_called()
+
+
+@pytest.mark.unit
+def test_chat_calls_validate_tools_and_normalize_tool_choice(adapter):
+    fake_response = {"id": "resp_123"}
+    fake_chat_response = ChatResponse()
+    tools = [
+        ToolSpec(
+            name="get_weather",
+            description="Get weather",
+            json_schema={"type": "object", "properties": {}},
+        )
+    ]
+
+    with (
+        patch.object(adapter, "_validate_tools") as mock_validate_tools,
+        patch.object(adapter, "_normalize_tool_choice", return_value="auto") as mock_normalize_tool_choice,
+        patch.object(OpenAISyncClient, "complete", return_value=fake_response),
+        patch.object(
+            ChatResponse,
+            "from_openai_responses_response",
+            return_value=fake_chat_response,
+        ),
+    ):
+        adapter.chat(
+            [UserMessage("hi")],
+            tools=tools,
+            tool_choice="auto",
+        )
+
+    mock_validate_tools.assert_called_once_with(tools)
+    mock_normalize_tool_choice.assert_called_once_with("auto", tools)
+
+
+@pytest.mark.unit
+def test_chat_passes_responses_tools_and_tool_choice(adapter):
+    fake_response = {"id": "resp_123"}
+    fake_chat_response = ChatResponse()
+    tools = [
+        ToolSpec(
+            name="get_weather",
+            description="Get weather",
+            json_schema={"type": "object", "properties": {}},
+        )
+    ]
+
+    with (
+        patch.object(OpenAISyncClient, "complete", return_value=fake_response) as mock_complete,
+        patch.object(
+            ChatResponse,
+            "from_openai_responses_response",
+            return_value=fake_chat_response,
+        ),
+    ):
+        adapter.chat(
+            [UserMessage("hi")],
+            tools=tools,
+            tool_choice="get_weather",
+        )
+
+    _, kwargs = mock_complete.call_args
+    assert kwargs["tools"] == [
+        {
+            "type": "function",
+            "name": "get_weather",
+            "description": "Get weather",
+            "parameters": {"type": "object", "properties": {}},
+        }
+    ]
+    assert kwargs["tool_choice"] == {
+        "type": "function",
+        "name": "get_weather",
+    }
+
+
+@pytest.mark.unit
+def test_chat_passes_legacy_tools_and_tool_choice(legacy_adapter):
+    fake_response = {"id": "chatcmpl_123"}
+    fake_chat_response = ChatResponse()
+    tools = [
+        ToolSpec(
+            name="get_weather",
+            description="Get weather",
+            json_schema={"type": "object", "properties": {}},
+        )
+    ]
+
+    with (
+        patch.object(OpenAISyncClient, "complete", return_value=fake_response) as mock_complete,
+        patch.object(
+            ChatResponse,
+            "from_openai_response",
+            return_value=fake_chat_response,
+        ),
+    ):
+        legacy_adapter.chat(
+            [UserMessage("hi")],
+            tools=tools,
+            tool_choice="get_weather",
+        )
+
+    _, kwargs = mock_complete.call_args
+    assert kwargs["tools"] == [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+    assert kwargs["tool_choice"] == {
+        "type": "function",
+        "function": {"name": "get_weather"},
+    }
+
+
 @pytest.mark.unit
 def test_normalize_reasoning_level_disabled_warns_and_returns_none(adapter):
     adapter.is_reasoning = False
@@ -99,11 +393,20 @@ def test_normalize_reasoning_level_disabled_warns_and_returns_none(adapter):
     assert res is None
     assert any("does not support reasoning" in str(w.message) for w in record)
 
+
 @pytest.mark.unit
 def test_normalize_reasoning_level_enabled_none_returns_none_string(adapter):
     adapter.is_reasoning = True
     res = adapter._normalize_reasoning_level(None)
     assert res == "none"
+
+
+@pytest.mark.unit
+def test_normalize_reasoning_level_disabled_none_returns_none(adapter):
+    adapter.is_reasoning = False
+    res = adapter._normalize_reasoning_level(None)
+    assert res is None
+
 
 @pytest.mark.unit
 def test_normalize_reasoning_level_bool_raises(adapter):
@@ -111,11 +414,13 @@ def test_normalize_reasoning_level_bool_raises(adapter):
     with pytest.raises(ValueError, match="bool is not accepted"):
         adapter._normalize_reasoning_level(True)
 
+
 @pytest.mark.unit
 def test_normalize_reasoning_level_valid_string_key_returns_key(adapter):
     adapter.is_reasoning = True
     adapter.reasoning_levels = {"low": 1, "medium": 5, "high": 10}
     assert adapter._normalize_reasoning_level("medium") == "medium"
+
 
 @pytest.mark.unit
 def test_normalize_reasoning_level_invalid_string_key_raises(adapter):
@@ -124,7 +429,9 @@ def test_normalize_reasoning_level_invalid_string_key_raises(adapter):
     with pytest.raises(ValueError) as exc:
         adapter._normalize_reasoning_level("unknown")
     assert "Unknown reasoning level key" in str(exc.value)
-    assert "low" in str(exc.value) and "medium" in str(exc.value)
+    assert "low" in str(exc.value)
+    assert "medium" in str(exc.value)
+
 
 @pytest.mark.unit
 def test_normalize_reasoning_level_int_maps_to_correct_key(adapter):
@@ -133,3 +440,127 @@ def test_normalize_reasoning_level_int_maps_to_correct_key(adapter):
     assert adapter._normalize_reasoning_level(0) == "low"
     assert adapter._normalize_reasoning_level(3) == "medium"
     assert adapter._normalize_reasoning_level(100) == "high"
+
+
+@pytest.mark.unit
+def test_normalize_reasoning_level_invalid_type_raises(adapter):
+    adapter.is_reasoning = True
+    with pytest.raises(ValueError, match="expected int or str"):
+        adapter._normalize_reasoning_level(1.5)
+
+
+@pytest.mark.unit
+def test_map_tools_to_openai_returns_none_for_empty(adapter):
+    assert adapter._map_tools_to_openai(None) is None
+    assert adapter._map_tools_to_openai([]) is None
+
+
+@pytest.mark.unit
+def test_map_tools_to_openai_maps_description(adapter):
+    tools = [
+        ToolSpec(
+            name="get_weather",
+            description="Get weather",
+            json_schema={"type": "object", "properties": {"city": {"type": "string"}}},
+        )
+    ]
+
+    result = adapter._map_tools_to_openai(tools)
+
+    assert result == [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                },
+            },
+        }
+    ]
+
+
+@pytest.mark.unit
+def test_map_tools_to_openai_omits_description_when_missing(adapter):
+    tools = [
+        ToolSpec(
+            name="get_weather",
+            description=None,
+            json_schema={"type": "object", "properties": {}},
+        )
+    ]
+
+    result = adapter._map_tools_to_openai(tools)
+
+    assert result == [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+
+
+@pytest.mark.unit
+def test_map_tool_choice_to_openai(adapter):
+    assert adapter._map_tool_choice_to_openai(None) is None
+    assert adapter._map_tool_choice_to_openai("auto") == "auto"
+    assert adapter._map_tool_choice_to_openai("none") == "none"
+    assert adapter._map_tool_choice_to_openai("any") == "required"
+    assert adapter._map_tool_choice_to_openai("get_weather") == {
+        "type": "function",
+        "function": {"name": "get_weather"},
+    }
+
+
+@pytest.mark.unit
+def test_map_tools_to_openai_responses_returns_none_for_empty(adapter):
+    assert adapter._map_tools_to_openai_responses(None) is None
+    assert adapter._map_tools_to_openai_responses([]) is None
+
+
+@pytest.mark.unit
+def test_map_tools_to_openai_responses_maps_tool(adapter):
+    tools = [
+        ToolSpec(
+            name="get_weather",
+            description="Get weather",
+            json_schema={"type": "object", "properties": {"city": {"type": "string"}}},
+        )
+    ]
+
+    result = adapter._map_tools_to_openai_responses(tools)
+
+    assert result == [
+        {
+            "type": "function",
+            "name": "get_weather",
+            "description": "Get weather",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+            },
+        }
+    ]
+
+
+@pytest.mark.unit
+def test_map_tool_choice_to_openai_responses(adapter):
+    assert adapter._map_tool_choice_to_openai_responses(None) is None
+    assert adapter._map_tool_choice_to_openai_responses("auto") == "auto"
+    assert adapter._map_tool_choice_to_openai_responses("none") == "none"
+    assert adapter._map_tool_choice_to_openai_responses("any") == "required"
+    assert adapter._map_tool_choice_to_openai_responses("get_weather") == {
+        "type": "function",
+        "name": "get_weather",
+    }
+
+
+@pytest.mark.unit
+def test_map_tool_choice_to_openai_responses_passthrough_non_string(adapter):
+    tool_choice = {"type": "function", "name": "get_weather"}
+    assert adapter._map_tool_choice_to_openai_responses(tool_choice) is tool_choice

--- a/tests/unit/models/messages/test_chat_message.py
+++ b/tests/unit/models/messages/test_chat_message.py
@@ -1,9 +1,26 @@
+import json
+
 import pytest
 
-
 from src.llm_api_adapter.models.messages.chat_message import (
-    Message, Prompt, UserMessage, AIMessage, Messages
+    AIMessage,
+    Message,
+    Messages,
+    Prompt,
+    ToolMessage,
+    UserMessage,
 )
+from src.llm_api_adapter.models.tools import ToolCall
+
+
+@pytest.mark.unit
+def test_message_base_serializers():
+    m = UserMessage(content="hello")
+    assert m.to_openai() == {"role": "user", "content": "hello"}
+    assert m.to_openai_responses_input() == [{"role": "user", "content": "hello"}]
+    assert m.to_anthropic() == {"role": "user", "content": "hello"}
+    assert m.to_google() == {"role": "user", "parts": [{"text": "hello"}]}
+
 
 @pytest.mark.unit
 def test_prompt_to_anthropic_and_google_and_openai():
@@ -11,6 +28,7 @@ def test_prompt_to_anthropic_and_google_and_openai():
     assert p.to_anthropic() == "system instructions"
     assert p.to_google() == "system instructions"
     assert p.to_openai() == {"role": "system", "content": "system instructions"}
+
 
 @pytest.mark.unit
 def test_user_and_ai_to_google_and_openai():
@@ -20,6 +38,259 @@ def test_user_and_ai_to_google_and_openai():
     assert a.to_google() == {"role": "model", "parts": [{"text": "hello ai"}]}
     assert u.to_openai() == {"role": "user", "content": "hello user"}
     assert a.to_openai() == {"role": "assistant", "content": "hello ai"}
+
+
+@pytest.mark.unit
+def test_ai_message_to_openai_with_tool_calls():
+    msg = AIMessage(
+        content="calling tool",
+        tool_calls=[
+            ToolCall(name="weather", arguments={"city": "TLV"}, call_id="call_1")
+        ],
+    )
+    assert msg.to_openai() == {
+        "role": "assistant",
+        "content": "calling tool",
+        "tool_calls": [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {
+                    "name": "weather",
+                    "arguments": json.dumps({"city": "TLV"}, ensure_ascii=False),
+                },
+            }
+        ],
+    }
+
+
+@pytest.mark.unit
+def test_ai_message_to_openai_responses_input_with_content():
+    msg = AIMessage(content="assistant text")
+    assert msg.to_openai_responses_input() == [
+        {"role": "assistant", "content": "assistant text"}
+    ]
+
+
+@pytest.mark.unit
+def test_ai_message_to_openai_responses_input_without_content():
+    msg = AIMessage(content="")
+    assert msg.to_openai_responses_input() == []
+
+
+@pytest.mark.unit
+def test_ai_message_to_anthropic_without_tool_calls():
+    msg = AIMessage(content="hello")
+    assert msg.to_anthropic() == {"role": "assistant", "content": "hello"}
+
+
+@pytest.mark.unit
+def test_ai_message_to_anthropic_with_tool_calls_and_text():
+    msg = AIMessage(
+        content="before tool",
+        tool_calls=[
+            ToolCall(name="weather", arguments={"city": "TLV"}, call_id="call_1")
+        ],
+    )
+    assert msg.to_anthropic() == {
+        "role": "assistant",
+        "content": [
+            {"type": "text", "text": "before tool"},
+            {
+                "type": "tool_use",
+                "id": "call_1",
+                "name": "weather",
+                "input": {"city": "TLV"},
+            },
+        ],
+    }
+
+
+@pytest.mark.unit
+def test_ai_message_to_anthropic_with_tool_calls_and_empty_arguments():
+    msg = AIMessage(
+        content="",
+        tool_calls=[
+            ToolCall(name="weather", arguments=None, call_id="call_1")
+        ],
+    )
+    assert msg.to_anthropic() == {
+        "role": "assistant",
+        "content": [
+            {
+                "type": "tool_use",
+                "id": "call_1",
+                "name": "weather",
+                "input": {},
+            }
+        ],
+    }
+
+
+@pytest.mark.unit
+def test_ai_message_to_anthropic_requires_call_id():
+    msg = AIMessage(
+        content="x",
+        tool_calls=[ToolCall(name="weather", arguments={"city": "TLV"}, call_id="")],
+    )
+    with pytest.raises(
+        ValueError,
+        match="Anthropic tool_use requires a non-empty call_id",
+    ):
+        msg.to_anthropic()
+
+
+@pytest.mark.unit
+def test_ai_message_to_google_without_parts_falls_back_to_empty_text():
+    msg = AIMessage(content="", tool_calls=None)
+    assert msg.to_google() == {"role": "model", "parts": [{"text": ""}]}
+
+
+@pytest.mark.unit
+def test_ai_message_to_google_with_text_and_tool_calls():
+    msg = AIMessage(
+        content="before tool",
+        tool_calls=[
+            ToolCall(name="weather", arguments={"city": "TLV"}, call_id="ignored")
+        ],
+    )
+    assert msg.to_google() == {
+        "role": "model",
+        "parts": [
+            {"text": "before tool"},
+            {
+                "functionCall": {
+                    "name": "weather",
+                    "args": {"city": "TLV"},
+                }
+            },
+        ],
+    }
+
+
+@pytest.mark.unit
+def test_ai_message_to_google_with_tool_calls_and_no_args():
+    msg = AIMessage(
+        content="",
+        tool_calls=[ToolCall(name="weather", arguments=None, call_id="ignored")],
+    )
+    assert msg.to_google() == {
+        "role": "model",
+        "parts": [
+            {
+                "functionCall": {
+                    "name": "weather",
+                    "args": {},
+                }
+            }
+        ],
+    }
+
+
+@pytest.mark.unit
+def test_tool_message_to_openai():
+    msg = ToolMessage(content='{"ok": true}', tool_call_id="call_1")
+    assert msg.to_openai() == {
+        "role": "tool",
+        "tool_call_id": "call_1",
+        "content": '{"ok": true}',
+    }
+
+
+@pytest.mark.unit
+def test_tool_message_to_openai_responses_input():
+    msg = ToolMessage(content='{"ok": true}', tool_call_id="call_1")
+    assert msg.to_openai_responses_input() == [
+        {
+            "type": "function_call_output",
+            "call_id": "call_1",
+            "output": '{"ok": true}',
+        }
+    ]
+
+
+@pytest.mark.unit
+def test_tool_message_to_anthropic():
+    msg = ToolMessage(content="tool result", tool_call_id="call_1")
+    assert msg.to_anthropic() == {
+        "role": "user",
+        "content": [
+            {
+                "type": "tool_result",
+                "tool_use_id": "call_1",
+                "content": "tool result",
+            }
+        ],
+    }
+
+
+@pytest.mark.unit
+def test_tool_message_to_anthropic_requires_tool_call_id():
+    msg = ToolMessage(content="tool result", tool_call_id="")
+    with pytest.raises(
+        ValueError,
+        match="Anthropic tool_result requires tool_call_id",
+    ):
+        msg.to_anthropic()
+
+
+@pytest.mark.unit
+def test_tool_message_to_google_with_json_content():
+    msg = ToolMessage(content='{"temperature": 30}', tool_call_id="weather")
+    assert msg.to_google() == {
+        "role": "user",
+        "parts": [
+            {
+                "functionResponse": {
+                    "name": "weather",
+                    "response": {"temperature": 30},
+                }
+            }
+        ],
+    }
+
+
+@pytest.mark.unit
+def test_tool_message_to_google_with_empty_content():
+    msg = ToolMessage(content="   ", tool_call_id="weather")
+    assert msg.to_google() == {
+        "role": "user",
+        "parts": [
+            {
+                "functionResponse": {
+                    "name": "weather",
+                    "response": {},
+                }
+            }
+        ],
+    }
+
+
+@pytest.mark.unit
+def test_tool_message_to_google_with_non_json_content():
+    msg = ToolMessage(content="plain text result", tool_call_id="weather")
+    assert msg.to_google() == {
+        "role": "user",
+        "parts": [
+            {
+                "functionResponse": {
+                    "name": "weather",
+                    "response": {"content": "plain text result"},
+                }
+            }
+        ],
+    }
+
+
+@pytest.mark.unit
+def test_tool_message_to_google_requires_tool_call_id():
+    msg = ToolMessage(content="x", tool_call_id="")
+    with pytest.raises(
+        ValueError,
+        match="Google functionResponse requires tool_call_id to be set",
+    ):
+        msg.to_google()
+
 
 @pytest.mark.unit
 def test_messages_to_anthropic_with_prompt_and_messages():
@@ -32,6 +303,7 @@ def test_messages_to_anthropic_with_prompt_and_messages():
         {"role": "assistant", "content": "a1"},
     ]
 
+
 @pytest.mark.unit
 def test_messages_to_google_with_prompt_and_messages():
     items = [Prompt(content="sysg"), UserMessage(content="ug"), AIMessage(content="ag")]
@@ -43,16 +315,20 @@ def test_messages_to_google_with_prompt_and_messages():
         {"role": "model", "parts": [{"text": "ag"}]},
     ]
 
+
 @pytest.mark.unit
 def test_messages_to_anthropic_and_google_multiple_prompts_raise():
     items = [Prompt(content="p1"), Prompt(content="p2")]
     msgs = Messages(items=items)
+
     with pytest.raises(ValueError) as excinfo_an:
         msgs.to_anthropic()
     assert "Multiple system prompts are not allowed for Anthropic." in str(excinfo_an.value)
+
     with pytest.raises(ValueError) as excinfo_gg:
         msgs.to_google()
     assert "Multiple system prompts are not allowed for Google." in str(excinfo_gg.value)
+
 
 @pytest.mark.unit
 def test_messages_to_openai_returns_list_of_dicts():
@@ -64,11 +340,69 @@ def test_messages_to_openai_returns_list_of_dicts():
         {"role": "assistant", "content": "a"},
     ]
 
+
+@pytest.mark.unit
+def test_messages_to_openai_responses_input_skips_prompt_and_flattens():
+    items = [
+        Prompt(content="system"),
+        UserMessage(content="u"),
+        AIMessage(content="a"),
+        ToolMessage(content='{"ok": true}', tool_call_id="call_1"),
+    ]
+    msgs = Messages(items=items)
+    assert msgs.to_openai_responses_input() == [
+        {"role": "user", "content": "u"},
+        {"role": "assistant", "content": "a"},
+        {
+            "type": "function_call_output",
+            "call_id": "call_1",
+            "output": '{"ok": true}',
+        },
+    ]
+
+
+@pytest.mark.unit
+def test_messages_to_openai_responses_instructions_returns_prompt():
+    msgs = Messages(items=[Prompt(content="system"), UserMessage(content="hi")])
+    assert msgs.to_openai_responses_instructions() == "system"
+
+
+@pytest.mark.unit
+def test_messages_to_openai_responses_instructions_returns_none_without_prompt():
+    msgs = Messages(items=[UserMessage(content="hi")])
+    assert msgs.to_openai_responses_instructions() is None
+
+
+@pytest.mark.unit
+def test_messages_to_openai_responses_instructions_multiple_prompts_raise():
+    msgs = Messages(items=[Prompt(content="p1"), Prompt(content="p2")])
+    with pytest.raises(
+        ValueError,
+        match="Multiple system prompts are not allowed for OpenAI Responses.",
+    ):
+        msgs.to_openai_responses_instructions()
+
+
+@pytest.mark.unit
+def test_messages_post_init_accepts_message_instances():
+    items = [UserMessage(content="u"), AIMessage(content="a")]
+    msgs = Messages(items=items)
+    assert isinstance(msgs.items[0], UserMessage)
+    assert isinstance(msgs.items[1], AIMessage)
+
+
+@pytest.mark.unit
+def test_messages_post_init_unsupported_item_type_raises():
+    with pytest.raises(TypeError, match="Unsupported message type"):
+        Messages(items=[123])
+
+
 @pytest.mark.unit
 def test_messages_post_init_dict_missing_role_raises():
     with pytest.raises(ValueError) as excinfo:
         Messages(items=[{"content": "no role"}])
     assert "Missing 'role' in message data" in str(excinfo.value)
+
 
 @pytest.mark.unit
 def test_messages_post_init_dict_missing_content_raises():
@@ -76,8 +410,319 @@ def test_messages_post_init_dict_missing_content_raises():
         Messages(items=[{"role": "user"}])
     assert "Missing 'content' in message data" in str(excinfo.value)
 
+
 @pytest.mark.unit
 def test_messages_post_init_dict_unsupported_role_raises():
     with pytest.raises(ValueError) as excinfo:
         Messages(items=[{"role": "unknown", "content": "x"}])
     assert "Unsupported role: unknown" in str(excinfo.value)
+
+
+@pytest.mark.unit
+def test_messages_normalize_tool_message_from_dict():
+    msgs = Messages(
+        items=[
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": "result",
+            }
+        ]
+    )
+    assert isinstance(msgs.items[0], ToolMessage)
+    assert msgs.items[0].tool_call_id == "call_1"
+    assert msgs.items[0].content == "result"
+
+
+@pytest.mark.unit
+def test_messages_normalize_tool_message_missing_tool_call_id_raises():
+    with pytest.raises(ValueError, match="Missing 'tool_call_id' for tool message"):
+        Messages(items=[{"role": "tool", "content": "result"}])
+
+
+@pytest.mark.unit
+def test_messages_normalize_tool_message_missing_content_raises():
+    with pytest.raises(ValueError, match="Missing 'content' in message data"):
+        Messages(items=[{"role": "tool", "tool_call_id": "call_1"}])
+
+
+@pytest.mark.unit
+def test_messages_normalize_assistant_message_with_no_content_defaults_to_empty():
+    msgs = Messages(items=[{"role": "assistant"}])
+    assert isinstance(msgs.items[0], AIMessage)
+    assert msgs.items[0].content == ""
+    assert msgs.items[0].tool_calls is None
+
+
+@pytest.mark.unit
+def test_messages_normalize_assistant_message_with_normalized_tool_calls():
+    msgs = Messages(
+        items=[
+            {
+                "role": "assistant",
+                "content": "working",
+                "tool_calls": [
+                    {
+                        "name": "weather",
+                        "arguments": {"city": "TLV"},
+                        "call_id": "call_1",
+                    }
+                ],
+            }
+        ]
+    )
+    msg = msgs.items[0]
+    assert isinstance(msg, AIMessage)
+    assert msg.content == "working"
+    assert msg.tool_calls == [
+        ToolCall(name="weather", arguments={"city": "TLV"}, call_id="call_1")
+    ]
+
+
+@pytest.mark.unit
+def test_messages_normalize_assistant_message_with_normalized_tool_call_arguments_none():
+    msgs = Messages(
+        items=[
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "name": "weather",
+                        "arguments": None,
+                        "call_id": "call_1",
+                    }
+                ],
+            }
+        ]
+    )
+    msg = msgs.items[0]
+    assert msg.tool_calls == [
+        ToolCall(name="weather", arguments={}, call_id="call_1")
+    ]
+
+
+@pytest.mark.unit
+def test_messages_normalize_assistant_message_with_legacy_openai_tool_calls():
+    msgs = Messages(
+        items=[
+            {
+                "role": "assistant",
+                "content": "working",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "weather",
+                            "arguments": '{"city": "TLV"}',
+                        },
+                    }
+                ],
+            }
+        ]
+    )
+    msg = msgs.items[0]
+    assert msg.tool_calls == [
+        ToolCall(name="weather", arguments={"city": "TLV"}, call_id="call_1")
+    ]
+
+
+@pytest.mark.unit
+def test_messages_parse_assistant_tool_calls_none_returns_none():
+    msgs = Messages(items=[])
+    assert msgs._parse_assistant_tool_calls(None) is None
+
+
+@pytest.mark.unit
+def test_messages_parse_assistant_tool_calls_requires_list():
+    msgs = Messages(items=[])
+    with pytest.raises(ValueError, match="assistant.tool_calls must be a list"):
+        msgs._parse_assistant_tool_calls("bad")
+
+
+@pytest.mark.unit
+def test_messages_parse_single_tool_call_requires_dict():
+    msgs = Messages(items=[])
+    with pytest.raises(ValueError, match="assistant.tool_calls items must be dict"):
+        msgs._parse_single_tool_call("bad")
+
+
+@pytest.mark.unit
+def test_messages_parse_normalized_tool_call_requires_name():
+    msgs = Messages(items=[])
+    with pytest.raises(
+        ValueError,
+        match="assistant.tool_calls.name must be non-empty str",
+    ):
+        msgs._parse_normalized_tool_call({"name": ""})
+
+
+@pytest.mark.unit
+def test_messages_parse_normalized_tool_call_requires_arguments_dict():
+    msgs = Messages(items=[])
+    with pytest.raises(
+        ValueError,
+        match="assistant.tool_calls.arguments must be dict",
+    ):
+        msgs._parse_normalized_tool_call(
+            {"name": "weather", "arguments": "bad"}
+        )
+
+
+@pytest.mark.unit
+def test_messages_parse_legacy_openai_tool_call_requires_name():
+    msgs = Messages(items=[])
+    with pytest.raises(
+        ValueError,
+        match="assistant.tool_calls.function.name must be non-empty str",
+    ):
+        msgs._parse_legacy_openai_tool_call({"function": {"arguments": "{}"}})
+
+
+@pytest.mark.unit
+def test_messages_parse_legacy_openai_tool_arguments_from_json_string():
+    msgs = Messages(items=[])
+    assert msgs._parse_legacy_openai_tool_arguments('{"x": 1}') == {"x": 1}
+
+
+@pytest.mark.unit
+def test_messages_parse_legacy_openai_tool_arguments_from_empty_string():
+    msgs = Messages(items=[])
+    assert msgs._parse_legacy_openai_tool_arguments("   ") == {}
+
+
+@pytest.mark.unit
+def test_messages_parse_legacy_openai_tool_arguments_from_dict():
+    msgs = Messages(items=[])
+    assert msgs._parse_legacy_openai_tool_arguments({"x": 1}) == {"x": 1}
+
+
+@pytest.mark.unit
+def test_messages_parse_legacy_openai_tool_arguments_from_other_type_returns_empty_dict():
+    msgs = Messages(items=[])
+    assert msgs._parse_legacy_openai_tool_arguments(123) == {}
+
+
+@pytest.mark.unit
+def test_messages_parse_legacy_openai_tool_arguments_invalid_json_raises():
+    msgs = Messages(items=[])
+    with pytest.raises(
+        ValueError,
+        match="assistant.tool_calls.arguments JSON parse failed",
+    ):
+        msgs._parse_legacy_openai_tool_arguments("{bad json}")
+
+
+@pytest.mark.unit
+def test_messages_normalize_simple_message_rejects_none_content():
+    msgs = Messages(items=[])
+    with pytest.raises(ValueError, match="Missing 'content' in message data"):
+        msgs._normalize_simple_message({"role": "user"}, UserMessage)
+
+
+@pytest.mark.unit
+def test_messages_normalize_simple_message_rejects_empty_content():
+    msgs = Messages(items=[])
+    with pytest.raises(ValueError, match="Missing 'content' in message data"):
+        msgs._normalize_simple_message({"role": "user", "content": ""}, UserMessage)
+
+
+@pytest.mark.unit
+def test_messages_normalize_simple_message_casts_content_to_str():
+    msgs = Messages(items=[])
+    msg = msgs._normalize_simple_message({"role": "user", "content": 123}, UserMessage)
+    assert isinstance(msg, UserMessage)
+    assert msg.content == "123"
+
+
+@pytest.mark.unit
+def test_messages_to_anthropic_with_tool_message_and_ai_tool_calls():
+    items = [
+        Prompt(content="sys"),
+        UserMessage(content="u1"),
+        AIMessage(
+            content="working",
+            tool_calls=[ToolCall(name="weather", arguments={"city": "TLV"}, call_id="call_1")],
+        ),
+        ToolMessage(content='{"temperature": 30}', tool_call_id="call_1"),
+    ]
+    msgs = Messages(items=items)
+    prompt, anthropic_messages = msgs.to_anthropic()
+
+    assert prompt == "sys"
+    assert anthropic_messages == [
+        {"role": "user", "content": "u1"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "working"},
+                {
+                    "type": "tool_use",
+                    "id": "call_1",
+                    "name": "weather",
+                    "input": {"city": "TLV"},
+                },
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "call_1",
+                    "content": '{"temperature": 30}',
+                }
+            ],
+        },
+    ]
+
+
+@pytest.mark.unit
+def test_messages_to_google_with_tool_message_and_non_user_message_fallback():
+    class DummyOtherMessage(Message):
+        role: str = "custom"
+
+    other = DummyOtherMessage(content="fallback text")
+
+    items = [
+        Prompt(content="sys"),
+        UserMessage(content="u1"),
+        AIMessage(
+            content="working",
+            tool_calls=[ToolCall(name="weather", arguments={"city": "TLV"}, call_id="call_1")],
+        ),
+        ToolMessage(content='{"temperature": 30}', tool_call_id="weather"),
+        other,
+    ]
+    msgs = Messages(items=items)
+    prompt, google_messages = msgs.to_google()
+
+    assert prompt == "sys"
+    assert google_messages == [
+        {"role": "user", "parts": [{"text": "u1"}]},
+        {
+            "role": "model",
+            "parts": [
+                {"text": "working"},
+                {
+                    "functionCall": {
+                        "name": "weather",
+                        "args": {"city": "TLV"},
+                    }
+                },
+            ],
+        },
+        {
+            "role": "user",
+            "parts": [
+                {
+                    "functionResponse": {
+                        "name": "weather",
+                        "response": {"temperature": 30},
+                    }
+                }
+            ],
+        },
+        {"role": "user", "parts": [{"text": "fallback text"}]},
+    ]

--- a/tests/unit/models/responses/test_chat_response.py
+++ b/tests/unit/models/responses/test_chat_response.py
@@ -1,6 +1,12 @@
 import pytest
 
-from src.llm_api_adapter.models.responses.chat_response import ChatResponse
+from src.llm_api_adapter.errors.llm_api_error import (
+    InvalidToolArgumentsError,
+    LLMAPIError,
+)
+from src.llm_api_adapter.models.responses.chat_response import ChatResponse, Usage
+from src.llm_api_adapter.models.tools import ToolCall
+
 
 @pytest.mark.unit
 def test_from_openai_response():
@@ -8,38 +14,527 @@ def test_from_openai_response():
         "model": "gpt-4",
         "id": "response123",
         "created": 1234567890,
-        "usage": {"total_tokens": 100},
+        "usage": {
+            "prompt_tokens": 30,
+            "completion_tokens": 70,
+            "total_tokens": 100,
+        },
         "choices": [
             {
                 "message": {"content": "Hello from OpenAI!"},
-                "finish_reason": "stop"
+                "finish_reason": "stop",
             }
-        ]
+        ],
     }
     response = ChatResponse.from_openai_response(api_response)
     assert response.model == "gpt-4"
     assert response.response_id == "response123"
     assert response.timestamp == 1234567890
+    assert response.usage.input_tokens == 30
+    assert response.usage.output_tokens == 70
     assert response.usage.total_tokens == 100
     assert response.content == "Hello from OpenAI!"
+    assert response.tool_calls is None
     assert response.finish_reason == "stop"
 
+
 @pytest.mark.unit
-def test_from_anthropic_response(monkeypatch):
+def test_from_openai_response_parses_tool_calls_json_string():
+    api_response = {
+        "model": "gpt-4",
+        "id": "resp_1",
+        "created": 111,
+        "usage": {},
+        "choices": [
+            {
+                "message": {
+                    "content": "tool time",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "weather",
+                                "arguments": '{"city":"Tel Aviv"}',
+                            },
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+    }
+
+    response = ChatResponse.from_openai_response(api_response)
+    assert response.content == "tool time"
+    assert response.tool_calls == [
+        ToolCall(
+            name="weather",
+            arguments={"city": "Tel Aviv"},
+            call_id="call_1",
+        )
+    ]
+    assert response.finish_reason == "tool_calls"
+
+
+@pytest.mark.unit
+def test_from_openai_response_parses_tool_calls_dict_arguments():
+    api_response = {
+        "choices": [
+            {
+                "message": {
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "function": {
+                                "name": "weather",
+                                "arguments": {"city": "Haifa"},
+                            },
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ]
+    }
+
+    response = ChatResponse.from_openai_response(api_response)
+    assert response.tool_calls == [
+        ToolCall(name="weather", arguments={"city": "Haifa"}, call_id="call_1")
+    ]
+
+
+@pytest.mark.unit
+def test_from_openai_response_parses_tool_calls_non_str_non_dict_arguments_as_empty_dict():
+    api_response = {
+        "choices": [
+            {
+                "message": {
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "function": {
+                                "name": "weather",
+                                "arguments": 123,
+                            },
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+
+    response = ChatResponse.from_openai_response(api_response)
+    assert response.tool_calls == [
+        ToolCall(name="weather", arguments={}, call_id="call_1")
+    ]
+
+
+@pytest.mark.unit
+def test_from_openai_response_invalid_tool_arguments_raise():
+    api_response = {
+        "choices": [
+            {
+                "message": {
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "function": {
+                                "name": "weather",
+                                "arguments": "{bad json}",
+                            },
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+
+    with pytest.raises(
+        InvalidToolArgumentsError,
+        match="OpenAI tool arguments JSON parse failed",
+    ):
+        ChatResponse.from_openai_response(api_response)
+
+
+@pytest.mark.unit
+def test_from_openai_response_legacy_function_call_parses_json_string():
+    api_response = {
+        "choices": [
+            {
+                "message": {
+                    "content": "",
+                    "function_call": {
+                        "name": "weather",
+                        "arguments": '{"city":"Jerusalem"}',
+                    },
+                },
+                "finish_reason": "function_call",
+            }
+        ]
+    }
+
+    response = ChatResponse.from_openai_response(api_response)
+    assert response.tool_calls == [
+        ToolCall(
+            name="weather",
+            arguments={"city": "Jerusalem"},
+            call_id=None,
+        )
+    ]
+    assert response.finish_reason == "function_call"
+
+
+@pytest.mark.unit
+def test_from_openai_response_legacy_function_call_parses_dict_arguments():
+    api_response = {
+        "choices": [
+            {
+                "message": {
+                    "function_call": {
+                        "name": "weather",
+                        "arguments": {"city": "Eilat"},
+                    }
+                }
+            }
+        ]
+    }
+
+    response = ChatResponse.from_openai_response(api_response)
+    assert response.tool_calls == [
+        ToolCall(name="weather", arguments={"city": "Eilat"}, call_id=None)
+    ]
+
+
+@pytest.mark.unit
+def test_from_openai_response_legacy_function_call_non_str_non_dict_arguments_become_empty_dict():
+    api_response = {
+        "choices": [
+            {
+                "message": {
+                    "function_call": {
+                        "name": "weather",
+                        "arguments": 42,
+                    }
+                }
+            }
+        ]
+    }
+
+    response = ChatResponse.from_openai_response(api_response)
+    assert response.tool_calls == [
+        ToolCall(name="weather", arguments={}, call_id=None)
+    ]
+
+
+@pytest.mark.unit
+def test_from_openai_response_legacy_function_call_invalid_json_raises():
+    api_response = {
+        "choices": [
+            {
+                "message": {
+                    "function_call": {
+                        "name": "weather",
+                        "arguments": "{bad json}",
+                    }
+                }
+            }
+        ]
+    }
+
+    with pytest.raises(
+        InvalidToolArgumentsError,
+        match="OpenAI function_call arguments JSON parse failed",
+    ):
+        ChatResponse.from_openai_response(api_response)
+
+
+@pytest.mark.unit
+def test_from_openai_response_warns_on_empty_content_and_no_tool_calls():
+    api_response = {
+        "choices": [
+            {
+                "message": {"content": "   "},
+                "finish_reason": "length",
+            }
+        ]
+    }
+
+    with pytest.warns(UserWarning, match="OpenAI returned empty content"):
+        response = ChatResponse.from_openai_response(api_response)
+
+    assert response.tool_calls is None
+    assert response.content == "   "
+
+
+@pytest.mark.unit
+def test_from_openai_response_handles_missing_choices():
+    response = ChatResponse.from_openai_response({"usage": {}})
+    assert response.usage.input_tokens == 0
+    assert response.usage.output_tokens == 0
+    assert response.usage.total_tokens == 0
+    assert response.content is None
+    assert response.tool_calls is None
+    assert response.finish_reason is None
+
+
+@pytest.mark.unit
+def test_from_openai_responses_response_parses_text_and_tool_calls():
+    api_response = {
+        "model": "gpt-5",
+        "id": "resp_123",
+        "created_at": 999,
+        "status": "completed",
+        "usage": {
+            "input_tokens": 10,
+            "output_tokens": 20,
+            "total_tokens": 30,
+        },
+        "output": [
+            {
+                "type": "message",
+                "content": [
+                    {"type": "output_text", "text": "Hello"},
+                    {"type": "text", "text": "World"},
+                ],
+            },
+            {
+                "type": "function_call",
+                "id": "fc_1",
+                "call_id": "call_1",
+                "name": "weather",
+                "arguments": '{"city":"Tel Aviv"}',
+            },
+        ],
+    }
+
+    response = ChatResponse.from_openai_responses_response(api_response)
+    assert response.model == "gpt-5"
+    assert response.response_id == "resp_123"
+    assert response.timestamp == 999
+    assert response.usage.input_tokens == 10
+    assert response.usage.output_tokens == 20
+    assert response.usage.total_tokens == 30
+    assert response.content == "Hello\nWorld"
+    assert response.tool_calls == [
+        ToolCall(name="weather", arguments={"city": "Tel Aviv"}, call_id="call_1")
+    ]
+    assert response.finish_reason == "completed"
+
+
+@pytest.mark.unit
+def test_from_openai_responses_response_uses_id_when_call_id_missing():
+    api_response = {
+        "output": [
+            {
+                "type": "tool_call",
+                "id": "item_1",
+                "name": "weather",
+                "arguments": {"city": "Ashdod"},
+            }
+        ]
+    }
+
+    response = ChatResponse.from_openai_responses_response(api_response)
+    assert response.tool_calls == [
+        ToolCall(name="weather", arguments={"city": "Ashdod"}, call_id="item_1")
+    ]
+
+
+@pytest.mark.unit
+def test_from_openai_responses_response_non_list_output_becomes_empty_and_warns():
+    api_response = {
+        "output": {"not": "a list"},
+    }
+
+    with pytest.warns(
+        UserWarning,
+        match="OpenAI Responses API returned empty content and no tool calls",
+    ):
+        response = ChatResponse.from_openai_responses_response(api_response)
+
+    assert response.content is None
+    assert response.tool_calls is None
+
+
+@pytest.mark.unit
+def test_from_openai_responses_response_skips_non_dict_items():
+    api_response = {
+        "output": [
+            "bad-item",
+            123,
+            {
+                "type": "message",
+                "content": [{"type": "output_text", "text": "ok"}],
+            },
+        ]
+    }
+
+    response = ChatResponse.from_openai_responses_response(api_response)
+    assert response.content == "ok"
+    assert response.tool_calls is None
+
+
+@pytest.mark.unit
+def test_from_openai_responses_response_skips_non_list_message_content():
+    api_response = {
+        "output": [
+            {
+                "type": "message",
+                "content": "bad-content",
+            }
+        ]
+    }
+
+    with pytest.warns(
+        UserWarning,
+        match="OpenAI Responses API returned empty content and no tool calls",
+    ):
+        response = ChatResponse.from_openai_responses_response(api_response)
+
+    assert response.content is None
+
+
+@pytest.mark.unit
+def test_from_openai_responses_response_skips_non_dict_content_items():
+    api_response = {
+        "output": [
+            {
+                "type": "message",
+                "content": [
+                    "bad",
+                    {"type": "output_text", "text": "ok"},
+                ],
+            }
+        ]
+    }
+
+    response = ChatResponse.from_openai_responses_response(api_response)
+    assert response.content == "ok"
+
+
+@pytest.mark.unit
+def test_from_openai_responses_response_ignores_blank_text_chunks():
+    api_response = {
+        "output": [
+            {
+                "type": "message",
+                "content": [
+                    {"type": "output_text", "text": "   "},
+                    {"type": "text", "text": "hello"},
+                ],
+            }
+        ]
+    }
+
+    response = ChatResponse.from_openai_responses_response(api_response)
+    assert response.content == "hello"
+
+
+@pytest.mark.unit
+def test_from_openai_responses_response_tool_arguments_non_str_non_dict_become_empty_dict():
+    api_response = {
+        "output": [
+            {
+                "type": "function_call",
+                "name": "weather",
+                "arguments": 123,
+            }
+        ]
+    }
+
+    response = ChatResponse.from_openai_responses_response(api_response)
+    assert response.tool_calls == [
+        ToolCall(name="weather", arguments={}, call_id=None)
+    ]
+
+
+@pytest.mark.unit
+def test_from_openai_responses_response_invalid_tool_arguments_raise():
+    api_response = {
+        "output": [
+            {
+                "type": "function_call",
+                "name": "weather",
+                "arguments": "{bad json}",
+            }
+        ]
+    }
+
+    with pytest.raises(
+        InvalidToolArgumentsError,
+        match="OpenAI responses tool arguments JSON parse failed",
+    ):
+        ChatResponse.from_openai_responses_response(api_response)
+
+
+@pytest.mark.unit
+def test_from_anthropic_response():
     api_response = {
         "usage": {"input_tokens": 30, "output_tokens": 70},
         "model": "claude-2",
         "id": "anthropic123",
         "content": [{"type": "text", "text": "Hello from Anthropic!"}],
-        "stop_reason": "end"
+        "stop_reason": "end",
     }
-    monkeypatch.setattr("builtins.print", lambda *args, **kwargs: None)
     response = ChatResponse.from_anthropic_response(api_response)
     assert response.model == "claude-2"
     assert response.response_id == "anthropic123"
+    assert response.usage.input_tokens == 30
+    assert response.usage.output_tokens == 70
     assert response.usage.total_tokens == 100
     assert response.content == "Hello from Anthropic!"
+    assert response.tool_calls is None
     assert response.finish_reason == "end"
+
+
+@pytest.mark.unit
+def test_from_anthropic_response_parses_tool_use_blocks():
+    api_response = {
+        "usage": {"input_tokens": 5, "output_tokens": 7},
+        "model": "claude-3",
+        "id": "a1",
+        "content": [
+            {"type": "text", "text": "first text"},
+            {
+                "type": "tool_use",
+                "id": "tool_1",
+                "name": "weather",
+                "input": {"city": "TLV"},
+            },
+            {"type": "text", "text": "second text"},
+        ],
+        "stop_reason": "tool_use",
+    }
+
+    response = ChatResponse.from_anthropic_response(api_response)
+    assert response.content == "first text"
+    assert response.tool_calls == [
+        ToolCall(name="weather", arguments={"city": "TLV"}, call_id="tool_1")
+    ]
+    assert response.finish_reason == "tool_use"
+
+
+@pytest.mark.unit
+def test_from_anthropic_response_invalid_tool_input_raises():
+    api_response = {
+        "content": [
+            {
+                "type": "tool_use",
+                "id": "tool_1",
+                "name": "weather",
+                "input": "bad",
+            }
+        ]
+    }
+
+    with pytest.raises(
+        InvalidToolArgumentsError,
+        match="Anthropic tool input must be dict",
+    ):
+        ChatResponse.from_anthropic_response(api_response)
+
 
 @pytest.mark.unit
 def test_from_google_response():
@@ -47,12 +542,227 @@ def test_from_google_response():
         "candidates": [
             {
                 "content": {"parts": [{"text": "Hello from Google!"}]},
-                "finishReason": "length"
+                "finishReason": "length",
             }
         ],
-        "usageMetadata": {"totalTokenCount": 42}
+        "usageMetadata": {"totalTokenCount": 42},
     }
     response = ChatResponse.from_google_response(api_response)
     assert response.usage.total_tokens == 42
     assert response.content == "Hello from Google!"
     assert response.finish_reason == "length"
+
+
+@pytest.mark.unit
+def test_from_google_response_parses_usage_and_function_call():
+    api_response = {
+        "usageMetadata": {
+            "promptTokenCount": 10,
+            "candidatesTokenCount": 20,
+            "thoughtsTokenCount": 5,
+            "totalTokenCount": 35,
+        },
+        "candidates": [
+            {
+                "finishReason": "STOP",
+                "content": {
+                    "parts": [
+                        {"text": "Hello from Google!"},
+                        {
+                            "functionCall": {
+                                "name": "weather",
+                                "args": {"city": "Tel Aviv"},
+                            }
+                        },
+                    ]
+                },
+            }
+        ],
+    }
+
+    response = ChatResponse.from_google_response(api_response)
+    assert response.usage.input_tokens == 10
+    assert response.usage.output_tokens == 25
+    assert response.usage.total_tokens == 35
+    assert response.content == "Hello from Google!"
+    assert response.tool_calls == [
+        ToolCall(name="weather", arguments={"city": "Tel Aviv"}, call_id="weather")
+    ]
+    assert response.finish_reason == "STOP"
+
+
+@pytest.mark.unit
+def test_from_google_response_uses_function_call_alias():
+    api_response = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {
+                            "function_call": {
+                                "name": "weather",
+                                "arguments": {"city": "Beer Sheva"},
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+
+    response = ChatResponse.from_google_response(api_response)
+    assert response.tool_calls == [
+        ToolCall(
+            name="weather",
+            arguments={"city": "Beer Sheva"},
+            call_id="weather",
+        )
+    ]
+
+
+@pytest.mark.unit
+def test_from_google_response_none_args_become_empty_dict():
+    api_response = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {
+                            "functionCall": {
+                                "name": "weather",
+                                "args": None,
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+
+    response = ChatResponse.from_google_response(api_response)
+    assert response.tool_calls == [
+        ToolCall(name="weather", arguments={}, call_id="weather")
+    ]
+
+
+@pytest.mark.unit
+def test_from_google_response_malformed_parts_raises():
+    api_response = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": "not-a-list",
+                }
+            }
+        ]
+    }
+
+    with pytest.raises(LLMAPIError, match="Google API returned malformed response"):
+        ChatResponse.from_google_response(api_response)
+
+
+@pytest.mark.unit
+def test_from_google_response_skips_non_dict_parts_and_uses_first_text_only():
+    api_response = {
+        "candidates": [
+            {
+                "finishReason": 123,
+                "content": {
+                    "parts": [
+                        "bad",
+                        {"text": "first"},
+                        {"text": "second"},
+                    ]
+                },
+            }
+        ]
+    }
+
+    response = ChatResponse.from_google_response(api_response)
+    assert response.content == "first"
+    assert response.finish_reason == "123"
+
+
+@pytest.mark.unit
+def test_from_google_response_function_call_requires_non_empty_name():
+    api_response = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {
+                            "functionCall": {
+                                "name": "",
+                                "args": {},
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+
+    with pytest.raises(
+        InvalidToolArgumentsError,
+        match="Google functionCall.name must be non-empty str",
+    ):
+        ChatResponse.from_google_response(api_response)
+
+
+@pytest.mark.unit
+def test_from_google_response_function_call_requires_dict_args():
+    api_response = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {
+                            "functionCall": {
+                                "name": "weather",
+                                "args": "bad",
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+
+    with pytest.raises(
+        InvalidToolArgumentsError,
+        match="Google functionCall args must be dict",
+    ):
+        ChatResponse.from_google_response(api_response)
+
+
+@pytest.mark.unit
+def test_apply_pricing_sets_costs():
+    response = ChatResponse(
+        usage=Usage(input_tokens=100, output_tokens=50, total_tokens=150)
+    )
+
+    response.apply_pricing(
+        price_input_per_token=0.001,
+        price_output_per_token=0.002,
+        currency="USD",
+    )
+
+    assert response.currency == "USD"
+    assert response.cost_input == 0.1
+    assert response.cost_output == 0.1
+    assert response.cost_total == 0.2
+
+
+@pytest.mark.unit
+def test_apply_pricing_without_usage_does_nothing():
+    response = ChatResponse()
+    response.apply_pricing(
+        price_input_per_token=0.001,
+        price_output_per_token=0.002,
+        currency="EUR",
+    )
+
+    assert response.currency is None
+    assert response.cost_input is None
+    assert response.cost_output is None
+    assert response.cost_total is None


### PR DESCRIPTION
## v0.3.0 — Unified Tool Calling API

Adds provider-agnostic tool/function calling support.

- introduce ToolSpec and ToolCall models
- add ChatResponse.tool_calls
- implement tool calling for OpenAI, Anthropic, and Google Gemini
- add tool validation and tool_choice normalization
- support OpenAI Responses API for reasoning models (gpt-5*)
- expand tests and add README tool example