### PR TITLE
feat: add PDF DocumentPart support across providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,7 +718,7 @@ messages = [{
 response = adapter.chat(messages=messages, max_tokens=200)
 ```
 
-> **Note:** Only `ImagePart` is supported in v0.5.0. `DocumentPart` and `AudioPart` are planned for v0.5.1.
+> **Note:** Only `ImagePart` is supported in v0.5.0. `DocumentPart` is planned for v0.5.1. Google already supports audio input, but `AudioPart` is postponed because Anthropic does not support audio and OpenAI uses a separate audio API (`gpt-audio-1.5` with `modalities`), so there is no common provider-neutral contract yet.
 
 ## Token Usage and Pricing
 

--- a/README.md
+++ b/README.md
@@ -718,7 +718,56 @@ messages = [{
 response = adapter.chat(messages=messages, max_tokens=200)
 ```
 
-> **Note:** Only `ImagePart` is supported in v0.5.0. `DocumentPart` is planned for v0.5.1. Google already supports audio input, but `AudioPart` is postponed because Anthropic does not support audio and OpenAI uses a separate audio API (`gpt-audio-1.5` with `modalities`), so there is no common provider-neutral contract yet.
+> **Note:** `ImagePart` is supported in v0.5.0; `DocumentPart` is introduced in v0.5.1. Google already supports audio input, but `AudioPart` is postponed because Anthropic does not support audio and OpenAI uses a separate audio API (`gpt-audio-1.5` with `modalities`), so there is no common provider-neutral contract yet.
+
+## Document Input
+
+The SDK supports PDF documents alongside text using `DocumentPart` and the `files` parameter on `UserMessage`. Provider-specific wire formats are handled automatically.
+
+### Import
+
+```python
+from llm_api_adapter.models.messages.chat_message import UserMessage
+from llm_api_adapter.models.messages.file_parts import DocumentPart
+```
+
+### PDF from URL
+
+```python
+msg = UserMessage(
+    "Summarize this document in one sentence.",
+    files=[DocumentPart(url="https://example.com/report.pdf")]
+)
+response = adapter.chat(messages=[msg], max_tokens=200)
+print(response.content)
+```
+
+The PDF MIME type is detected from the `.pdf` extension. Anthropic, Google, and the OpenAI Responses API accept a document URL. OpenAI Chat Completions models below `gpt-5` do not accept a document URL; use bytes instead.
+
+### PDF from bytes
+
+```python
+with open("report.pdf", "rb") as f:
+    pdf_bytes = f.read()
+
+msg = UserMessage(
+    "Summarize this document in one sentence.",
+    files=[DocumentPart(data=pdf_bytes, media_type="application/pdf")]
+)
+response = adapter.chat(messages=[msg], max_tokens=200)
+print(response.content)
+```
+
+For bytes, the adapter sends the PDF as base64 data in the provider-specific request format. The same `DocumentPart` works with Anthropic, Google, OpenAI Chat Completions, and the OpenAI Responses API.
+
+### File type support
+
+| File type | Anthropic | OpenAI (< gpt-5) | OpenAI (gpt-5+) | Google |
+|-----------|-----------|------------------|-----------------|--------|
+| ImagePart (URL) | ✅ | ✅ | ✅ | ✅ |
+| ImagePart (bytes) | ✅ | ✅ | ✅ | ✅ |
+| DocumentPart (URL) | ✅ | ❌ | ✅ | ✅ |
+| DocumentPart (bytes) | ✅ | ✅ | ✅ | ✅ |
 
 ## Token Usage and Pricing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-api-adapter"
-version = "0.5.0"
+version = "0.5.1"
 description = "Lightweight, pluggable adapter for multiple LLM APIs (OpenAI, Anthropic, Google)"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/llm_api_adapter/models/messages/__init__.py
+++ b/src/llm_api_adapter/models/messages/__init__.py
@@ -1,3 +1,3 @@
-from .file_parts import FilePart, FileParts, ImagePart
+from .file_parts import DocumentPart, FilePart, FileParts, ImagePart
 
-__all__ = ["FilePart", "ImagePart", "FileParts"]
+__all__ = ["FilePart", "ImagePart", "DocumentPart", "FileParts"]

--- a/src/llm_api_adapter/models/messages/chat_message.py
+++ b/src/llm_api_adapter/models/messages/chat_message.py
@@ -6,7 +6,7 @@ import json
 from typing import Any, Dict, List, Optional, Tuple, Type
 
 from ..tools import ToolCall
-from .file_parts import FilePart, ImagePart
+from .file_parts import DocumentPart, FilePart, ImagePart
 
 
 @dataclass
@@ -113,7 +113,21 @@ class UserMessage(Message):
                     "data": part._get_b64_data(),
                 },
             }
