### PR TITLE
feat: is_adaptive_thinking registry flag, fix LLMReasoningLevelError wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,24 @@ The SDK provides a set of standardized errors for easier debugging and integrati
 
 - **LLMReasoningLevelError**: Raised only for Anthropic models when max_tokens is less than reasoning_level.
 
+### Provider Error Mapping
+
+| Exception | OpenAI | Anthropic | Google |
+|---|---|---|---|
+| `LLMAPIAuthorizationError` | HTTP 401; `InvalidAuthenticationError`, `AuthenticationError` | HTTP 401; `AuthenticationError`, `PermissionError` | HTTP 401/403; `PERMISSION_DENIED` |
+| `LLMAPIRateLimitError` | HTTP 429; `RateLimitError` | HTTP 429; `RateLimitError` | HTTP 429; `RESOURCE_EXHAUSTED` |
+| `LLMAPITokenLimitError` | `MaxTokensExceededError`, `TokenLimitError` | — | — |
+| `LLMAPIClientError` | HTTP 4xx; `InvalidRequestError`, `BadRequestError` | HTTP 4xx; `InvalidRequestError`, `RequestTooLargeError`, `NotFoundError` | HTTP 4xx; `INVALID_ARGUMENT`, `FAILED_PRECONDITION`, `NOT_FOUND` |
+| `LLMAPIServerError` | HTTP 5xx; `InternalServerError`, `ServiceUnavailableError` | HTTP 5xx; `APIError`, `OverloadedError` | HTTP 5xx; `INTERNAL`, `UNAVAILABLE` |
+| `LLMAPITimeoutError` | `requests.Timeout`; `TimeoutError` | `requests.Timeout` | `requests.Timeout`; `DEADLINE_EXCEEDED` |
+| `LLMAPIUsageLimitError` | `UsageLimitError`, `QuotaExceededError` | — | — |
+
+> - `LLMAPITokenLimitError` and `LLMAPIUsageLimitError` are OpenAI-only; equivalent cases for Anthropic and Google fall into `LLMAPIClientError` (HTTP 4xx).
+> - `LLMAPIClientError` is the default fallback for all unhandled HTTP 4xx responses.
+> - `LLMAPIServerError` is the default fallback for all HTTP 5xx responses.
+> - `InvalidToolSchemaError`, `InvalidToolArgumentsError`, `ToolChoiceError`, `JSONSchemaError` — client-side errors (validated before the request is sent); inherit from `LLMAPIClientError`.
+> - `LLMConfigError`, `LLMReasoningLevelError` — configuration errors (parameter validation before the request); `LLMReasoningLevelError` is only raised for Anthropic models with `budget_tokens`.
+
 ## Configuration and Management
 
 ### Using Different Providers and Models

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Currently, the project supports OpenAI, Anthropic, and Google with a consistent 
 
 ### Version
 
-Current version: 0.4.1
+Current version: 0.4.2
 
 
 ## Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-api-adapter"
-version = "0.4.1"
+version = "0.4.2"
 description = "Lightweight, pluggable adapter for multiple LLM APIs (OpenAI, Anthropic, Google)"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/llm_api_adapter/adapters/anthropic_adapter.py
+++ b/src/llm_api_adapter/adapters/anthropic_adapter.py
@@ -7,7 +7,7 @@ import warnings
 
 from ..adapters.base_adapter import LLMAdapterBase
 from ..errors.llm_api_error import LLMAPIError
-from ..errors.config_errors import LLMConfigError
+from ..errors.config_errors import LLMReasoningLevelError
 from ..llms.anthropic.sync_client import ClaudeSyncClient
 from ..models.messages.chat_message import Message, Messages
 from ..models.responses.chat_response import ChatResponse
@@ -56,6 +56,7 @@ class AnthropicAdapter(LLMAdapterBase):
                 "top_p": top_p,
                 "system": system_prompt,
                 "timeout_s": timeout_s,
+                "is_adaptive_thinking": self.is_adaptive_thinking,
             }
             if validated_tools:
                 params["tools"] = [
@@ -82,11 +83,12 @@ class AnthropicAdapter(LLMAdapterBase):
                     reasoning_level
                 )
                 if normalized_reasoning_level:
