### PR TITLE
v0.4.1 — Pydantic Integration + GPT-5.6 models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,5 @@ cython_debug/
 docs/
 CLAUDE.md
 graphify-out/
+.claude/settings.json
+.mcp.json

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Currently, the project supports OpenAI, Anthropic, and Google with a consistent 
 
 ### Version
 
-Current version: 0.4.0
+Current version: 0.4.1
 
 
 ## Features
@@ -28,6 +28,7 @@ Current version: 0.4.0
 - **Unified Reasoning Support**: A single `reasoning_level` parameter that works identically across all providers.
 - **Request Timeouts:** Per-request timeout control with a unified `timeout_s` parameter.
 - **Strict JSON Mode**: Pass a JSON Schema to `chat()` and get a parsed object in `ChatResponse.parsed_json` — provider normalization is handled automatically.
+- **Pydantic Integration**: Pass a Pydantic model as `response_model` and get a typed instance back in `ChatResponse.parsed_model` — no manual schema writing required.
 
 ## Installation
 
@@ -139,7 +140,7 @@ The SDK provides a set of standardized errors for easier debugging and integrati
 
 - **ToolChoiceError**: Raised when `tool_choice` is invalid or references an unknown tool.
 
-- **JSONSchemaError**: Raised when `json_schema` is not a `dict`, is passed together with `tools`, or the model response is not valid JSON.
+- **JSONSchemaError**: Raised when `json_schema` or `response_model` is used incorrectly (combined with each other or with `tools`), when `response_model` is not a Pydantic `BaseModel` subclass, when Pydantic is not installed, or when the model response is not valid JSON.
 
 ### Config Errors
 
@@ -153,7 +154,7 @@ The SDK provides a set of standardized errors for easier debugging and integrati
 
 The SDK allows you to easily switch between LLM providers and specify the model you want to use. Currently supported providers are OpenAI, Anthropic, and Google.
 
-- **OpenAI**: You can use models like `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.2`, `gpt-5.1`, `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`, `gpt-4o`, `gpt-4o-mini`.
+- **OpenAI**: You can use models like `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.2`, `gpt-5.1`, `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`, `gpt-4o`, `gpt-4o-mini`.
 - **Anthropic**: Available models include `claude-fable-5`, `claude-sonnet-5`, `claude-opus-4-8`, `claude-opus-4-7`, `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-opus-4-5`, `claude-sonnet-4-5`, `claude-haiku-4-5`, `claude-opus-4-1`.
 - **Google**: Models such as `gemini-3.5-flash`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite`, `gemini-3-flash-preview`, `gemini-2.5-pro`, `gemini-2.5-flash` can be used.
 
@@ -253,7 +254,8 @@ The `ChatResponse` object returned by `chat` includes:
 8. **cost\_total**: Total combined cost.
 9. **content**: The generated text response.
 10. **finish\_reason**: Reason why generation stopped (e.g., `"stop"`, `"length"`).
-11. **parsed\_json**: Parsed JSON object when `json_schema` was provided, otherwise `None`.
+11. **parsed\_json**: Parsed JSON object when `json_schema` or `response_model` was provided, otherwise `None`.
+12. **parsed\_model**: Typed Pydantic instance when `response_model` was provided, otherwise `None`.
 
 ## Timeout Support
 
@@ -481,9 +483,49 @@ if first.tool_calls:
     print(final.content)
 ```
 
-## Strict JSON Mode
+## Structured Output
 