-        raise ValueError(f"{type(part).__name__} not supported in 0.5.0")
+        if isinstance(part, DocumentPart):
+            if part._is_url():
+                return {
+                    "type": "document",
+                    "source": {"type": "url", "url": part.url},
+                }
+            return {
+                "type": "document",
+                "source": {
+                    "type": "base64",
+                    "media_type": part._get_media_type(),
+                    "data": part._get_b64_data(),
+                },
+            }
+        raise ValueError(f"{type(part).__name__} is not supported as Anthropic file part")
 
     def _part_to_google(self, part: FilePart) -> Dict[str, Any]:
         if isinstance(part, ImagePart):
@@ -425,6 +439,15 @@ class Messages:
                 return ImagePart(url=source["url"])
             if source.get("type") == "base64":
                 return ImagePart(
+                    data=base64.b64decode(source["data"]),
+                    media_type=source["media_type"],
+                )
+        if part_type == "document":
+            source = part.get("source", {})
+            if source.get("type") == "url":
+                return DocumentPart(url=source["url"])
+            if source.get("type") == "base64":
+                return DocumentPart(
                     data=base64.b64decode(source["data"]),
                     media_type=source["media_type"],
                 )

--- a/src/llm_api_adapter/models/messages/chat_message.py
+++ b/src/llm_api_adapter/models/messages/chat_message.py
@@ -93,13 +93,38 @@ class UserMessage(Message):
         if isinstance(part, ImagePart):
             url = part.url if part._is_url() else part._to_data_uri()
             return {"type": "image_url", "image_url": {"url": url}}
-        raise ValueError(f"{type(part).__name__} not supported in 0.5.0")
+        if isinstance(part, DocumentPart):
+            if part._is_url():
+                raise ValueError(
+                    "OpenAI Chat Completions does not support DocumentPart URL. "
+                    "Use bytes/data, or switch to Responses API (gpt-5 models)."
+                )
+            return {
+                "type": "file",
+                "file": {
+                    "filename": "document.pdf",
+                    "file_data": part._to_data_uri(),
+                },
+            }
+        raise ValueError(
+            f"{type(part).__name__} is not supported as OpenAI Chat Completions file part"
+        )
 
     def _part_to_openai_responses(self, part: FilePart) -> Dict[str, Any]:
         if isinstance(part, ImagePart):
             url = part.url if part._is_url() else part._to_data_uri()
             return {"type": "input_image", "image_url": url}
-        raise ValueError(f"{type(part).__name__} not supported in 0.5.0")
+        if isinstance(part, DocumentPart):
+            if part._is_url():
+                return {"type": "input_file", "file_url": part.url}
+            return {
+                "type": "input_file",
+                "filename": "document.pdf",
+                "file_data": part._to_data_uri(),
+            }
+        raise ValueError(
+            f"{type(part).__name__} is not supported as OpenAI Responses API file part"
+        )
 
     def _part_to_anthropic(self, part: FilePart) -> Dict[str, Any]:
         if isinstance(part, ImagePart):
@@ -431,31 +456,65 @@ class Messages:
             raise ValueError(f"Unsupported file part type: {type(part)}")
         part_type = part.get("type")
         if part_type == "image_url":
