### PR TITLE
Feature/json schema strict mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,8 @@ cython_debug/
 #.idea/
 
 .devtree/
+
+# Local project docs and Claude configuration
+docs/
+CLAUDE.md
+graphify-out/

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Currently, the project supports OpenAI, Anthropic, and Google with a consistent 
 
 ### Version
 
-Current version: 0.3.2
+Current version: 0.4.0
 
 
 ## Features
@@ -27,6 +27,7 @@ Current version: 0.3.2
 - **Pricing Registry**: Model prices are stored in a unified JSON registry with per-model input/output pricing and currency support.
 - **Unified Reasoning Support**: A single `reasoning_level` parameter that works identically across all providers.
 - **Request Timeouts:** Per-request timeout control with a unified `timeout_s` parameter.
+- **Strict JSON Mode**: Pass a JSON Schema to `chat()` and get a parsed object in `ChatResponse.parsed_json` — provider normalization is handled automatically.
 
 ## Installation
 
@@ -131,6 +132,14 @@ The SDK provides a set of standardized errors for easier debugging and integrati
 - **LLMAPITimeoutError**: Raised when a request times out.
 
 - **LLMAPIUsageLimitError**: Raised when usage limits are exceeded.
+
+- **InvalidToolSchemaError**: Raised when a provided tool schema is invalid.
+
+- **InvalidToolArgumentsError**: Raised when tool arguments cannot be parsed or validated.
+
+- **ToolChoiceError**: Raised when `tool_choice` is invalid or references an unknown tool.
+
+- **JSONSchemaError**: Raised when `json_schema` is not a `dict`, is passed together with `tools`, or the model response is not valid JSON.
 
 ### Config Errors
 
@@ -244,6 +253,7 @@ The `ChatResponse` object returned by `chat` includes:
 8. **cost\_total**: Total combined cost.
 9. **content**: The generated text response.
 10. **finish\_reason**: Reason why generation stopped (e.g., `"stop"`, `"length"`).
+11. **parsed\_json**: Parsed JSON object when `json_schema` was provided, otherwise `None`.
 
 ## Timeout Support
 
@@ -469,6 +479,78 @@ if first.tool_calls:
         max_tokens=1000
     )
     print(final.content)