-The SDK supports structured JSON output via a `json_schema` parameter in `chat()`. Pass any JSON Schema object — the adapter normalizes it for each provider automatically and returns the parsed result in `ChatResponse.parsed_json`.
+The SDK supports two ways to get structured output from `chat()`: a raw `json_schema` dict, or a Pydantic model via `response_model`. Both work across all providers without any changes to your code.
+
+### Pydantic Integration (`response_model`)
+
+Pass a Pydantic `BaseModel` subclass as `response_model` — the adapter extracts the JSON Schema automatically and returns a typed instance in `ChatResponse.parsed_model`.
+
+```python
+from pydantic import BaseModel
+from llm_api_adapter.models.messages.chat_message import Prompt, UserMessage
+from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
+
+class Person(BaseModel):
+    name: str
+    age: int
+
+adapter = UniversalLLMAPIAdapter(
+    organization="openai",
+    model="gpt-5",
+    api_key=openai_api_key,
+)
+
+response = adapter.chat(
+    messages=[
+        Prompt("Extract structured data from the user's message."),
+        UserMessage("My name is Alice and I'm 30 years old."),
+    ],
+    response_model=Person,
+    max_tokens=200,
+)
+
+print(response.parsed_model)  # Person(name='Alice', age=30)
+print(response.parsed_json)   # {"name": "Alice", "age": 30}
+```
+
+> **Note:** Pydantic is not a required dependency of this package. Install it separately: `pip install pydantic`.
+
+`response_model` cannot be combined with `json_schema` or `tools` — passing both raises `JSONSchemaError`.
+
+### Raw JSON Schema (`json_schema`)
+
+The SDK also supports structured JSON output via a `json_schema` parameter in `chat()`. Pass any JSON Schema object — the adapter normalizes it for each provider automatically and returns the parsed result in `ChatResponse.parsed_json`.
 
 ```python
 from llm_api_adapter.models.messages.chat_message import Prompt, UserMessage
@@ -520,12 +562,12 @@ print(response.parsed_json)  # {"name": "Alice", "age": 30}
 ### `json_schema` parameter
 
 - Accepts a `dict` containing a JSON Schema object.
-- Cannot be combined with `tools` — passing both raises `JSONSchemaError`.
+- Cannot be combined with `tools` or `response_model` — passing both raises `JSONSchemaError`.
 - If the model returns a response that is not valid JSON, `JSONSchemaError` is raised.
 
 ### `parsed_json` field
 
-`ChatResponse.parsed_json` contains the parsed `dict` when `json_schema` was provided, or `None` otherwise.
+`ChatResponse.parsed_json` contains the parsed `dict` when `json_schema` or `response_model` was provided, or `None` otherwise.
 
 ### Provider behavior
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-api-adapter"
-version = "0.4.0"
+version = "0.4.1"
 description = "Lightweight, pluggable adapter for multiple LLM APIs (OpenAI, Anthropic, Google)"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/llm_api_adapter/adapters/anthropic_adapter.py
+++ b/src/llm_api_adapter/adapters/anthropic_adapter.py
@@ -34,12 +34,13 @@ class AnthropicAdapter(LLMAdapterBase):
         parallel_tool_calls: Optional[bool] = None,
         previous_response: Optional[ChatResponse] = None,
         json_schema: Optional[dict] = None,
+        response_model: Optional[Any] = None,
     ) -> ChatResponse:
         temperature = self._validate_parameter("temperature", temperature, 0, 2)
         top_p = self._validate_parameter("top_p", top_p, 0, 1)
         try:
             self._validate_tools(tools)
-            self._validate_json_schema(json_schema, tools)
+            effective_schema = self._resolve_json_schema(json_schema, response_model, tools)
             validated_tools = tools
             normalized_tool_choice = self._normalize_tool_choice(
                 tool_choice,
@@ -69,11 +70,11 @@ class AnthropicAdapter(LLMAdapterBase):
                 params["disable_parallel_tool_use"] = True
             elif parallel_tool_calls is True:
                 params["disable_parallel_tool_use"] = False
-            if json_schema is not None:
+            if effective_schema is not None:
                 params["output_config"] = {
                     "format": {
                         "type": "json_schema",
-                        "schema": self._enforce_strict_schema(json_schema),
+                        "schema": self._enforce_strict_schema(effective_schema),
                     }
                 }
             if reasoning_level:
@@ -96,7 +97,8 @@ class AnthropicAdapter(LLMAdapterBase):
             client = ClaudeSyncClient(api_key=self.api_key)
             response = client.chat_completion(**params)
             chat_response = ChatResponse.from_anthropic_response(response)
-            chat_response.parsed_json = self._parse_json_response(chat_response.content, json_schema)
+            chat_response.parsed_json = self._parse_json_response(chat_response.content, effective_schema)
+            chat_response.parsed_model = self._parse_response_model(chat_response.parsed_json, response_model)
             if self.pricing:
                 chat_response.apply_pricing(
                     price_input_per_token=self.pricing.in_per_token,

--- a/src/llm_api_adapter/adapters/base_adapter.py
+++ b/src/llm_api_adapter/adapters/base_adapter.py
@@ -240,17 +240,43 @@ class LLMAdapterBase(ABC):
             schema["items"] = self._enforce_strict_schema(schema["items"])
         return schema
 
-    def _validate_json_schema(
+
+    def _resolve_json_schema(
         self,
         json_schema: Optional[dict],
-        tools: Optional[List[ToolSpec]] = None,
-    ) -> None:
-        if json_schema is None:
-            return
-        if not isinstance(json_schema, dict):
-            raise JSONSchemaError(detail="json_schema must be a dict")
-        if tools is not None:
+        response_model: Optional[Any],
+        tools: Optional[List[ToolSpec]],
+    ) -> Optional[dict]:
+        if json_schema is not None and response_model is not None:
+            raise JSONSchemaError(detail="json_schema and response_model cannot be used together")
+        if response_model is not None and tools is not None:
+            raise JSONSchemaError(detail="response_model and tools cannot be used together")
+        if json_schema is not None and tools is not None:
             raise JSONSchemaError(detail="json_schema and tools cannot be used together")
+        if response_model is not None:
+            try:
+                return response_model.model_json_schema()
+            except AttributeError:
+                try:
+                    import pydantic  # noqa
+                except ImportError:
+                    raise JSONSchemaError(
+                        detail="pydantic is required for response_model; install it with: pip install pydantic"
+                    )
+                raise JSONSchemaError(detail="response_model must be a Pydantic BaseModel subclass")
+        if json_schema is not None and not isinstance(json_schema, dict):
+            raise JSONSchemaError(detail="json_schema must be a dict")
+        return json_schema
+
+    def _strip_json_fences(self, content: str) -> str:
+        text = content.strip()
+        fence_match = re.match(r'^```(?:json)?\s*([\s\S]*?)\s*```$', text, re.IGNORECASE)
+        if fence_match:
+            return fence_match.group(1).strip()
+        block_match = re.search(r'(\{[\s\S]*\}|\[[\s\S]*\])', text)
+        if block_match:
+            return block_match.group(1)
+        return text
 
     def _parse_json_response(
         self,
@@ -261,8 +287,26 @@ class LLMAdapterBase(ABC):
             return None
         try:
             return json.loads(content)
-        except json.JSONDecodeError as e:
-            raise JSONSchemaError(detail=f"Model response is not valid JSON: {e}")
+        except json.JSONDecodeError:
+            try:
+                return json.loads(self._strip_json_fences(content))
+            except json.JSONDecodeError as e:
+                raise JSONSchemaError(detail=f"Model response is not valid JSON: {e}")
+
+    def _parse_response_model(
+        self,
+        parsed_json: Optional[dict],
+        response_model: Optional[Any],
+    ) -> Optional[Any]:
+        if response_model is None or parsed_json is None:
+            return None
+        try:
+            return response_model.model_validate(parsed_json)
+        except Exception:
+            try:
+                return response_model.model_validate(parsed_json, strict=False)
+            except Exception as e:
+                raise JSONSchemaError(detail=f"Response failed Pydantic validation: {e}")
 
     def handle_error(self, error: Exception, error_message: Optional[str] = None):
         err_msg = (

--- a/src/llm_api_adapter/adapters/google_adapter.py
+++ b/src/llm_api_adapter/adapters/google_adapter.py
@@ -33,6 +33,7 @@ class GoogleAdapter(LLMAdapterBase):
         parallel_tool_calls: Optional[bool] = None,
         previous_response: Optional[ChatResponse] = None,
         json_schema: Optional[dict] = None,
+        response_model: Optional[Any] = None,
     ) -> ChatResponse:
         temperature = self._validate_parameter(
             name="temperature",
@@ -48,7 +49,7 @@ class GoogleAdapter(LLMAdapterBase):
         )
         try:
             self._validate_tools(tools)
-            self._validate_json_schema(json_schema, tools)
+            effective_schema = self._resolve_json_schema(json_schema, response_model, tools)
             validated_tools = tools
             normalized_tool_choice = self._normalize_tool_choice(
                 tool_choice,
@@ -62,9 +63,9 @@ class GoogleAdapter(LLMAdapterBase):
                 "temperature": temperature,
                 "topP": top_p,
             }
-            if json_schema is not None:
+            if effective_schema is not None:
                 generation_config["responseMimeType"] = "application/json"
-                generation_config["responseSchema"] = self._to_google_schema(json_schema)
+                generation_config["responseSchema"] = self._to_google_schema(effective_schema)
             if reasoning_level:
                 normalized_reasoning_level = self._normalize_reasoning_level(
                     reasoning_level
@@ -102,7 +103,8 @@ class GoogleAdapter(LLMAdapterBase):
                 **payload,
             )
             chat_response = ChatResponse.from_google_response(response_json)
-            chat_response.parsed_json = self._parse_json_response(chat_response.content, json_schema)
+            chat_response.parsed_json = self._parse_json_response(chat_response.content, effective_schema)
+            chat_response.parsed_model = self._parse_response_model(chat_response.parsed_json, response_model)
             if self.pricing:
                 chat_response.apply_pricing(
                     price_input_per_token=self.pricing.in_per_token,

--- a/src/llm_api_adapter/adapters/openai_adapter.py
+++ b/src/llm_api_adapter/adapters/openai_adapter.py
@@ -32,6 +32,7 @@ class OpenAIAdapter(LLMAdapterBase):
         parallel_tool_calls: Optional[bool] = None,
         previous_response: Optional[ChatResponse] = None,
         json_schema: Optional[dict] = None,
+        response_model: Optional[Any] = None,
     ) -> ChatResponse:
         temperature = self._validate_parameter(
             name="temperature",
@@ -46,7 +47,7 @@ class OpenAIAdapter(LLMAdapterBase):
             max_value=1,
         )
         self._validate_tools(tools)
-        self._validate_json_schema(json_schema, tools)
+        effective_schema = self._resolve_json_schema(json_schema, response_model, tools)
         normalized_tool_choice = self._normalize_tool_choice(tool_choice, tools)
 
         try:
@@ -92,25 +93,25 @@ class OpenAIAdapter(LLMAdapterBase):
                     params["instructions"] = instructions
                 if previous_response_id is not None:
                     params["previous_response_id"] = previous_response_id
-                if json_schema is not None:
+                if effective_schema is not None:
                     params["text"] = {
                         "format": {
                             "type": "json_schema",
                             "name": "response",
                             "strict": True,
-                            "schema": self._enforce_strict_schema(json_schema),
+                            "schema": self._enforce_strict_schema(effective_schema),
                         }
                     }
             else:
                 params["messages"] = transformed_messages
                 params["parallel_tool_calls"] = parallel_tool_calls
-                if json_schema is not None:
+                if effective_schema is not None:
                     params["response_format"] = {
                         "type": "json_schema",
                         "json_schema": {
                             "name": "response",
                             "strict": True,
-                            "schema": self._enforce_strict_schema(json_schema),
+                            "schema": self._enforce_strict_schema(effective_schema),
                         },
                     }
 
@@ -122,7 +123,8 @@ class OpenAIAdapter(LLMAdapterBase):
             else:
                 chat_response = ChatResponse.from_openai_response(response)
 
-            chat_response.parsed_json = self._parse_json_response(chat_response.content, json_schema)
+            chat_response.parsed_json = self._parse_json_response(chat_response.content, effective_schema)
+            chat_response.parsed_model = self._parse_response_model(chat_response.parsed_json, response_model)
 
             if self.pricing:
                 chat_response.apply_pricing(

--- a/src/llm_api_adapter/llm_registry/llm_registry.json
+++ b/src/llm_api_adapter/llm_registry/llm_registry.json
@@ -1,10 +1,22 @@
 {
   "schema_version": 6,
-  "effective_date": "2026-07-07",
+  "effective_date": "2026-07-13",
   "providers": {
     "openai": {
       "currency": "USD",
       "models": {
+        "gpt-5.6-sol": {
+          "pricing": {"in_per_1m": 5.0, "out_per_1m": 30.0},
+          "is_reasoning": true
+        },
+        "gpt-5.6-terra": {
+          "pricing": {"in_per_1m": 2.5, "out_per_1m": 15.0},
+          "is_reasoning": true
+        },
+        "gpt-5.6-luna": {
+          "pricing": {"in_per_1m": 1.0, "out_per_1m": 6.0},
+          "is_reasoning": true
+        },
         "gpt-5.5": {
           "pricing": {"in_per_1m": 5.0, "out_per_1m": 30.0},
           "is_reasoning": true

--- a/src/llm_api_adapter/models/responses/chat_response.py
+++ b/src/llm_api_adapter/models/responses/chat_response.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 import json
-from typing import List, Optional
+from typing import Any, List, Optional
 import warnings
 
 from ...errors.llm_api_error import InvalidToolArgumentsError, LLMAPIError
@@ -28,6 +28,7 @@ class ChatResponse:
     tool_calls: Optional[List[ToolCall]] = None
     finish_reason: Optional[str] = None
     parsed_json: Optional[dict] = None
+    parsed_model: Optional[Any] = None
 
     @classmethod
     def from_openai_response(cls, api_response: dict) -> "ChatResponse":

--- a/tests/e2e/test_llm_adapter_chat.py
+++ b/tests/e2e/test_llm_adapter_chat.py
@@ -56,7 +56,7 @@ def test_chat_with_reasoning_level_returns_valid_contract(providers, subtests):
                 )
                 resp = adapter.chat(
                     messages=[{"role": "user", "content": "Say 'OK'."}],
-                    max_tokens=1026,
+                    max_tokens=2000,
                     reasoning_level=1024,
                     timeout_s=60
                 )

--- a/tests/e2e/test_tools_auto_loop.py
+++ b/tests/e2e/test_tools_auto_loop.py
@@ -1,4 +1,5 @@
 import json
+import time
 
 import pytest
 
@@ -9,6 +10,16 @@ from llm_api_adapter.models.messages.chat_message import (
 )
 from llm_api_adapter.models.tools import ToolSpec
 from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
+
+
+def chat_with_retry(adapter, *, retries=2, retry_delay=3, **kwargs):
+    for attempt in range(retries + 1):
+        resp = adapter.chat(**kwargs)
+        if resp.finish_reason != "refusal":
+            return resp
+        if attempt < retries:
+            time.sleep(retry_delay)
+    return resp
 
 
 def run_tool(name, args):
@@ -63,7 +74,8 @@ def test_basic_auto_tool_loop_with_previous_response(providers, subtests):
                     )
                 ]
 
-                first = adapter.chat(
+                first = chat_with_retry(
+                    adapter,
                     messages=messages,
                     tools=tools,
                     tool_choice="any",
@@ -99,7 +111,8 @@ def test_basic_auto_tool_loop_with_previous_response(providers, subtests):
                         )
                     )
 
-                final = adapter.chat(
+                final = chat_with_retry(
+                    adapter,
                     messages=messages,
                     previous_response=first,
                     max_tokens=512,

--- a/tests/e2e/test_tools_auto_loop.py
+++ b/tests/e2e/test_tools_auto_loop.py
@@ -12,19 +12,19 @@ from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
 
 
 def run_tool(name, args):
-    if name == "get_word_score":
-        word = args["word"]
-        scores = {
+    if name == "get_fruit_popularity":
+        fruit = args["fruit"]
+        popularity = {
             "strawberry": 73,
             "banana": 41,
             "orange": 58,
         }
-        if word not in scores:
-            raise ValueError(f"Unknown word {word}")
+        if fruit not in popularity:
+            raise ValueError(f"Unknown fruit {fruit}")
 
         return {
-            "word": word,
-            "score": scores[word],
+            "fruit": fruit,
+            "popularity": popularity[fruit],
         }
 
     raise ValueError(f"Unknown tool {name}")
@@ -34,14 +34,14 @@ def run_tool(name, args):
 def test_basic_auto_tool_loop_with_previous_response(providers, subtests):
     tools = [
         ToolSpec(
-            name="get_word_score",
-            description="Return the score for a word. Use this tool when the user asks for a word score.",
+            name="get_fruit_popularity",
+            description="Return the popularity rating for a fruit.",
             json_schema={
                 "type": "object",
                 "properties": {
-                    "word": {"type": "string"},
+                    "fruit": {"type": "string"},
                 },
-                "required": ["word"],
+                "required": ["fruit"],
                 "additionalProperties": False,
             },
         )
@@ -58,7 +58,7 @@ def test_basic_auto_tool_loop_with_previous_response(providers, subtests):
 
                 messages = [
                     UserMessage(
-                        'What is the score for the word "strawberry"? '
+                        'What is the popularity of the fruit "strawberry"? '
                         "Use the available tool if needed."
                     )
                 ]
@@ -69,6 +69,10 @@ def test_basic_auto_tool_loop_with_previous_response(providers, subtests):
                     tool_choice="any",
                     max_tokens=512,
                     timeout_s=60,
+                )
+
+                assert first.finish_reason != "refusal", (
+                    f"{p['name']} / {model}: model refused the request (safety classifier)"
                 )
 
                 assert first.tool_calls, (
@@ -82,9 +86,9 @@ def test_basic_auto_tool_loop_with_previous_response(providers, subtests):
                 )
 
                 for tc in first.tool_calls:
-                    assert tc.name == "get_word_score"
+                    assert tc.name == "get_fruit_popularity"
                     assert isinstance(tc.arguments, dict)
-                    assert tc.arguments["word"] == "strawberry"
+                    assert tc.arguments["fruit"] == "strawberry"
 
                     result = run_tool(tc.name, tc.arguments)
 

--- a/tests/integration/test_json_schema.py
+++ b/tests/integration/test_json_schema.py
@@ -1,5 +1,6 @@
 import pytest
 import requests_mock as requests_mock_module
+from pydantic import BaseModel
 
 from src.llm_api_adapter.models.messages.chat_message import UserMessage
 from src.llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
@@ -15,6 +16,11 @@ SCHEMA = {
     },
     "required": ["name", "age"],
 }
+
+
+class Person(BaseModel):
+    name: str
+    age: int
 
 
 @pytest.fixture
@@ -119,6 +125,25 @@ def test_openai_responses_api_sends_json_schema_in_text_param(openai_responses_j
     assert resp.parsed_json == {"name": "Alice", "age": 30}
 
 
+@pytest.mark.integration
+def test_openai_responses_api_sends_schema_and_returns_parsed_model(openai_responses_json_mock):
+    adapter = UniversalLLMAPIAdapter(
+        organization="openai", model="gpt-5", api_key="dummy_key"
+    )
+
+    resp = adapter.chat(messages=[UserMessage("hi")], response_model=Person)
+
+    payload = openai_responses_json_mock.request_history[0].json()
+    fmt = payload["text"]["format"]
+    assert fmt["type"] == "json_schema"
+    assert fmt["schema"] == {**Person.model_json_schema(), "additionalProperties": False}
+
+    assert resp.parsed_json == {"name": "Alice", "age": 30}
+    assert isinstance(resp.parsed_model, Person)
+    assert resp.parsed_model.name == "Alice"
+    assert resp.parsed_model.age == 30
+
+
 # ---------------------------
 # OpenAI Legacy API (gpt-4o)
 # ---------------------------
@@ -142,6 +167,24 @@ def test_openai_legacy_api_sends_json_schema_in_response_format(openai_legacy_js
 
     assert resp.content == JSON_CONTENT
     assert resp.parsed_json == {"name": "Alice", "age": 30}
+
+
+@pytest.mark.integration
+def test_openai_legacy_api_sends_schema_and_returns_parsed_model(openai_legacy_json_mock):
+    adapter = UniversalLLMAPIAdapter(
+        organization="openai", model="gpt-4o", api_key="dummy_key"
+    )
+
+    resp = adapter.chat(messages=[UserMessage("hi")], response_model=Person)
+
+    payload = openai_legacy_json_mock.request_history[0].json()
+    js = payload["response_format"]["json_schema"]
+    assert js["schema"] == {**Person.model_json_schema(), "additionalProperties": False}
+
+    assert resp.parsed_json == {"name": "Alice", "age": 30}
+    assert isinstance(resp.parsed_model, Person)
+    assert resp.parsed_model.name == "Alice"
+    assert resp.parsed_model.age == 30
 
 
 # ---------------------------
@@ -169,6 +212,25 @@ def test_anthropic_sends_output_config_for_json_schema(anthropic_json_mock):
     assert resp.parsed_json == {"name": "Alice", "age": 30}
 
 
+@pytest.mark.integration
+def test_anthropic_sends_schema_and_returns_parsed_model(anthropic_json_mock):
+    adapter = UniversalLLMAPIAdapter(
+        organization="anthropic", model="claude-sonnet-4-5", api_key="dummy_key"
+    )
+
+    resp = adapter.chat(messages=[UserMessage("hi")], max_tokens=256, response_model=Person)
+
+    payload = anthropic_json_mock.request_history[0].json()
+    fmt = payload["output_config"]["format"]
+    assert fmt["type"] == "json_schema"
+    assert fmt["schema"] == {**Person.model_json_schema(), "additionalProperties": False}
+
+    assert resp.parsed_json == {"name": "Alice", "age": 30}
+    assert isinstance(resp.parsed_model, Person)
+    assert resp.parsed_model.name == "Alice"
+    assert resp.parsed_model.age == 30
+
+
 # ---------------------------
 # Google
 # ---------------------------
@@ -192,3 +254,23 @@ def test_google_sends_response_mime_type_and_schema(google_json_mock):
 
     assert resp.content == JSON_CONTENT
     assert resp.parsed_json == {"name": "Alice", "age": 30}
+
+
+@pytest.mark.integration
+def test_google_sends_schema_and_returns_parsed_model_for_response_model(google_json_mock):
+    adapter = UniversalLLMAPIAdapter(
+        organization="google", model="gemini-2.5-pro", api_key="dummy_key"
+    )
+
+    resp = adapter.chat(messages=[UserMessage("hi")], response_model=Person)
+
+    payload = google_json_mock.request_history[0].json()
+    gen_cfg = payload["generationConfig"]
+    assert gen_cfg["responseMimeType"] == "application/json"
+    assert "name" in gen_cfg["responseSchema"]["properties"]
+    assert "age" in gen_cfg["responseSchema"]["properties"]
+
+    assert resp.parsed_json == {"name": "Alice", "age": 30}
+    assert isinstance(resp.parsed_model, Person)
+    assert resp.parsed_model.name == "Alice"
+    assert resp.parsed_model.age == 30

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -1,4 +1,5 @@
 # Test dependencies
+pydantic
 python-dotenv
 httpx==0.28.1
 pytest==8.4.1

--- a/tests/unit/adapters/test_base_adapter.py
+++ b/tests/unit/adapters/test_base_adapter.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
+from pydantic import BaseModel
 
 from src.llm_api_adapter.adapters.base_adapter import LLMAdapterBase
 from src.llm_api_adapter.adapters import base_adapter as base_module
@@ -465,35 +466,92 @@ def test_raise_required_tool_choice_error(adapter):
 
 
 # ---------------------------
-# _validate_json_schema
+# _resolve_json_schema
+# ---------------------------
+
+class _Person(BaseModel):
+    name: str
+    age: int
+
+
+class _NotPydantic:
+    pass
+
+
+@pytest.mark.unit
+def test_resolve_json_schema_all_none_returns_none(adapter):
+    assert adapter._resolve_json_schema(None, None, None) is None
+
+
+@pytest.mark.unit
+def test_resolve_json_schema_dict_returns_dict(adapter):
+    schema = {"type": "object"}
+    assert adapter._resolve_json_schema(schema, None, None) == schema
+
+
+@pytest.mark.unit
+def test_resolve_json_schema_response_model_returns_schema(adapter):
+    result = adapter._resolve_json_schema(None, _Person, None)
+    assert result == _Person.model_json_schema()
+
+
+@pytest.mark.unit
+def test_resolve_json_schema_rejects_non_dict_json_schema(adapter):
+    with pytest.raises(JSONSchemaError, match="json_schema must be a dict"):
+        adapter._resolve_json_schema("not-a-dict", None, None)
+
+
+@pytest.mark.unit
+def test_resolve_json_schema_rejects_both_json_schema_and_response_model(adapter):
+    with pytest.raises(JSONSchemaError, match="json_schema and response_model cannot be used together"):
+        adapter._resolve_json_schema({"type": "object"}, _Person, None)
+
+
+@pytest.mark.unit
+def test_resolve_json_schema_rejects_response_model_with_tools(adapter):
+    with pytest.raises(JSONSchemaError, match="response_model and tools cannot be used together"):
+        adapter._resolve_json_schema(None, _Person, [make_tool("weather")])
+
+
+@pytest.mark.unit
+def test_resolve_json_schema_rejects_json_schema_with_tools(adapter):
+    with pytest.raises(JSONSchemaError, match="json_schema and tools cannot be used together"):
+        adapter._resolve_json_schema({"type": "object"}, None, [make_tool("weather")])
+
+
+@pytest.mark.unit
+def test_resolve_json_schema_rejects_non_pydantic_class(adapter):
+    with pytest.raises(JSONSchemaError, match="Pydantic BaseModel"):
+        adapter._resolve_json_schema(None, _NotPydantic, None)
+
+
+# ---------------------------
+# _strip_json_fences
 # ---------------------------
 
 @pytest.mark.unit
-def test_validate_json_schema_accepts_none(adapter):
-    adapter._validate_json_schema(None)
+def test_strip_json_fences_plain_json_unchanged(adapter):
+    assert adapter._strip_json_fences('{"a": 1}') == '{"a": 1}'
 
 
 @pytest.mark.unit
-def test_validate_json_schema_accepts_valid_dict(adapter):
-    adapter._validate_json_schema({"type": "object", "properties": {"name": {"type": "string"}}})
+def test_strip_json_fences_removes_json_fence(adapter):
+    assert adapter._strip_json_fences('```json\n{"a": 1}\n```') == '{"a": 1}'
 
 
 @pytest.mark.unit
-def test_validate_json_schema_rejects_non_dict(adapter):
-    with pytest.raises(JSONSchemaError, match="json_schema must be a dict"):
-        adapter._validate_json_schema("string")
+def test_strip_json_fences_removes_plain_fence(adapter):
+    assert adapter._strip_json_fences('```\n{"a": 1}\n```') == '{"a": 1}'
 
 
 @pytest.mark.unit
-def test_validate_json_schema_rejects_dict_combined_with_tools(adapter):
-    tools = [make_tool("weather")]
-    with pytest.raises(JSONSchemaError, match="json_schema and tools cannot be used together"):
-        adapter._validate_json_schema({"type": "object"}, tools)
+def test_strip_json_fences_extracts_object_from_preamble(adapter):
+    assert adapter._strip_json_fences('Here you go:\n{"a": 1}\nDone.') == '{"a": 1}'
 
 
 @pytest.mark.unit
-def test_validate_json_schema_accepts_dict_when_tools_none(adapter):
-    adapter._validate_json_schema({"type": "object"}, None)
+def test_strip_json_fences_extracts_array(adapter):
+    assert adapter._strip_json_fences('Result: [1, 2, 3]') == '[1, 2, 3]'
 
 
 # ---------------------------
@@ -517,6 +575,46 @@ def test_parse_json_response_returns_parsed_dict(adapter):
 
 
 @pytest.mark.unit
+def test_parse_json_response_strips_json_fence(adapter):
+    result = adapter._parse_json_response('```json\n{"name": "test"}\n```', {"type": "object"})
+    assert result == {"name": "test"}
+
+
+@pytest.mark.unit
+def test_parse_json_response_strips_preamble(adapter):
+    result = adapter._parse_json_response('Sure! {"name": "test"} done.', {"type": "object"})
+    assert result == {"name": "test"}
+
+
+@pytest.mark.unit
 def test_parse_json_response_raises_on_invalid_json(adapter):
     with pytest.raises(JSONSchemaError, match="Model response is not valid JSON"):
-        adapter._parse_json_response("not json", {"type": "object"})
+        adapter._parse_json_response("not json at all !!!", {"type": "object"})
+
+
+# ---------------------------
+# _parse_response_model
+# ---------------------------
+
+@pytest.mark.unit
+def test_parse_response_model_returns_none_when_model_none(adapter):
+    assert adapter._parse_response_model({"name": "Alice", "age": 30}, None) is None
+
+
+@pytest.mark.unit
+def test_parse_response_model_returns_none_when_json_none(adapter):
+    assert adapter._parse_response_model(None, _Person) is None
+
+
+@pytest.mark.unit
+def test_parse_response_model_returns_validated_instance(adapter):
+    result = adapter._parse_response_model({"name": "Alice", "age": 30}, _Person)
+    assert isinstance(result, _Person)
+    assert result.name == "Alice"
+    assert result.age == 30
+
+
+@pytest.mark.unit
+def test_parse_response_model_raises_on_invalid_data(adapter):
+    with pytest.raises(JSONSchemaError, match="Pydantic validation"):
+        adapter._parse_response_model({"name": 123, "age": "not-an-int"}, _Person)

--- a/tests/unit/models/responses/test_chat_response.py
+++ b/tests/unit/models/responses/test_chat_response.py
@@ -774,6 +774,33 @@ def test_parsed_json_can_be_assigned_after_construction():
 
 
 @pytest.mark.unit
+def test_parsed_model_defaults_to_none():
+    response = ChatResponse()
+    assert response.parsed_model is None
+
+
+@pytest.mark.unit
+def test_parsed_model_can_be_set_on_construction():
+    response = ChatResponse(parsed_model={"any": "object"})
+    assert response.parsed_model == {"any": "object"}
+
+
+@pytest.mark.unit
+def test_parsed_model_can_be_assigned_after_construction():
+    response = ChatResponse()
+    response.parsed_model = "some-value"
+    assert response.parsed_model == "some-value"
+
+
+@pytest.mark.unit
+def test_parsed_json_and_parsed_model_coexist():
+    data = {"name": "Alice", "age": 30}
+    response = ChatResponse(parsed_json=data, parsed_model="model-instance")
+    assert response.parsed_json == data
+    assert response.parsed_model == "model-instance"
+
+
+@pytest.mark.unit
 def test_apply_pricing_without_usage_does_nothing():
     response = ChatResponse()
     response.apply_pricing(


### PR DESCRIPTION
**Pydantic integration (`response_model`)**

Pass a Pydantic `BaseModel` subclass directly to `chat()` — the adapter extracts the JSON Schema automatically and returns a typed instance in `ChatResponse.parsed_model`.