-            image_url = part.get("image_url")
-            if isinstance(image_url, dict):
-                return ImagePart(url=image_url["url"])
-            return ImagePart(url=image_url)
+            return self._normalize_image_url_part(part)
         if part_type == "input_image":
-            return ImagePart(url=part["image_url"])
+            return self._normalize_openai_input_image_part(part)
         if part_type == "image":
-            source = part.get("source", {})
-            if source.get("type") == "url":
-                return ImagePart(url=source["url"])
-            if source.get("type") == "base64":
-                return ImagePart(
-                    data=base64.b64decode(source["data"]),
-                    media_type=source["media_type"],
-                )
+            return self._normalize_anthropic_image_part(part)
         if part_type == "document":
-            source = part.get("source", {})
-            if source.get("type") == "url":
-                return DocumentPart(url=source["url"])
-            if source.get("type") == "base64":
-                return DocumentPart(
-                    data=base64.b64decode(source["data"]),
-                    media_type=source["media_type"],
-                )
+            return self._normalize_anthropic_document_part(part)
+        if part_type == "input_file":
+            return self._normalize_openai_input_file_part(part)
+        if part_type == "file":
+            return self._normalize_openai_chat_file_part(part)
         raise ValueError(f"Unsupported file part format: {part_type!r}")
+
+    def _normalize_image_url_part(self, part: Dict[str, Any]) -> ImagePart:
+        image_url = part.get("image_url")
+        if isinstance(image_url, dict):
+            return ImagePart(url=image_url["url"])
+        return ImagePart(url=image_url)
+
+    def _normalize_openai_input_image_part(self, part: Dict[str, Any]) -> ImagePart:
+        return ImagePart(url=part["image_url"])
+
+    def _normalize_anthropic_image_part(self, part: Dict[str, Any]) -> ImagePart:
+        source = part.get("source", {})
+        if source.get("type") == "url":
+            return ImagePart(url=source["url"])
+        if source.get("type") == "base64":
+            return ImagePart(
+                data=base64.b64decode(source["data"]),
+                media_type=source["media_type"],
+            )
+        raise ValueError(f"Unsupported file part format: {part.get('type')!r}")
+
+    def _normalize_anthropic_document_part(self, part: Dict[str, Any]) -> DocumentPart:
+        source = part.get("source", {})
+        if source.get("type") == "url":
+            return DocumentPart(url=source["url"])
+        if source.get("type") == "base64":
+            return DocumentPart(
+                data=base64.b64decode(source["data"]),
+                media_type=source["media_type"],
+            )
+        raise ValueError(f"Unsupported file part format: {part.get('type')!r}")
+
+    def _normalize_openai_input_file_part(self, part: Dict[str, Any]) -> DocumentPart:
+        file_url = part.get("file_url")
+        if file_url:
+            return DocumentPart(url=file_url)
+        file_data = part.get("file_data")
+        if file_data:
+            return DocumentPart(url=file_data)
+        raise ValueError(f"Unsupported file part format: {part.get('type')!r}")
+
+    def _normalize_openai_chat_file_part(self, part: Dict[str, Any]) -> DocumentPart:
+        file_obj = part.get("file", {})
+        file_data = file_obj.get("file_data")
+        if file_data:
+            return DocumentPart(url=file_data)
+        raise ValueError(f"Unsupported file part format: {part.get('type')!r}")
    
     def to_openai(self) -> List[Dict[str, Any]]:
         return [m.to_openai() for m in self.items]

--- a/src/llm_api_adapter/models/messages/chat_message.py
+++ b/src/llm_api_adapter/models/messages/chat_message.py
@@ -134,7 +134,11 @@ class UserMessage(Message):
             if part._is_url():
                 return {"fileData": {"mimeType": part._get_media_type(), "fileUri": part.url}}
             return {"inlineData": {"mimeType": part._get_media_type(), "data": part._get_b64_data()}}