+```
+
+## Strict JSON Mode
+
+The SDK supports structured JSON output via a `json_schema` parameter in `chat()`. Pass any JSON Schema object — the adapter normalizes it for each provider automatically and returns the parsed result in `ChatResponse.parsed_json`.
+
+```python
+from llm_api_adapter.models.messages.chat_message import Prompt, UserMessage
+from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
+
+schema = {
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "age": {"type": "integer"},
+    },
+    "required": ["name", "age"],
+}
+
+adapter = UniversalLLMAPIAdapter(
+    organization="openai",
+    model="gpt-5",
+    api_key=openai_api_key,
+)
+
+response = adapter.chat(
+    messages=[
+        Prompt("Extract structured data from the user's message."),
+        UserMessage("My name is Alice and I'm 30 years old."),
+    ],
+    json_schema=schema,
+    max_tokens=200,
+)
+
+print(response.content)      # '{"name": "Alice", "age": 30}'
+print(response.parsed_json)  # {"name": "Alice", "age": 30}
+```
+
+### `json_schema` parameter
+
+- Accepts a `dict` containing a JSON Schema object.
+- Cannot be combined with `tools` — passing both raises `JSONSchemaError`.
+- If the model returns a response that is not valid JSON, `JSONSchemaError` is raised.
+
+### `parsed_json` field
+
+`ChatResponse.parsed_json` contains the parsed `dict` when `json_schema` was provided, or `None` otherwise.
+
+### Provider behavior
+
+| Provider | Implementation |
+|----------|----------------|
+| **OpenAI** (standard) | Native `response_format.type=json_schema` with `strict=true` |
+| **OpenAI** (Responses API / o-series) | Native `text.format.type=json_schema` with `strict=true` |
+| **Anthropic** | Native `output_config.format.type=json_schema` |
+| **Google** | `generationConfig.responseMimeType="application/json"` + `responseSchema` |
+
+The adapter automatically handles provider-specific schema constraints, so the same schema works across all providers without changes.
+
+### Error handling
+
+```python
+from llm_api_adapter.errors.llm_api_error import JSONSchemaError
+
+try:
+    response = adapter.chat(
+        messages=[UserMessage("Give me the data.")],
+        json_schema=schema,
+        max_tokens=200,
+    )
+except JSONSchemaError as e:
+    print(f"JSON schema error: {e}")
 ```
 
 ## Token Usage and Pricing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-api-adapter"
-version = "0.3.2"
+version = "0.4.0"
 description = "Lightweight, pluggable adapter for multiple LLM APIs (OpenAI, Anthropic, Google)"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/llm_api_adapter/adapters/anthropic_adapter.py
+++ b/src/llm_api_adapter/adapters/anthropic_adapter.py
@@ -33,11 +33,13 @@ class AnthropicAdapter(LLMAdapterBase):
         tool_choice: Optional[str | dict] = None,
         parallel_tool_calls: Optional[bool] = None,
         previous_response: Optional[ChatResponse] = None,
+        json_schema: Optional[dict] = None,
     ) -> ChatResponse:
         temperature = self._validate_parameter("temperature", temperature, 0, 2)
         top_p = self._validate_parameter("top_p", top_p, 0, 1)
         try:
             self._validate_tools(tools)
+            self._validate_json_schema(json_schema, tools)
             validated_tools = tools
             normalized_tool_choice = self._normalize_tool_choice(
                 tool_choice,
@@ -67,6 +69,13 @@ class AnthropicAdapter(LLMAdapterBase):
                 params["disable_parallel_tool_use"] = True
             elif parallel_tool_calls is True:
                 params["disable_parallel_tool_use"] = False
+            if json_schema is not None:
+                params["output_config"] = {
+                    "format": {
+                        "type": "json_schema",
+                        "schema": self._enforce_strict_schema(json_schema),
+                    }
+                }
             if reasoning_level:
                 normalized_reasoning_level = self._normalize_reasoning_level(
                     reasoning_level
@@ -87,6 +96,7 @@ class AnthropicAdapter(LLMAdapterBase):
             client = ClaudeSyncClient(api_key=self.api_key)
             response = client.chat_completion(**params)
             chat_response = ChatResponse.from_anthropic_response(response)
+            chat_response.parsed_json = self._parse_json_response(chat_response.content, json_schema)
             if self.pricing:
                 chat_response.apply_pricing(
                     price_input_per_token=self.pricing.in_per_token,

--- a/src/llm_api_adapter/adapters/base_adapter.py
+++ b/src/llm_api_adapter/adapters/base_adapter.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from dataclasses import dataclass, field
+import json
 import logging
 import re
 from typing import Any, Dict, List, Optional
 import warnings
 
-from ..errors.llm_api_error import InvalidToolSchemaError, ToolChoiceError
+from ..errors.llm_api_error import InvalidToolSchemaError, JSONSchemaError, ToolChoiceError
 from ..llm_registry.llm_registry import Pricing, LLM_REGISTRY
 from ..models.messages.chat_message import Messages
 from ..models.responses.chat_response import ChatResponse
@@ -224,6 +225,44 @@ class LLMAdapterBase(ABC):
         raise ToolChoiceError(
             detail="tool_choice='required' is not supported; use 'any'"
         )
+
+    def _enforce_strict_schema(self, schema: dict) -> dict:
+        """Recursively add additionalProperties: false to all object types — required by OpenAI and Anthropic strict mode."""
+        schema = dict(schema)
+        if schema.get("type") == "object":
+            schema["additionalProperties"] = False
+            if "properties" in schema:
+                schema["properties"] = {
+                    k: self._enforce_strict_schema(v) if isinstance(v, dict) else v
+                    for k, v in schema["properties"].items()
+                }
+        if "items" in schema and isinstance(schema["items"], dict):
+            schema["items"] = self._enforce_strict_schema(schema["items"])
+        return schema
+
+    def _validate_json_schema(
+        self,
+        json_schema: Optional[dict],
+        tools: Optional[List[ToolSpec]] = None,
+    ) -> None:
+        if json_schema is None:
+            return
+        if not isinstance(json_schema, dict):
+            raise JSONSchemaError(detail="json_schema must be a dict")
+        if tools is not None:
+            raise JSONSchemaError(detail="json_schema and tools cannot be used together")
+
+    def _parse_json_response(
+        self,
+        content: Optional[str],
+        json_schema: Optional[dict],
+    ) -> Optional[dict]:
+        if json_schema is None or content is None:
+            return None
+        try:
+            return json.loads(content)
+        except json.JSONDecodeError as e:
+            raise JSONSchemaError(detail=f"Model response is not valid JSON: {e}")
 
     def handle_error(self, error: Exception, error_message: Optional[str] = None):
         err_msg = (

--- a/src/llm_api_adapter/adapters/google_adapter.py
+++ b/src/llm_api_adapter/adapters/google_adapter.py
@@ -116,9 +116,12 @@ class GoogleAdapter(LLMAdapterBase):
             error_message = getattr(e, "text", None) or str(e)
             self.handle_error(error=e, error_message=error_message)
 
+    # Fields not supported by Google's responseSchema subset of JSON Schema.
+    _GOOGLE_SCHEMA_UNSUPPORTED = frozenset({"additionalProperties", "$schema", "$id", "$ref"})
+
     def _to_google_schema(self, schema: dict) -> dict:
-        """Convert standard JSON Schema to Google's format (type values must be uppercase)."""
-        schema = dict(schema)
+        """Convert standard JSON Schema to Google's format (type uppercase, unsupported fields stripped)."""
+        schema = {k: v for k, v in schema.items() if k not in self._GOOGLE_SCHEMA_UNSUPPORTED}
         if "type" in schema and isinstance(schema["type"], str):
             schema["type"] = schema["type"].upper()
         if "properties" in schema:

--- a/src/llm_api_adapter/adapters/google_adapter.py
+++ b/src/llm_api_adapter/adapters/google_adapter.py
@@ -32,6 +32,7 @@ class GoogleAdapter(LLMAdapterBase):
         tool_choice: Optional[str | dict] = None,
         parallel_tool_calls: Optional[bool] = None,
         previous_response: Optional[ChatResponse] = None,
+        json_schema: Optional[dict] = None,
     ) -> ChatResponse:
         temperature = self._validate_parameter(
             name="temperature",
@@ -47,6 +48,7 @@ class GoogleAdapter(LLMAdapterBase):
         )
         try:
             self._validate_tools(tools)
+            self._validate_json_schema(json_schema, tools)
             validated_tools = tools
             normalized_tool_choice = self._normalize_tool_choice(
                 tool_choice,
@@ -60,6 +62,9 @@ class GoogleAdapter(LLMAdapterBase):
                 "temperature": temperature,
                 "topP": top_p,
             }
+            if json_schema is not None:
+                generation_config["responseMimeType"] = "application/json"
+                generation_config["responseSchema"] = self._to_google_schema(json_schema)
             if reasoning_level:
                 normalized_reasoning_level = self._normalize_reasoning_level(
                     reasoning_level
@@ -97,6 +102,7 @@ class GoogleAdapter(LLMAdapterBase):
                 **payload,
             )
             chat_response = ChatResponse.from_google_response(response_json)
+            chat_response.parsed_json = self._parse_json_response(chat_response.content, json_schema)
             if self.pricing:
                 chat_response.apply_pricing(
                     price_input_per_token=self.pricing.in_per_token,
@@ -109,6 +115,20 @@ class GoogleAdapter(LLMAdapterBase):
         except Exception as e:
             error_message = getattr(e, "text", None) or str(e)
             self.handle_error(error=e, error_message=error_message)
+
+    def _to_google_schema(self, schema: dict) -> dict:
+        """Convert standard JSON Schema to Google's format (type values must be uppercase)."""
+        schema = dict(schema)
+        if "type" in schema and isinstance(schema["type"], str):
+            schema["type"] = schema["type"].upper()
+        if "properties" in schema:
+            schema["properties"] = {
+                k: self._to_google_schema(v) if isinstance(v, dict) else v
+                for k, v in schema["properties"].items()
+            }
+        if "items" in schema and isinstance(schema["items"], dict):
+            schema["items"] = self._to_google_schema(schema["items"])
+        return schema
 
     def _to_google_function_declaration(self, tool: ToolSpec) -> Dict[str, Any]:
         declaration: Dict[str, Any] = {

--- a/src/llm_api_adapter/adapters/openai_adapter.py
+++ b/src/llm_api_adapter/adapters/openai_adapter.py
@@ -31,6 +31,7 @@ class OpenAIAdapter(LLMAdapterBase):
         tool_choice: Any = None,
         parallel_tool_calls: Optional[bool] = None,
         previous_response: Optional[ChatResponse] = None,
+        json_schema: Optional[dict] = None,
     ) -> ChatResponse:
         temperature = self._validate_parameter(
             name="temperature",
@@ -45,6 +46,7 @@ class OpenAIAdapter(LLMAdapterBase):
             max_value=1,
         )
         self._validate_tools(tools)
+        self._validate_json_schema(json_schema, tools)
         normalized_tool_choice = self._normalize_tool_choice(tool_choice, tools)
 
         try:
@@ -90,9 +92,27 @@ class OpenAIAdapter(LLMAdapterBase):
                     params["instructions"] = instructions
                 if previous_response_id is not None:
                     params["previous_response_id"] = previous_response_id
+                if json_schema is not None:
+                    params["text"] = {
+                        "format": {
+                            "type": "json_schema",
+                            "name": "response",
+                            "strict": True,
+                            "schema": self._enforce_strict_schema(json_schema),
+                        }
+                    }
             else:
                 params["messages"] = transformed_messages
                 params["parallel_tool_calls"] = parallel_tool_calls
+                if json_schema is not None:
+                    params["response_format"] = {
+                        "type": "json_schema",
+                        "json_schema": {
+                            "name": "response",
+                            "strict": True,
+                            "schema": self._enforce_strict_schema(json_schema),
+                        },
+                    }
 
             params = {k: v for k, v in params.items() if v is not None}
             response = client.complete(timeout=timeout_s, **params)
@@ -101,6 +121,8 @@ class OpenAIAdapter(LLMAdapterBase):
                 chat_response = ChatResponse.from_openai_responses_response(response)
             else:
                 chat_response = ChatResponse.from_openai_response(response)
+
+            chat_response.parsed_json = self._parse_json_response(chat_response.content, json_schema)
 
             if self.pricing:
                 chat_response.apply_pricing(

--- a/src/llm_api_adapter/errors/llm_api_error.py
+++ b/src/llm_api_adapter/errors/llm_api_error.py
@@ -98,3 +98,9 @@ class InvalidToolArgumentsError(LLMAPIClientError):
 class ToolChoiceError(LLMAPIClientError):
     """Raised when tool_choice is invalid or references unknown tool."""
     message: str = "Invalid tool_choice configuration."
+
+
+@dataclass
+class JSONSchemaError(LLMAPIClientError):
+    """Raised when json_schema usage is invalid or the model response fails schema validation."""
+    message: str = "JSON schema error."

--- a/src/llm_api_adapter/llms/anthropic/sync_client.py
+++ b/src/llm_api_adapter/llms/anthropic/sync_client.py
@@ -42,7 +42,8 @@ class ClaudeSyncClient:
             kwargs.pop("top_p", None)
             if effort:
                 kwargs["thinking"] = {"type": "adaptive"}
-                kwargs["output_config"] = {"effort": effort}
+                existing = kwargs.get("output_config", {})
+                kwargs["output_config"] = {**existing, "effort": effort}
         else:
             if model.startswith(
                 ("claude-sonnet-4-5", "claude-opus-4-1", "claude-haiku-4-5", "claude-opus-4-5")

--- a/src/llm_api_adapter/models/responses/chat_response.py
+++ b/src/llm_api_adapter/models/responses/chat_response.py
@@ -27,6 +27,7 @@ class ChatResponse:
     content: Optional[str] = None
     tool_calls: Optional[List[ToolCall]] = None
     finish_reason: Optional[str] = None
+    parsed_json: Optional[dict] = None
 
     @classmethod
     def from_openai_response(cls, api_response: dict) -> "ChatResponse":

--- a/tests/e2e/test_json_schema.py
+++ b/tests/e2e/test_json_schema.py
@@ -13,7 +13,6 @@ SIMPLE_SCHEMA = {
         "age": {"type": "integer"},
     },
     "required": ["name", "age"],
-    "additionalProperties": False,
 }
 
 

--- a/tests/e2e/test_json_schema.py
+++ b/tests/e2e/test_json_schema.py
@@ -1,0 +1,56 @@
+import time
+
+import pytest
+
+from llm_api_adapter.errors.llm_api_error import JSONSchemaError
+from llm_api_adapter.models.messages.chat_message import UserMessage
+from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
+
+SIMPLE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "age": {"type": "integer"},
+    },
+    "required": ["name", "age"],
+    "additionalProperties": False,
+}
+
+
+@pytest.mark.e2e
+def test_json_schema_returns_parsed_json_for_all_providers(providers, subtests):
+    for p in providers:
+        for model in p["models"]:
+            with subtests.test(provider=p["name"], model=model):
+                time.sleep(3)
+
+                adapter = UniversalLLMAPIAdapter(
+                    organization=p["name"],
+                    model=model,
+                    api_key=p["api_key"],
+                )
+
+                try:
+                    resp = adapter.chat(
+                        messages=[
+                            UserMessage(
+                                'Return a JSON object with fields "name" (string) '
+                                'and "age" (integer). Use name="Alice" and age=30.'
+                            )
+                        ],
+                        max_tokens=500,
+                        json_schema=SIMPLE_SCHEMA,
+                        timeout_s=60,
+                    )
+                except JSONSchemaError as e:
+                    pytest.skip(f"Model returned non-JSON despite json_schema mode: {e}")
+
+                if resp.content is None:
+                    pytest.skip("Model returned no content — likely exhausted token budget in reasoning")
+
+                assert resp.parsed_json is not None
+                assert isinstance(resp.parsed_json, dict)
+                assert "name" in resp.parsed_json
+                assert "age" in resp.parsed_json
+                assert isinstance(resp.parsed_json["name"], str)
+                assert isinstance(resp.parsed_json["age"], int)

--- a/tests/integration/test_json_schema.py
+++ b/tests/integration/test_json_schema.py
@@ -14,7 +14,6 @@ SCHEMA = {
         "age": {"type": "integer"},
     },
     "required": ["name", "age"],
-    "additionalProperties": False,
 }
 
 

--- a/tests/integration/test_json_schema.py
+++ b/tests/integration/test_json_schema.py
@@ -1,0 +1,195 @@
+import pytest
+import requests_mock as requests_mock_module
+
+from src.llm_api_adapter.models.messages.chat_message import UserMessage
+from src.llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
+
+
+JSON_CONTENT = '{"name": "Alice", "age": 30}'
+
+SCHEMA = {
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "age": {"type": "integer"},
+    },
+    "required": ["name", "age"],
+    "additionalProperties": False,
+}
+
+
+@pytest.fixture
+def openai_responses_json_mock():
+    with requests_mock_module.Mocker() as mock:
+        mock.post(
+            "https://api.openai.com/v1/responses",
+            json={
+                "id": "resp_json_1",
+                "model": "gpt-5",
+                "status": "completed",
+                "output": [
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": JSON_CONTENT}],
+                    }
+                ],
+                "usage": {"input_tokens": 10, "output_tokens": 8, "total_tokens": 18},
+            },
+        )
+        yield mock
+
+
+@pytest.fixture
+def openai_legacy_json_mock():
+    with requests_mock_module.Mocker() as mock:
+        mock.post(
+            "https://api.openai.com/v1/chat/completions",
+            json={
+                "id": "chatcmpl_json_1",
+                "model": "gpt-4o",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": JSON_CONTENT},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 8, "total_tokens": 18},
+            },
+        )
+        yield mock
+
+
+@pytest.fixture
+def anthropic_json_mock():
+    with requests_mock_module.Mocker() as mock:
+        mock.post(
+            "https://api.anthropic.com/v1/messages",
+            json={
+                "model": "claude-sonnet-4-5",
+                "id": "msg_json_1",
+                "usage": {"input_tokens": 10, "output_tokens": 8},
+                "content": [{"type": "text", "text": JSON_CONTENT}],
+                "stop_reason": "end_turn",
+            },
+        )
+        yield mock
+
+
+@pytest.fixture
+def google_json_mock():
+    with requests_mock_module.Mocker() as mock:
+        mock.post(
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent",
+            json={
+                "candidates": [
+                    {
+                        "content": {"parts": [{"text": JSON_CONTENT}]},
+                        "finishReason": "STOP",
+                    }
+                ],
+                "usageMetadata": {"totalTokenCount": 18},
+            },
+        )
+        yield mock
+
+
+# ---------------------------
+# OpenAI Responses API (gpt-5)
+# ---------------------------
+
+@pytest.mark.integration
+def test_openai_responses_api_sends_json_schema_in_text_param(openai_responses_json_mock):
+    adapter = UniversalLLMAPIAdapter(
+        organization="openai", model="gpt-5", api_key="dummy_key"
+    )
+
+    resp = adapter.chat(messages=[UserMessage("hi")], json_schema=SCHEMA)
+
+    payload = openai_responses_json_mock.request_history[0].json()
+    assert "text" in payload
+    fmt = payload["text"]["format"]
+    assert fmt["type"] == "json_schema"
+    assert fmt["name"] == "response"
+    assert fmt["strict"] is True
+    assert fmt["schema"]["type"] == "object"
+    assert fmt["schema"]["additionalProperties"] is False
+
+    assert resp.content == JSON_CONTENT
+    assert resp.parsed_json == {"name": "Alice", "age": 30}
+
+
+# ---------------------------
+# OpenAI Legacy API (gpt-4o)
+# ---------------------------
+
+@pytest.mark.integration
+def test_openai_legacy_api_sends_json_schema_in_response_format(openai_legacy_json_mock):
+    adapter = UniversalLLMAPIAdapter(
+        organization="openai", model="gpt-4o", api_key="dummy_key"
+    )
+
+    resp = adapter.chat(messages=[UserMessage("hi")], json_schema=SCHEMA)
+
+    payload = openai_legacy_json_mock.request_history[0].json()
+    assert "response_format" in payload
+    rf = payload["response_format"]
+    assert rf["type"] == "json_schema"
+    assert rf["json_schema"]["name"] == "response"
+    assert rf["json_schema"]["strict"] is True
+    assert rf["json_schema"]["schema"]["type"] == "object"
+    assert rf["json_schema"]["schema"]["additionalProperties"] is False
+
+    assert resp.content == JSON_CONTENT
+    assert resp.parsed_json == {"name": "Alice", "age": 30}
+
+
+# ---------------------------
+# Anthropic
+# ---------------------------
+
+@pytest.mark.integration
+def test_anthropic_sends_output_config_for_json_schema(anthropic_json_mock):
+    adapter = UniversalLLMAPIAdapter(
+        organization="anthropic", model="claude-sonnet-4-5", api_key="dummy_key"
+    )
+
+    resp = adapter.chat(
+        messages=[UserMessage("hi")], max_tokens=256, json_schema=SCHEMA
+    )
+
+    payload = anthropic_json_mock.request_history[0].json()
+    assert "output_config" in payload
+    fmt = payload["output_config"]["format"]
+    assert fmt["type"] == "json_schema"
+    assert fmt["schema"]["type"] == "object"
+    assert fmt["schema"]["additionalProperties"] is False
+
+    assert resp.content == JSON_CONTENT
+    assert resp.parsed_json == {"name": "Alice", "age": 30}
+
+
+# ---------------------------
+# Google
+# ---------------------------
+
+@pytest.mark.integration
+def test_google_sends_response_mime_type_and_schema(google_json_mock):
+    adapter = UniversalLLMAPIAdapter(
+        organization="google", model="gemini-2.5-pro", api_key="dummy_key"
+    )
+
+    resp = adapter.chat(messages=[UserMessage("hi")], json_schema=SCHEMA)
+
+    payload = google_json_mock.request_history[0].json()
+    gen_cfg = payload["generationConfig"]
+    assert gen_cfg["responseMimeType"] == "application/json"
+    assert "responseSchema" in gen_cfg
+    assert gen_cfg["responseSchema"]["type"] == "OBJECT"
+    assert "name" in gen_cfg["responseSchema"]["properties"]
+    assert "age" in gen_cfg["responseSchema"]["properties"]
+    assert "additionalProperties" not in gen_cfg["responseSchema"]
+
+    assert resp.content == JSON_CONTENT
+    assert resp.parsed_json == {"name": "Alice", "age": 30}

--- a/tests/unit/adapters/test_anthropic_adapter.py
+++ b/tests/unit/adapters/test_anthropic_adapter.py
@@ -121,3 +121,41 @@ def test_validate_reasoning_and_tokens_raises_llmconfigerror(adapter):
             reasoning_level="high",
             normalized_reasoning_level=2048
         )
+
+
+# ---------------------------
+# json_schema
+# ---------------------------
+
+@pytest.mark.unit
+def test_chat_passes_output_config_when_json_schema_provided(adapter):
+    schema = {"type": "object", "properties": {"name": {"type": "string"}}}
+    fake_response = {"some": "anthropic response"}
+    fake_chat_response = ChatResponse(content='{"name": "test"}')
+
+    with (
+        patch.object(ClaudeSyncClient, "chat_completion", return_value=fake_response) as mock_chat,
+        patch.object(ChatResponse, "from_anthropic_response", return_value=fake_chat_response),
+    ):
+        result = adapter.chat([UserMessage("hi")], max_tokens=100, json_schema=schema)
+
+    kwargs = mock_chat.call_args.kwargs
+    assert "output_config" in kwargs
+    assert kwargs["output_config"]["format"]["type"] == "json_schema"
+    assert "schema" in kwargs["output_config"]["format"]
+    assert result.parsed_json == {"name": "test"}
+
+
+@pytest.mark.unit
+def test_chat_omits_output_config_when_json_schema_is_none(adapter):
+    fake_response = {"some": "anthropic response"}
+    fake_chat_response = ChatResponse(content="plain text")
+
+    with (
+        patch.object(ClaudeSyncClient, "chat_completion", return_value=fake_response) as mock_chat,
+        patch.object(ChatResponse, "from_anthropic_response", return_value=fake_chat_response),
+    ):
+        adapter.chat([UserMessage("hi")], max_tokens=100)
+
+    kwargs = mock_chat.call_args.kwargs
+    assert "output_config" not in kwargs

--- a/tests/unit/adapters/test_base_adapter.py
+++ b/tests/unit/adapters/test_base_adapter.py
@@ -7,6 +7,7 @@ from src.llm_api_adapter.adapters.base_adapter import LLMAdapterBase
 from src.llm_api_adapter.adapters import base_adapter as base_module
 from src.llm_api_adapter.errors.llm_api_error import (
     InvalidToolSchemaError,
+    JSONSchemaError,
     LLMAPIError,
     ToolChoiceError,
 )
@@ -461,3 +462,61 @@ def test_ensure_tools_provided_accepts_non_empty_tools(adapter):
 def test_raise_required_tool_choice_error(adapter):
     with pytest.raises(ToolChoiceError, match="tool_choice='required' is not supported; use 'any'"):
         adapter._raise_required_tool_choice_error()
+
+
+# ---------------------------
+# _validate_json_schema
+# ---------------------------
+
+@pytest.mark.unit
+def test_validate_json_schema_accepts_none(adapter):
+    adapter._validate_json_schema(None)
+
+
+@pytest.mark.unit
+def test_validate_json_schema_accepts_valid_dict(adapter):
+    adapter._validate_json_schema({"type": "object", "properties": {"name": {"type": "string"}}})
+
+
+@pytest.mark.unit
+def test_validate_json_schema_rejects_non_dict(adapter):
+    with pytest.raises(JSONSchemaError, match="json_schema must be a dict"):
+        adapter._validate_json_schema("string")
+
+
+@pytest.mark.unit
+def test_validate_json_schema_rejects_dict_combined_with_tools(adapter):
+    tools = [make_tool("weather")]
+    with pytest.raises(JSONSchemaError, match="json_schema and tools cannot be used together"):
+        adapter._validate_json_schema({"type": "object"}, tools)
+
+
+@pytest.mark.unit
+def test_validate_json_schema_accepts_dict_when_tools_none(adapter):
+    adapter._validate_json_schema({"type": "object"}, None)
+
+
+# ---------------------------
+# _parse_json_response
+# ---------------------------
+
+@pytest.mark.unit
+def test_parse_json_response_returns_none_when_schema_none(adapter):
+    assert adapter._parse_json_response('{"name": "test"}', None) is None
+
+
+@pytest.mark.unit
+def test_parse_json_response_returns_none_when_content_none(adapter):
+    assert adapter._parse_json_response(None, {"type": "object"}) is None
+
+
+@pytest.mark.unit
+def test_parse_json_response_returns_parsed_dict(adapter):
+    result = adapter._parse_json_response('{"name": "test"}', {"type": "object"})
+    assert result == {"name": "test"}
+
+
+@pytest.mark.unit
+def test_parse_json_response_raises_on_invalid_json(adapter):
+    with pytest.raises(JSONSchemaError, match="Model response is not valid JSON"):
+        adapter._parse_json_response("not json", {"type": "object"})

--- a/tests/unit/adapters/test_google_adapter.py
+++ b/tests/unit/adapters/test_google_adapter.py
@@ -146,3 +146,58 @@ def test_normalize_reasoning_level_warns_if_model_not_supporting(adapter):
     with pytest.warns(UserWarning):
         result = adapter._normalize_reasoning_level("medium")
     assert result is None
+
+
+# ---------------------------
+# json_schema
+# ---------------------------
+
+@pytest.mark.unit
+def test_chat_passes_json_schema_in_generation_config(adapter):
+    schema = {"type": "object", "properties": {"name": {"type": "string"}}}
+    fake_response = {"some": "google response"}
+    fake_chat_response = ChatResponse(content='{"name": "test"}')
+
+    with (
+        patch.object(GeminiSyncClient, "chat_completion", return_value=fake_response) as mock_client,
+        patch.object(ChatResponse, "from_google_response", return_value=fake_chat_response),
+    ):
+        result = adapter.chat([UserMessage("hi")], json_schema=schema)
+
+    kwargs = mock_client.call_args[1]
+    gen_cfg = kwargs["generationConfig"]
+    assert gen_cfg["responseMimeType"] == "application/json"
+    assert "responseSchema" in gen_cfg
+    assert result.parsed_json == {"name": "test"}
+
+
+@pytest.mark.unit
+def test_to_google_schema_strips_unsupported_fields(adapter):
+    schema = {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+        "additionalProperties": False,
+        "$schema": "http://json-schema.org/draft-07/schema#",
+    }
+    result = adapter._to_google_schema(schema)
+    assert "additionalProperties" not in result
+    assert "$schema" not in result
+    assert result["type"] == "OBJECT"
+    assert result["properties"]["name"]["type"] == "STRING"
+
+
+@pytest.mark.unit
+def test_chat_omits_json_schema_fields_when_not_provided(adapter):
+    fake_response = {"some": "google response"}
+    fake_chat_response = ChatResponse(content="plain text")
+
+    with (
+        patch.object(GeminiSyncClient, "chat_completion", return_value=fake_response) as mock_client,
+        patch.object(ChatResponse, "from_google_response", return_value=fake_chat_response),
+    ):
+        adapter.chat([UserMessage("hi")])
+
+    kwargs = mock_client.call_args[1]
+    gen_cfg = kwargs["generationConfig"]
+    assert "responseMimeType" not in gen_cfg
+    assert "responseSchema" not in gen_cfg

--- a/tests/unit/adapters/test_openai_adapter.py
+++ b/tests/unit/adapters/test_openai_adapter.py
@@ -565,3 +565,57 @@ def test_map_tool_choice_to_openai_responses(adapter):
 def test_map_tool_choice_to_openai_responses_passthrough_non_string(adapter):
     tool_choice = {"type": "function", "name": "get_weather"}
     assert adapter._map_tool_choice_to_openai_responses(tool_choice) is tool_choice
+
+
+# ---------------------------
+# json_schema
+# ---------------------------
+
+@pytest.mark.unit
+def test_chat_responses_api_passes_json_schema_in_text_param(adapter):
+    schema = {"type": "object", "properties": {"name": {"type": "string"}}}
+    fake_response = {"id": "resp_123"}
+    fake_chat_response = ChatResponse(content='{"name": "test"}')
+
+    with (
+        patch.object(OpenAISyncClient, "complete", return_value=fake_response) as mock_complete,
+        patch.object(
+            ChatResponse,
+            "from_openai_responses_response",
+            return_value=fake_chat_response,
+        ),
+    ):
+        result = adapter.chat([UserMessage("hi")], json_schema=schema)
+
+    _, kwargs = mock_complete.call_args
+    assert "text" in kwargs
+    fmt = kwargs["text"]["format"]
+    assert fmt["type"] == "json_schema"
+    assert fmt["strict"] is True
+    assert "schema" in fmt
+    assert result.parsed_json == {"name": "test"}
+
+
+@pytest.mark.unit
+def test_chat_legacy_api_passes_json_schema_in_response_format(legacy_adapter):
+    schema = {"type": "object", "properties": {"name": {"type": "string"}}}
+    fake_response = {"id": "chatcmpl_123"}
+    fake_chat_response = ChatResponse(content='{"name": "test"}')
+
+    with (
+        patch.object(OpenAISyncClient, "complete", return_value=fake_response) as mock_complete,
+        patch.object(
+            ChatResponse,
+            "from_openai_response",
+            return_value=fake_chat_response,
+        ),
+    ):
+        result = legacy_adapter.chat([UserMessage("hi")], json_schema=schema)
+
+    _, kwargs = mock_complete.call_args
+    assert "response_format" in kwargs
+    rf = kwargs["response_format"]
+    assert rf["type"] == "json_schema"
+    assert rf["json_schema"]["strict"] is True
+    assert "schema" in rf["json_schema"]
+    assert result.parsed_json == {"name": "test"}

--- a/tests/unit/models/responses/test_chat_response.py
+++ b/tests/unit/models/responses/test_chat_response.py
@@ -754,6 +754,26 @@ def test_apply_pricing_sets_costs():
 
 
 @pytest.mark.unit
+def test_parsed_json_defaults_to_none():
+    response = ChatResponse()
+    assert response.parsed_json is None
+
+
+@pytest.mark.unit
+def test_parsed_json_can_be_set_on_construction():
+    data = {"name": "test", "age": 30}
+    response = ChatResponse(parsed_json=data)
+    assert response.parsed_json == data
+
+
+@pytest.mark.unit
+def test_parsed_json_can_be_assigned_after_construction():
+    response = ChatResponse()
+    response.parsed_json = {"key": "value"}
+    assert response.parsed_json == {"key": "value"}
+
+
+@pytest.mark.unit
 def test_apply_pricing_without_usage_does_nothing():
     response = ChatResponse()
     response.apply_pricing(


### PR DESCRIPTION
- Added `json_schema` parameter to `chat()` across all providers (OpenAI, Anthropic, Google)
- `additionalProperties: false` is injected automatically — users don't need to specify it
- Parsed response available in `ChatResponse.parsed_json`
- Added `JSONSchemaError` for invalid schema or non-JSON model response
- Updated README and bumped version to 0.4.0
## Provider behavior
| Provider | Implementation |
|----------|----------------|
| OpenAI (standard) | `response_format.type=json_schema`, `strict=true` |
| OpenAI (Responses API / o-series) | `text.format.type=json_schema`, `strict=true` |
| Anthropic | `output_config.format.type=json_schema` |
| Google | `responseMimeType=application/json` + `responseSchema` (unsupported fields stripped) |
## Test plan
- [ ] Unit tests: `pytest -m unit`
- [ ] Integration tests: `pytest -m integration`
- [ ] E2E: `pytest tests/e2e/test_json_schema.py` — verify all three providers