-                    self.validate_reasoning_and_tokens(
-                        max_tokens=max_tokens,
-                        reasoning_level=reasoning_level,
-                        normalized_reasoning_level=normalized_reasoning_level,
-                    )
+                    if not self.is_adaptive_thinking:
+                        self.validate_reasoning_and_tokens(
+                            max_tokens=max_tokens,
+                            reasoning_level=reasoning_level,
+                            normalized_reasoning_level=normalized_reasoning_level,
+                        )
                     params["budget_tokens"] = normalized_reasoning_level
                 if self.is_reasoning:
                     effort = self._reasoning_level_to_effort(reasoning_level)
@@ -195,7 +197,7 @@ class AnthropicAdapter(LLMAdapterBase):
         normalized_reasoning_level: int,
     ) -> None:
         if max_tokens <= normalized_reasoning_level:
-            raise LLMConfigError(
+            raise LLMReasoningLevelError(
                 detail=(
                     f"Provided max_tokens={max_tokens}, "
                     f"reasoning_level={normalized_reasoning_level} "

--- a/src/llm_api_adapter/adapters/base_adapter.py
+++ b/src/llm_api_adapter/adapters/base_adapter.py
@@ -34,6 +34,7 @@ class LLMAdapterBase(ABC):
     company: str
     pricing: Optional[Pricing] = None
     is_reasoning: bool = False
+    is_adaptive_thinking: bool = False
     reasoning_levels: Dict[str, int] = field(
         default_factory=lambda: REASONING_LEVELS_DEFAULT.copy()
     )
@@ -59,6 +60,7 @@ class LLMAdapterBase(ABC):
             base_pricing = getattr(model_spec, "pricing", None)
             self.pricing = deepcopy(base_pricing) if base_pricing else None
             self.is_reasoning = getattr(model_spec, "is_reasoning", False)
+            self.is_adaptive_thinking = getattr(model_spec, "is_adaptive_thinking", False)
 
     @abstractmethod
     def chat(self, **kwargs) -> ChatResponse:

--- a/src/llm_api_adapter/errors/config_errors.py
+++ b/src/llm_api_adapter/errors/config_errors.py
@@ -15,6 +15,7 @@ class LLMConfigError(Exception):
         super().__init__(full_message)
 
 
+@dataclass
 class LLMReasoningLevelError(LLMConfigError):
     """Raised when reasoning_level is greater max_tokens."""
     message: str = "Reasoning level is too high: 'max_tokens' must be > 'reasoning_level'."

--- a/src/llm_api_adapter/llm_registry/llm_registry.json
+++ b/src/llm_api_adapter/llm_registry/llm_registry.json
@@ -1,6 +1,6 @@
 {
-  "schema_version": 6,
-  "effective_date": "2026-07-13",
+  "schema_version": 7,
+  "effective_date": "2026-07-14",
   "providers": {
     "openai": {
       "currency": "USD",
@@ -65,27 +65,33 @@
       "models": {
         "claude-fable-5": {
           "pricing": {"in_per_1m": 10.0, "out_per_1m": 50.0},
-          "is_reasoning": true
+          "is_reasoning": true,
+          "is_adaptive": true
         },
         "claude-sonnet-5": {
           "pricing": {"in_per_1m": 3.0, "out_per_1m": 15.0},
-          "is_reasoning": true
+          "is_reasoning": true,
+          "is_adaptive": true
         },
         "claude-opus-4-8": {
           "pricing": {"in_per_1m": 5.0, "out_per_1m": 25.0},
-          "is_reasoning": true
+          "is_reasoning": true,
+          "is_adaptive": true
         },
         "claude-opus-4-7": {
           "pricing": {"in_per_1m": 5.0, "out_per_1m": 25.0},
-          "is_reasoning": true
+          "is_reasoning": true,
+          "is_adaptive": true
         },
         "claude-opus-4-6": {
           "pricing": {"in_per_1m": 5.0, "out_per_1m": 25.0},
-          "is_reasoning": true
+          "is_reasoning": true,
+          "is_adaptive": true
         },
         "claude-sonnet-4-6": {
           "pricing": {"in_per_1m": 3.0, "out_per_1m": 15.0},
-          "is_reasoning": true
+          "is_reasoning": true,
+          "is_adaptive": true
         },
         "claude-opus-4-5": {
           "pricing": {"in_per_1m": 5.0, "out_per_1m": 25.0},

--- a/src/llm_api_adapter/llm_registry/llm_registry.json
+++ b/src/llm_api_adapter/llm_registry/llm_registry.json
@@ -66,32 +66,32 @@
         "claude-fable-5": {
           "pricing": {"in_per_1m": 10.0, "out_per_1m": 50.0},
           "is_reasoning": true,
-          "is_adaptive": true
+          "is_adaptive_thinking": true
         },
         "claude-sonnet-5": {
           "pricing": {"in_per_1m": 3.0, "out_per_1m": 15.0},
           "is_reasoning": true,
-          "is_adaptive": true
+          "is_adaptive_thinking": true
         },
         "claude-opus-4-8": {
           "pricing": {"in_per_1m": 5.0, "out_per_1m": 25.0},
           "is_reasoning": true,
-          "is_adaptive": true
+          "is_adaptive_thinking": true
         },
         "claude-opus-4-7": {
           "pricing": {"in_per_1m": 5.0, "out_per_1m": 25.0},
           "is_reasoning": true,
-          "is_adaptive": true
+          "is_adaptive_thinking": true
         },
         "claude-opus-4-6": {
           "pricing": {"in_per_1m": 5.0, "out_per_1m": 25.0},
           "is_reasoning": true,
-          "is_adaptive": true
+          "is_adaptive_thinking": true
         },
         "claude-sonnet-4-6": {
           "pricing": {"in_per_1m": 3.0, "out_per_1m": 15.0},
           "is_reasoning": true,
-          "is_adaptive": true
+          "is_adaptive_thinking": true
         },
         "claude-opus-4-5": {
           "pricing": {"in_per_1m": 5.0, "out_per_1m": 25.0},

--- a/src/llm_api_adapter/llm_registry/llm_registry.py
+++ b/src/llm_api_adapter/llm_registry/llm_registry.py
@@ -27,6 +27,7 @@ class ModelSpec:
     name: str
     pricing: Optional[Pricing] = None
     is_reasoning: bool = False
+    is_adaptive: bool = False
 
     @classmethod
     def from_dict(cls, name: str, d: Dict[str, Any]) -> "ModelSpec":
@@ -38,7 +39,8 @@ class ModelSpec:
         else:
             pricing = None
         is_reasoning = bool(d.get("is_reasoning", False))
-        return cls(name=name, pricing=pricing, is_reasoning=is_reasoning)
+        is_adaptive = bool(d.get("is_adaptive", False))
+        return cls(name=name, pricing=pricing, is_reasoning=is_reasoning, is_adaptive=is_adaptive)
 
 
 @dataclass(frozen=True)

--- a/src/llm_api_adapter/llm_registry/llm_registry.py
+++ b/src/llm_api_adapter/llm_registry/llm_registry.py
@@ -27,7 +27,7 @@ class ModelSpec:
     name: str
     pricing: Optional[Pricing] = None
     is_reasoning: bool = False
-    is_adaptive: bool = False
+    is_adaptive_thinking: bool = False
 
     @classmethod
     def from_dict(cls, name: str, d: Dict[str, Any]) -> "ModelSpec":
@@ -39,8 +39,8 @@ class ModelSpec:
         else:
             pricing = None
         is_reasoning = bool(d.get("is_reasoning", False))
-        is_adaptive = bool(d.get("is_adaptive", False))
-        return cls(name=name, pricing=pricing, is_reasoning=is_reasoning, is_adaptive=is_adaptive)
+        is_adaptive_thinking = bool(d.get("is_adaptive_thinking", False))
+        return cls(name=name, pricing=pricing, is_reasoning=is_reasoning, is_adaptive_thinking=is_adaptive_thinking)
 
 
 @dataclass(frozen=True)

--- a/src/llm_api_adapter/llms/anthropic/sync_client.py
+++ b/src/llm_api_adapter/llms/anthropic/sync_client.py
@@ -14,8 +14,6 @@ from ...errors.llm_api_error import (
 
 logger = logging.getLogger(__name__)
 
-_ADAPTIVE_THINKING_MODELS = ("claude-opus-4-6", "claude-sonnet-4-6", "claude-opus-4-7", "claude-opus-4-8", "claude-fable-5", "claude-sonnet-5")
-
 @dataclass
 class ClaudeSyncClient:
     api_key: str
@@ -38,7 +36,8 @@ class ClaudeSyncClient:
     def _prepare_chat_payload_for_model(self, model: str, kwargs: dict) -> dict:
         budget_tokens = kwargs.pop("budget_tokens", None)
         effort = kwargs.pop("effort", None)
-        if model.startswith(_ADAPTIVE_THINKING_MODELS):
+        is_adaptive_thinking = kwargs.pop("is_adaptive_thinking", False)
+        if is_adaptive_thinking:
             kwargs.pop("top_p", None)
             if effort:
                 kwargs["thinking"] = {"type": "adaptive"}

--- a/tests/unit/adapters/test_anthropic_adapter.py
+++ b/tests/unit/adapters/test_anthropic_adapter.py
@@ -113,14 +113,27 @@ def test_chat_sets_thinking_when_reasoning_level_provided(adapter):
         assert kwargs["budget_tokens"] == 4096
 
 @pytest.mark.unit
-def test_validate_reasoning_and_tokens_raises_llmconfigerror(adapter):
-    from src.llm_api_adapter.errors.config_errors import LLMConfigError
-    with pytest.raises(LLMConfigError):
+def test_validate_reasoning_and_tokens_raises_llm_reasoning_level_error(adapter):
+    from src.llm_api_adapter.errors.config_errors import LLMReasoningLevelError
+    with pytest.raises(LLMReasoningLevelError):
         adapter.validate_reasoning_and_tokens(
             max_tokens=1024,
             reasoning_level="high",
             normalized_reasoning_level=2048
         )
+
+
+@pytest.mark.unit
+def test_chat_skips_validation_for_adaptive_thinking_model(adapter):
+    adapter.is_reasoning = True
+    adapter.is_adaptive_thinking = True
+    adapter.reasoning_levels = {"high": 4096}
+    fake_response = {"some": "anthropic response"}
+    fake_chat_response = ChatResponse(content="fake")
+    with patch.object(ClaudeSyncClient, "chat_completion", return_value=fake_response), \
+         patch.object(ChatResponse, "from_anthropic_response", return_value=fake_chat_response):
+        # max_tokens < budget_tokens — would raise LLMReasoningLevelError for a legacy model
+        adapter.chat([UserMessage("hi")], max_tokens=100, reasoning_level="high")
 
 
 # ---------------------------

--- a/tests/unit/adapters/test_base_adapter.py
+++ b/tests/unit/adapters/test_base_adapter.py
@@ -155,7 +155,7 @@ def test_pricing_copied_from_registry(monkeypatch):
 @pytest.mark.unit
 def test_post_init_sets_reasoning_flag_from_registry(monkeypatch):
     provider = SimpleNamespace(
-        models={"m-reason": SimpleNamespace(pricing=None, is_reasoning=True)}
+        models={"m-reason": SimpleNamespace(pricing=None, is_reasoning=True, is_adaptive_thinking=False)}
     )
     monkeypatch.setattr(
         base_module,
@@ -165,6 +165,21 @@ def test_post_init_sets_reasoning_flag_from_registry(monkeypatch):
     )
     adapter_instance = _TestAdapter(company="acme", api_key="k", model="m-reason")
     assert adapter_instance.is_reasoning is True
+
+
+@pytest.mark.unit
+def test_post_init_sets_adaptive_thinking_flag_from_registry(monkeypatch):
+    provider = SimpleNamespace(
+        models={"m-adaptive": SimpleNamespace(pricing=None, is_reasoning=True, is_adaptive_thinking=True)}
+    )
+    monkeypatch.setattr(
+        base_module,
+        "LLM_REGISTRY",
+        SimpleNamespace(providers={"acme": provider}),
+        raising=False,
+    )
+    adapter_instance = _TestAdapter(company="acme", api_key="k", model="m-adaptive")
+    assert adapter_instance.is_adaptive_thinking is True
 
 
 @pytest.mark.unit

--- a/tests/unit/errors/test_llm_api_error.py
+++ b/tests/unit/errors/test_llm_api_error.py
@@ -12,6 +12,14 @@ from src.llm_api_adapter.errors.llm_api_error import (
 )
 
 @pytest.mark.unit
+def test_llm_reasoning_level_error_accepts_detail_kwarg():
+    from src.llm_api_adapter.errors.config_errors import LLMConfigError, LLMReasoningLevelError
+    err = LLMReasoningLevelError(detail="budget_tokens=2000 must be < max_tokens=1000")
+    assert "budget_tokens=2000" in str(err)
+    assert isinstance(err, LLMConfigError)
+
+
+@pytest.mark.unit
 def test_llmapierror_message_and_detail():
     err = LLMAPIError(message="Error occurred", detail="Detailed info")
     assert str(err) == "Error occurred Detail: Detailed info"

--- a/tests/unit/llms/anthropic/test_sync_client.py
+++ b/tests/unit/llms/anthropic/test_sync_client.py
@@ -86,3 +86,42 @@ def test_send_request_fallback_error_parsing(mock_post, client):
     mock_post.side_effect = http_err
     with pytest.raises(LLMAPIClientError):
         client._send_request("http://example.com", {})
+
+
+# ---------------------------
+# _prepare_chat_payload_for_model
+# ---------------------------
+
+@pytest.mark.unit
+def test_prepare_payload_adaptive_thinking_strips_top_p_and_sets_thinking(client):
+    kwargs = {"messages": [], "top_p": 1.0, "is_adaptive_thinking": True, "effort": "high"}
+    payload = client._prepare_chat_payload_for_model("claude-opus-4-8", kwargs)
+    assert "top_p" not in payload
+    assert "is_adaptive_thinking" not in payload
+    assert payload["thinking"] == {"type": "adaptive"}
+    assert payload["output_config"]["effort"] == "high"
+
+
+@pytest.mark.unit
+def test_prepare_payload_adaptive_thinking_no_effort_strips_top_p_only(client):
+    kwargs = {"messages": [], "top_p": 1.0, "is_adaptive_thinking": True}
+    payload = client._prepare_chat_payload_for_model("claude-opus-4-8", kwargs)
+    assert "top_p" not in payload
+    assert "thinking" not in payload
+    assert "is_adaptive_thinking" not in payload
+
+
+@pytest.mark.unit
+def test_prepare_payload_legacy_sets_budget_tokens_thinking(client):
+    kwargs = {"messages": [], "budget_tokens": 4096, "is_adaptive_thinking": False}
+    payload = client._prepare_chat_payload_for_model("claude-opus-4-5", kwargs)
+    assert payload["thinking"] == {"type": "enabled", "budget_tokens": 4096}
+    assert "is_adaptive_thinking" not in payload
+
+
+@pytest.mark.unit
+def test_prepare_payload_is_adaptive_thinking_never_in_result(client):
+    for flag in (True, False):
+        kwargs = {"messages": [], "is_adaptive_thinking": flag}
+        payload = client._prepare_chat_payload_for_model("claude-opus-4-8", kwargs)
+        assert "is_adaptive_thinking" not in payload


### PR DESCRIPTION
- Add `is_adaptive_thinking` flag to `ModelSpec` and `llm_registry.json` for 6 Anthropic adaptive models (claude-opus-4-6/4-7/4-8, claude-sonnet-4-6, claude-fable-5, claude-sonnet-5) — removes hardcoded `_ADAPTIVE_THINKING_MODELS` tuple from the transport layer
- Fix `LLMReasoningLevelError`: add `@dataclass` so `detail=` kwarg works; wire it up instead of `LLMConfigError`; gate validation — adaptive models skip it (budget_tokens isn't sent for them anyway)
- Add Provider Error Mapping table to README `## Handling Errors`