-        raise ValueError(f"{type(part).__name__} not supported in 0.5.0")
+        if isinstance(part, DocumentPart):
+            if part._is_url():
+                return {"fileData": {"mimeType": part._get_media_type(), "fileUri": part.url}}
+            return {"inlineData": {"mimeType": part._get_media_type(), "data": part._get_b64_data()}}
+        raise ValueError(f"{type(part).__name__} is not supported as Google file part")
 
 
 @dataclass

--- a/src/llm_api_adapter/models/messages/file_parts.py
+++ b/src/llm_api_adapter/models/messages/file_parts.py
@@ -83,5 +83,5 @@ class ImagePart(FilePart):
             )
 
 
-# In 0.5.1 this will expand to Union[ImagePart, DocumentPart, AudioPart]
+# In 0.5.1 this will expand to Union[ImagePart, DocumentPart]. AudioPart remains deferred.
 FileParts = Union[ImagePart]

--- a/src/llm_api_adapter/models/messages/file_parts.py
+++ b/src/llm_api_adapter/models/messages/file_parts.py
@@ -83,5 +83,19 @@ class ImagePart(FilePart):
             )
 
 
-# In 0.5.1 this will expand to Union[ImagePart, DocumentPart]. AudioPart remains deferred.
-FileParts = Union[ImagePart]
+@dataclass
+class DocumentPart(FilePart):
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        mt = self._get_media_type()
+        if mt is None:
+            raise ValueError(
+                "Cannot detect document media_type from URL — pass media_type explicitly"
+            )
+        if mt != "application/pdf":
+            raise ValueError(
+                f"DocumentPart requires application/pdf media_type, got {mt!r}"
+            )
+
+
+FileParts = Union[ImagePart, DocumentPart]

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -62,6 +62,11 @@ def vision_image_bytes() -> bytes:
 
 
 @pytest.fixture(scope="session")
+def pdf_bytes() -> bytes:
+    return (_FIXTURES_DIR / "test_document.pdf").read_bytes()
+
+
+@pytest.fixture(scope="session")
 def providers():
     providers_with_models = []
     for provider_name, provider_spec in LLM_REGISTRY.providers.items():

--- a/tests/e2e/test_file_uploads.py
+++ b/tests/e2e/test_file_uploads.py
@@ -1,0 +1,36 @@
+import pytest
+
+from llm_api_adapter.models.messages.chat_message import UserMessage
+from llm_api_adapter.models.messages.file_parts import DocumentPart
+from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
+
+
+_PROMPT = "Summarize this document in one sentence."
+
+
+@pytest.mark.e2e
+def test_document_bytes_returns_non_empty_response(
+    subtests,
+    iter_provider_models,
+    pdf_bytes,
+    chat_with_retry,
+):
+    for p, model in iter_provider_models():
+        if p["name"] not in {"anthropic", "google"}:
+            continue
+        if not p["api_key"]:
+            continue
+
+        with subtests.test(provider=p["name"], model=model):
+            adapter = UniversalLLMAPIAdapter(
+                organization=p["name"],
+                model=model,
+                api_key=p["api_key"],
+            )
+            msg = UserMessage(
+                _PROMPT,
+                files=[DocumentPart(data=pdf_bytes, media_type="application/pdf")],
+            )
+            resp = chat_with_retry(adapter, messages=[msg], max_tokens=150)
+            assert isinstance(resp.content, str)
+            assert len(resp.content) > 0

--- a/tests/fixtures/test_document.pdf
+++ b/tests/fixtures/test_document.pdf
@@ -1,0 +1,26 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 45 >>
+stream
+BT
+/F1 18 Tf
+72 720 Td
+(Test document) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+trailer
+<< /Root 1 0 R >>
+%%EOF

--- a/tests/integration/test_documents.py
+++ b/tests/integration/test_documents.py
@@ -1,0 +1,251 @@
+import base64
+
+import pytest
+import requests_mock as req_mock
+
+from src.llm_api_adapter.models.messages.chat_message import UserMessage
+from src.llm_api_adapter.models.messages.file_parts import DocumentPart
+from src.llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
+
+PDF_URL = "https://example.com/report.pdf"
+PDF_BYTES = b"%PDF-1.4 test document"
+PDF_MEDIA_TYPE = "application/pdf"
+
+_OPENAI_CHAT_RESPONSE = {
+    "id": "chatcmpl_123",
+    "object": "chat.completion",
+    "model": "gpt-4o",
+    "choices": [{
+        "index": 0,
+        "message": {"role": "assistant", "content": "ok"},
+        "finish_reason": "stop",
+    }],
+    "usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8},
+}
+
+_OPENAI_RESPONSES_RESPONSE = {
+    "id": "resp_123",
+    "object": "response",
+    "model": "gpt-5.5",
+    "output": [{
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "output_text", "text": "ok"}],
+    }],
+    "usage": {"input_tokens": 5, "output_tokens": 3, "total_tokens": 8},
+}
+
+_ANTHROPIC_RESPONSE = {
+    "model": "claude-haiku-4-5",
+    "id": "msg_123",
+    "usage": {"input_tokens": 5, "output_tokens": 3},
+    "content": [{"type": "text", "text": "ok"}],
+    "stop_reason": "end_turn",
+}
+
+_GOOGLE_RESPONSE = {
+    "candidates": [{"content": {"parts": [{"text": "ok"}]}, "finishReason": "STOP"}],
+    "usageMetadata": {"totalTokenCount": 8},
+}
+
+
+# ---------------------------------------------------------------------------
+# Anthropic
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+def test_anthropic_document_url():
+    with req_mock.Mocker() as m:
+        m.post("https://api.anthropic.com/v1/messages", json=_ANTHROPIC_RESPONSE)
+        adapter = UniversalLLMAPIAdapter(
+            organization="anthropic",
+            model="claude-haiku-4-5",
+            api_key="dummy",
+        )
+        adapter.chat(
+            messages=[UserMessage("summarize", files=[DocumentPart(url=PDF_URL)])],
+            max_tokens=100,
+        )
+
+        document = m.last_request.json()["messages"][0]["content"][1]
+        assert document == {
+            "type": "document",
+            "source": {"type": "url", "url": PDF_URL},
+        }
+
+
+@pytest.mark.integration
+def test_anthropic_document_bytes():
+    with req_mock.Mocker() as m:
+        m.post("https://api.anthropic.com/v1/messages", json=_ANTHROPIC_RESPONSE)
+        adapter = UniversalLLMAPIAdapter(
+            organization="anthropic",
+            model="claude-haiku-4-5",
+            api_key="dummy",
+        )
+        adapter.chat(
+            messages=[
+                UserMessage(
+                    "summarize",
+                    files=[DocumentPart(data=PDF_BYTES, media_type=PDF_MEDIA_TYPE)],
+                )
+            ],
+            max_tokens=100,
+        )
+
+        source = m.last_request.json()["messages"][0]["content"][1]["source"]
+        assert source["type"] == "base64"
+        assert source["media_type"] == PDF_MEDIA_TYPE
+        assert source["data"] == base64.b64encode(PDF_BYTES).decode()
+
+
+# ---------------------------------------------------------------------------
+# Google
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+def test_google_document_url():
+    with req_mock.Mocker() as m:
+        m.post(
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent",
+            json=_GOOGLE_RESPONSE,
+        )
+        adapter = UniversalLLMAPIAdapter(
+            organization="google",
+            model="gemini-2.5-flash",
+            api_key="dummy",
+        )
+        adapter.chat(
+            messages=[UserMessage("summarize", files=[DocumentPart(url=PDF_URL)])],
+        )
+
+        document = m.last_request.json()["contents"][0]["parts"][1]
+        assert document == {
+            "fileData": {"mimeType": PDF_MEDIA_TYPE, "fileUri": PDF_URL},
+        }
+
+
+@pytest.mark.integration
+def test_google_document_bytes():
+    with req_mock.Mocker() as m:
+        m.post(
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent",
+            json=_GOOGLE_RESPONSE,
+        )
+        adapter = UniversalLLMAPIAdapter(
+            organization="google",
+            model="gemini-2.5-flash",
+            api_key="dummy",
+        )
+        adapter.chat(
+            messages=[
+                UserMessage(
+                    "summarize",
+                    files=[DocumentPart(data=PDF_BYTES, media_type=PDF_MEDIA_TYPE)],
+                )
+            ],
+        )
+
+        document = m.last_request.json()["contents"][0]["parts"][1]
+        assert document == {
+            "inlineData": {
+                "mimeType": PDF_MEDIA_TYPE,
+                "data": base64.b64encode(PDF_BYTES).decode(),
+            },
+        }
+
+
+# ---------------------------------------------------------------------------
+# OpenAI Responses API
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+def test_openai_responses_document_url():
+    with req_mock.Mocker() as m:
+        m.post("https://api.openai.com/v1/responses", json=_OPENAI_RESPONSES_RESPONSE)
+        adapter = UniversalLLMAPIAdapter(
+            organization="openai",
+            model="gpt-5.5",
+            api_key="dummy",
+        )
+        adapter.chat(
+            messages=[UserMessage("summarize", files=[DocumentPart(url=PDF_URL)])],
+        )
+
+        document = m.last_request.json()["input"][0]["content"][1]
+        assert document == {"type": "input_file", "file_url": PDF_URL}
+
+
+@pytest.mark.integration
+def test_openai_responses_document_bytes():
+    with req_mock.Mocker() as m:
+        m.post("https://api.openai.com/v1/responses", json=_OPENAI_RESPONSES_RESPONSE)
+        adapter = UniversalLLMAPIAdapter(
+            organization="openai",
+            model="gpt-5.5",
+            api_key="dummy",
+        )
+        adapter.chat(
+            messages=[
+                UserMessage(
+                    "summarize",
+                    files=[DocumentPart(data=PDF_BYTES, media_type=PDF_MEDIA_TYPE)],
+                )
+            ],
+        )
+
+        document = m.last_request.json()["input"][0]["content"][1]
+        assert document == {
+            "type": "input_file",
+            "filename": "document.pdf",
+            "file_data": f"data:{PDF_MEDIA_TYPE};base64,{base64.b64encode(PDF_BYTES).decode()}",
+        }
+
+
+# ---------------------------------------------------------------------------
+# OpenAI Chat Completions
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+def test_openai_chat_document_bytes():
+    with req_mock.Mocker() as m:
+        m.post("https://api.openai.com/v1/chat/completions", json=_OPENAI_CHAT_RESPONSE)
+        adapter = UniversalLLMAPIAdapter(
+            organization="openai",
+            model="gpt-4o",
+            api_key="dummy",
+        )
+        adapter.chat(
+            messages=[
+                UserMessage(
+                    "summarize",
+                    files=[DocumentPart(data=PDF_BYTES, media_type=PDF_MEDIA_TYPE)],
+                )
+            ],
+        )
+
+        document = m.last_request.json()["messages"][0]["content"][1]
+        assert document == {
+            "type": "file",
+            "file": {
+                "filename": "document.pdf",
+                "file_data": f"data:{PDF_MEDIA_TYPE};base64,{base64.b64encode(PDF_BYTES).decode()}",
+            },
+        }
+
+
+@pytest.mark.integration
+def test_openai_chat_document_url_raises_before_request():
+    with req_mock.Mocker() as m:
+        m.post("https://api.openai.com/v1/chat/completions", json=_OPENAI_CHAT_RESPONSE)
+        adapter = UniversalLLMAPIAdapter(
+            organization="openai",
+            model="gpt-4o",
+            api_key="dummy",
+        )
+
+        with pytest.raises(ValueError, match="does not support DocumentPart URL"):
+            adapter.chat(
+                messages=[UserMessage("summarize", files=[DocumentPart(url=PDF_URL)])],
+            )
+        assert not m.called

--- a/tests/unit/models/messages/test_chat_message.py
+++ b/tests/unit/models/messages/test_chat_message.py
@@ -3,7 +3,7 @@ import json
 
 import pytest
 
-from src.llm_api_adapter.models.messages.file_parts import ImagePart
+from src.llm_api_adapter.models.messages.file_parts import DocumentPart, ImagePart
 from src.llm_api_adapter.models.messages.chat_message import (
     AIMessage,
     Message,
@@ -928,3 +928,140 @@ def test_messages_normalize_dict_file_part_passthrough():
     img = ImagePart(url="https://example.com/a.gif")
     msgs = Messages(items=[])
     assert msgs._normalize_dict_file_part(img) is img
+
+
+# ---------------------------------------------------------------------------
+# UserMessage.files — DocumentPart provider serialization
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_user_message_to_anthropic_with_url_document():
+    u = UserMessage("summarize", files=[DocumentPart(url="https://example.com/report.pdf")])
+    result = u.to_anthropic()
+    assert result["content"][1] == {
+        "type": "document",
+        "source": {"type": "url", "url": "https://example.com/report.pdf"},
+    }
+
+
+@pytest.mark.unit
+def test_user_message_to_anthropic_with_bytes_document():
+    raw = b"%PDF"
+    u = UserMessage("summarize", files=[DocumentPart(data=raw, media_type="application/pdf")])
+    assert u.to_anthropic()["content"][1] == {
+        "type": "document",
+        "source": {
+            "type": "base64",
+            "media_type": "application/pdf",
+            "data": base64.b64encode(raw).decode(),
+        },
+    }
+
+
+@pytest.mark.unit
+def test_user_message_to_google_with_url_document():
+    u = UserMessage("summarize", files=[DocumentPart(url="https://example.com/report.pdf")])
+    assert u.to_google()["parts"][1] == {
+        "fileData": {
+            "mimeType": "application/pdf",
+            "fileUri": "https://example.com/report.pdf",
+        },
+    }
+
+
+@pytest.mark.unit
+def test_user_message_to_google_with_bytes_document():
+    raw = b"%PDF"
+    u = UserMessage("summarize", files=[DocumentPart(data=raw, media_type="application/pdf")])
+    assert u.to_google()["parts"][1] == {
+        "inlineData": {
+            "mimeType": "application/pdf",
+            "data": base64.b64encode(raw).decode(),
+        },
+    }
+
+
+@pytest.mark.unit
+def test_user_message_to_openai_responses_with_url_document():
+    u = UserMessage("summarize", files=[DocumentPart(url="https://example.com/report.pdf")])
+    assert u.to_openai_responses_input()[0]["content"][1] == {
+        "type": "input_file",
+        "file_url": "https://example.com/report.pdf",
+    }
+
+
+@pytest.mark.unit
+def test_user_message_to_openai_responses_with_bytes_document():
+    raw = b"%PDF"
+    u = UserMessage("summarize", files=[DocumentPart(data=raw, media_type="application/pdf")])
+    assert u.to_openai_responses_input()[0]["content"][1] == {
+        "type": "input_file",
+        "filename": "document.pdf",
+        "file_data": f"data:application/pdf;base64,{base64.b64encode(raw).decode()}",
+    }
+
+
+@pytest.mark.unit
+def test_user_message_to_openai_chat_with_url_document_raises():
+    u = UserMessage("summarize", files=[DocumentPart(url="https://example.com/report.pdf")])
+    with pytest.raises(ValueError, match="does not support DocumentPart URL"):
+        u.to_openai()
+
+
+@pytest.mark.unit
+def test_user_message_to_openai_chat_with_bytes_document():
+    raw = b"%PDF"
+    u = UserMessage("summarize", files=[DocumentPart(data=raw, media_type="application/pdf")])
+    assert u.to_openai()["content"][1] == {
+        "type": "file",
+        "file": {
+            "filename": "document.pdf",
+            "file_data": f"data:application/pdf;base64,{base64.b64encode(raw).decode()}",
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Messages normalization — DocumentPart wire formats
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_messages_normalize_document_file_part_formats():
+    msgs = Messages(items=[])
+    raw = b"%PDF"
+    data_uri = f"data:application/pdf;base64,{base64.b64encode(raw).decode()}"
+
+    parts = [
+        msgs._normalize_dict_file_part({
+            "type": "document",
+            "source": {"type": "url", "url": "https://example.com/report.pdf"},
+        }),
+        msgs._normalize_dict_file_part({
+            "type": "document",
+            "source": {
+                "type": "base64",
+                "media_type": "application/pdf",
+                "data": base64.b64encode(raw).decode(),
+            },
+        }),
+        msgs._normalize_dict_file_part({
+            "type": "input_file",
+            "file_url": "https://example.com/report.pdf",
+        }),
+        msgs._normalize_dict_file_part({"type": "input_file", "file_data": data_uri}),
+        msgs._normalize_dict_file_part({
+            "type": "file",
+            "file": {"file_data": data_uri},
+        }),
+    ]
+
+    assert isinstance(parts[0], DocumentPart)
+    assert parts[0].url == "https://example.com/report.pdf"
+    assert isinstance(parts[1], DocumentPart)
+    assert parts[1].data == raw
+    assert isinstance(parts[2], DocumentPart)
+    assert parts[2].url == "https://example.com/report.pdf"
+    assert isinstance(parts[3], DocumentPart)
+    assert parts[3]._get_media_type() == "application/pdf"
+    assert isinstance(parts[4], DocumentPart)
+    assert parts[4]._get_media_type() == "application/pdf"

--- a/tests/unit/models/messages/test_file_parts.py
+++ b/tests/unit/models/messages/test_file_parts.py
@@ -2,7 +2,11 @@ import base64
 
 import pytest
 
-from src.llm_api_adapter.models.messages.file_parts import FilePart, ImagePart
+from src.llm_api_adapter.models.messages.file_parts import (
+    DocumentPart,
+    FilePart,
+    ImagePart,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -139,3 +143,43 @@ def test_image_part_data_with_non_image_media_type_raises():
 def test_image_part_data_uri_in_url_resolves_media_type():
     img = ImagePart(url="data:image/webp;base64,abc")
     assert img._get_media_type() == "image/webp"
+
+
+# ---------------------------------------------------------------------------
+# DocumentPart — validation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_document_part_url_auto_detects_pdf_media_type():
+    doc = DocumentPart(url="https://example.com/report.pdf")
+    assert doc.media_type == "application/pdf"
+
+
+@pytest.mark.unit
+def test_document_part_data_with_pdf_media_type_ok():
+    doc = DocumentPart(data=b"%PDF", media_type="application/pdf")
+    assert doc.media_type == "application/pdf"
+
+
+@pytest.mark.unit
+def test_document_part_url_without_extension_raises():
+    with pytest.raises(ValueError, match="Cannot detect document"):
+        DocumentPart(url="https://api.example.com/report")
+
+
+@pytest.mark.unit
+def test_document_part_url_with_non_pdf_extension_raises():
+    with pytest.raises(ValueError, match="application/pdf"):
+        DocumentPart(url="https://example.com/photo.jpg")
+
+
+@pytest.mark.unit
+def test_document_part_data_with_non_pdf_media_type_raises():
+    with pytest.raises(ValueError, match="application/pdf"):
+        DocumentPart(data=b"image", media_type="image/jpeg")
+
+
+@pytest.mark.unit
+def test_document_part_data_uri_resolves_pdf_media_type():
+    doc = DocumentPart(url="data:application/pdf;base64,JVBERg==")
+    assert doc._get_media_type() == "application/pdf"


### PR DESCRIPTION
- Add `DocumentPart` support for PDF files.
- Serialize PDF input for Anthropic, Google, and OpenAI.
- Support URL and bytes-based documents.
- Refactor file-part normalization into explicit helpers.
- Add unit, integration, and E2E tests.
- Update documentation and bump version to `0.5.1`.