### PR TITLE
feat: add synchronous streaming support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Calling an LLM from Python currently means one of three paths: lock yourself to 
 | Unified reasoning control | ✓               | partial¹      | partial¹      | ✗            |
 | Built-in cost accounting  | ✓               | ✓             | via callbacks | ✗            |
 | Unified error hierarchy   | ✓               | partial       | ✗             | ✗            |
-| Async / streaming         | ✗               | ✓             | ✓             | ✓            |
+| Sync streaming            | ✓               | ✓             | ✓            | ✓            |
+| Async API                 | ✗               | ✓             | ✓            | ✓            |
 | Number of providers       | 3               | 100+          | 50+           | 1            |
 
 ¹ LiteLLM and LangChain expose reasoning via provider-specific parameters — there is no single unified parameter that works identically across providers.
@@ -44,6 +45,7 @@ Calling an LLM from Python currently means one of three paths: lock yourself to 
 
 ## Features
 
+- **Synchronous Streaming**: Iterate normalized text deltas with `stream_chat()` across OpenAI, Anthropic, and Google; receive completed tool calls and the final normalized `ChatResponse` through optional callbacks.
 - **Vision Input**: Send images alongside text via `ImagePart` — URL or raw bytes, all providers handled automatically.
 - **Tool / Function Calling**: Provider-agnostic tool definitions and normalized tool calls in `ChatResponse.tool_calls`.
 - **Strict JSON Mode**: Pass a JSON Schema to `chat()` and get a parsed object in `ChatResponse.parsed_json` — provider normalization is handled automatically.
@@ -131,6 +133,37 @@ print(response.content)
 ```
 > **Note**  
 > The adapter automatically normalizes message input — you can mix custom message classes and OpenAI-style dicts in one list.
+
+## Streaming
+
+`stream_chat()` is the synchronous streaming counterpart to `chat()`. It yields normalized visible text deltas as `str`, independently of the provider's native streaming event format.
+
+```python
+from llm_api_adapter import UniversalLLMAPIAdapter
+
+adapter = UniversalLLMAPIAdapter(
+    organization="openai",
+    model="gpt-5.6-sol",
+    api_key="...",
+)
+
+chunks = []
+for delta in adapter.stream_chat(
+    messages=[{"role": "user", "content": "Explain SSE in one sentence."}],
+    on_delta=chunks.append,
+    on_tool_call=lambda call: print(call.name, call.arguments),
+    on_done=lambda response: print(response.usage),
+):
+    print(delta, end="", flush=True)
+```
+
+- `on_delta(delta)` is called for every yielded visible text delta.
+- `on_tool_call(tool_call)` receives only completed, normalized `ToolCall` objects after the provider stream finishes.
+- `on_done(response)` receives the finalized `ChatResponse`, including usage, pricing, parsed structured output, and any tool calls.
+
+Streaming in v0.6.0 is synchronous and text-first. Async streaming, buffer/backpressure controls, a universal provider-event type, partial tool arguments, and tool-call sequencing are deferred to later releases.
+
+Provider event references: [OpenAI Responses streaming](https://platform.openai.com/docs/api-reference/responses-streaming), [Anthropic streaming](https://platform.claude.com/docs/en/build-with-claude/streaming), and [Google `streamGenerateContent`](https://ai.google.dev/api/generate-content).
 
 ## Handling Errors
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-api-adapter"
-version = "0.5.1"
+version = "0.6.0"
 description = "Lightweight, pluggable adapter for multiple LLM APIs (OpenAI, Anthropic, Google)"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/llm_api_adapter/adapters/anthropic_adapter.py
+++ b/src/llm_api_adapter/adapters/anthropic_adapter.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import json
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterator, List, Mapping, Optional
 import warnings
 
-from ..adapters.base_adapter import LLMAdapterBase
-from ..errors.llm_api_error import LLMAPIError
+from ..adapters.base_adapter import LLMAdapterBase, OnDelta, OnDone, OnToolCall
+from ..errors.llm_api_error import InvalidToolArgumentsError, LLMAPIError
 from ..errors.config_errors import LLMReasoningLevelError
 from ..llms.anthropic.sync_client import ClaudeSyncClient
 from ..models.messages.chat_message import Message, Messages
@@ -113,6 +114,280 @@ class AnthropicAdapter(LLMAdapterBase):
         except Exception as e:
             error_message = getattr(e, "text", None) or str(e)
             self.handle_error(error=e, error_message=error_message)
+
+    def stream_chat(
+        self,
+        messages: List[Message] | Messages,
+        max_tokens: int,
+        temperature: float = 1.0,
+        top_p: float = 1.0,
+        reasoning_level: Optional[str | int] = None,
+        timeout_s: Optional[float] = None,
+        *,
+        tools: Optional[List[ToolSpec]] = None,
+        tool_choice: Optional[str | dict] = None,
+        parallel_tool_calls: Optional[bool] = None,
+        previous_response: Optional[ChatResponse] = None,
+        json_schema: Optional[dict] = None,
+        response_model: Optional[Any] = None,
+        on_delta: Optional[OnDelta] = None,
+        on_tool_call: Optional[OnToolCall] = None,
+        on_done: Optional[OnDone] = None,
+    ) -> Iterator[str]:
+        temperature = self._validate_parameter("temperature", temperature, 0, 2)
+        top_p = self._validate_parameter("top_p", top_p, 0, 1)
+        self._validate_tools(tools)
+        effective_schema = self._resolve_json_schema(json_schema, response_model, tools)
+        normalized_tool_choice = self._normalize_tool_choice(tool_choice, tools)
+        normalized_messages = self._normalize_messages(messages)
+        params = self._build_stream_params(
+            normalized_messages=normalized_messages,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
+            reasoning_level=reasoning_level,
+            timeout_s=timeout_s,
+            tools=tools,
+            normalized_tool_choice=normalized_tool_choice,
+            parallel_tool_calls=parallel_tool_calls,
+            effective_schema=effective_schema,
+        )
+        _ = previous_response
+        client = ClaudeSyncClient(api_key=self.api_key)
+        events = client.stream(**params)
+        yield from self._consume_stream(
+            events,
+            effective_schema,
+            response_model,
+            on_delta,
+            on_tool_call,
+            on_done,
+        )
+
+    def _build_stream_params(
+        self,
+        *,
+        normalized_messages: Messages,
+        max_tokens: int,
+        temperature: float,
+        top_p: float,
+        reasoning_level: Optional[str | int],
+        timeout_s: Optional[float],
+        tools: Optional[List[ToolSpec]],
+        normalized_tool_choice: Optional[str],
+        parallel_tool_calls: Optional[bool],
+        effective_schema: Optional[dict],
+    ) -> Dict[str, Any]:
+        system_prompt, transformed_messages = normalized_messages.to_anthropic()
+        params: Dict[str, Any] = {
+            "model": self.model,
+            "messages": transformed_messages,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "top_p": top_p,
+            "system": system_prompt,
+            "timeout_s": timeout_s,
+            "is_adaptive_thinking": self.is_adaptive_thinking,
+        }
+        if tools:
+            params["tools"] = [self._to_anthropic_tool(tool) for tool in tools]
+        if normalized_tool_choice is not None:
+            params["tool_choice"] = self._to_anthropic_tool_choice(
+                normalized_tool_choice
+            )
+        if parallel_tool_calls is False:
+            params["disable_parallel_tool_use"] = True
+        elif parallel_tool_calls is True:
+            params["disable_parallel_tool_use"] = False
+        if effective_schema is not None:
+            params["output_config"] = {
+                "format": {
+                    "type": "json_schema",
+                    "schema": self._enforce_strict_schema(effective_schema),
+                }
+            }
+        if reasoning_level:
+            normalized_reasoning_level = self._normalize_reasoning_level(reasoning_level)
+            if normalized_reasoning_level:
+                if not self.is_adaptive_thinking:
+                    self.validate_reasoning_and_tokens(
+                        max_tokens=max_tokens,
+                        reasoning_level=reasoning_level,
+                        normalized_reasoning_level=normalized_reasoning_level,
+                    )
+                params["budget_tokens"] = normalized_reasoning_level
+            if self.is_reasoning:
+                effort = self._reasoning_level_to_effort(reasoning_level)
+                if effort:
+                    params["effort"] = effort
+        return {key: value for key, value in params.items() if value is not None}
+
+    def _consume_stream(
+        self,
+        events: Iterator[Any],
+        effective_schema: Optional[dict],
+        response_model: Optional[Any],
+        on_delta: Optional[OnDelta],
+        on_tool_call: Optional[OnToolCall],
+        on_done: Optional[OnDone],
+    ) -> Iterator[str]:
+        message_data: Dict[str, Any] = {"model": self.model, "content": []}
+        content_blocks: Dict[int, Dict[str, Any]] = {}
+        input_json_fragments: Dict[int, List[str]] = {}
+        usage: Dict[str, Any] = {}
+        message_delta: Dict[str, Any] = {}
+
+        for event in self._iter_provider_stream_events(events):
+            payload = event.data if isinstance(event.data, Mapping) else {}
+            event_type = event.event or payload.get("type")
+            if event_type == "message_start":
+                message_data = self._handle_message_start(payload, usage, message_data)
+            elif event_type == "content_block_start":
+                self._start_content_block(payload, content_blocks)
+            elif event_type == "content_block_delta":
+                yield from self._consume_content_block_delta(
+                    payload,
+                    content_blocks,
+                    input_json_fragments,
+                    on_delta,
+                )
+            elif event_type == "content_block_stop":
+                self._finalize_content_block(
+                    payload,
+                    content_blocks,
+                    input_json_fragments,
+                )
+            elif event_type == "message_delta":
+                self._handle_message_delta(payload, message_delta, usage)
+
+        chat_response = ChatResponse.from_anthropic_response(
+            self._build_stream_response(message_data, content_blocks, message_delta, usage)
+        )
+        self._finalize_stream_response(
+            chat_response,
+            effective_schema,
+            response_model,
+            on_tool_call,
+            on_done,
+        )
+
+    def _handle_message_start(
+        self,
+        payload: Mapping[str, Any],
+        usage: Dict[str, Any],
+        message_data: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        message = payload.get("message")
+        if not isinstance(message, Mapping):
+            return message_data
+        initial_usage = message.get("usage")
+        if isinstance(initial_usage, Mapping):
+            usage.update(initial_usage)
+        return dict(message)
+
+    def _start_content_block(
+        self,
+        payload: Mapping[str, Any],
+        content_blocks: Dict[int, Dict[str, Any]],
+    ) -> None:
+        index = payload.get("index")
+        block = payload.get("content_block")
+        if not isinstance(index, int) or not isinstance(block, Mapping):
+            return
+        content_blocks[index] = dict(block)
+        if block.get("type") == "text":
+            content_blocks[index]["text"] = str(block.get("text") or "")
+        elif block.get("type") == "tool_use":
+            current_input = block.get("input")
+            content_blocks[index]["input"] = (
+                dict(current_input) if isinstance(current_input, Mapping) else {}
+            )
+
+    def _consume_content_block_delta(
+        self,
+        payload: Mapping[str, Any],
+        content_blocks: Dict[int, Dict[str, Any]],
+        input_json_fragments: Dict[int, List[str]],
+        on_delta: Optional[OnDelta],
+    ) -> Iterator[str]:
+        index = payload.get("index")
+        delta = payload.get("delta")
+        if not isinstance(index, int) or not isinstance(delta, Mapping):
+            return
+        block = content_blocks.get(index)
+        if block is None:
+            return
+        if delta.get("type") == "text_delta":
+            text = delta.get("text")
+            if isinstance(text, str) and text:
+                block["text"] = f"{block.get('text', '')}{text}"
+                if on_delta is not None:
+                    on_delta(text)
+                yield text
+        elif delta.get("type") == "input_json_delta":
+            partial_json = delta.get("partial_json")
+            if isinstance(partial_json, str):
+                input_json_fragments.setdefault(index, []).append(partial_json)
+
+    def _finalize_content_block(
+        self,
+        payload: Mapping[str, Any],
+        content_blocks: Dict[int, Dict[str, Any]],
+        input_json_fragments: Dict[int, List[str]],
+    ) -> None:
+        index = payload.get("index")
+        block = content_blocks.get(index) if isinstance(index, int) else None
+        if not block or block.get("type") != "tool_use":
+            return
+        raw_input = "".join(input_json_fragments.get(index, []))
+        if not raw_input:
+            return
+        try:
+            parsed_input = json.loads(raw_input)
+        except json.JSONDecodeError as error:
+            raise InvalidToolArgumentsError(
+                detail=(
+                    "Anthropic tool input JSON parse failed "
+                    f"for tool={block.get('name')!r}: {error}"
+                )
+            ) from error
+        if not isinstance(parsed_input, dict):
+            raise InvalidToolArgumentsError(
+                detail=(
+                    "Anthropic tool input must decode to dict "
+                    f"for tool={block.get('name')!r}"
+                )
+            )
+        block["input"] = parsed_input
+
+    def _handle_message_delta(
+        self,
+        payload: Mapping[str, Any],
+        message_delta: Dict[str, Any],
+        usage: Dict[str, Any],
+    ) -> None:
+        delta = payload.get("delta")
+        if isinstance(delta, Mapping):
+            message_delta.update(delta)
+        delta_usage = payload.get("usage")
+        if isinstance(delta_usage, Mapping):
+            usage.update(delta_usage)
+
+    def _build_stream_response(
+        self,
+        message_data: Dict[str, Any],
+        content_blocks: Dict[int, Dict[str, Any]],
+        message_delta: Dict[str, Any],
+        usage: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        final_response = dict(message_data)
+        final_response["content"] = [
+            content_blocks[index] for index in sorted(content_blocks)
+        ]
+        final_response.update(message_delta)
+        if usage:
+            final_response["usage"] = usage
+        return final_response
 
     def _to_anthropic_tool(self, tool: ToolSpec) -> Dict[str, Any]:
         payload: Dict[str, Any] = {

--- a/src/llm_api_adapter/adapters/base_adapter.py
+++ b/src/llm_api_adapter/adapters/base_adapter.py
@@ -6,14 +6,14 @@ from dataclasses import dataclass, field
 import json
 import logging
 import re
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, Iterator, List, Optional
 import warnings
 
 from ..errors.llm_api_error import InvalidToolSchemaError, JSONSchemaError, ToolChoiceError
 from ..llm_registry.llm_registry import Pricing, LLM_REGISTRY
 from ..models.messages.chat_message import Messages
 from ..models.responses.chat_response import ChatResponse
-from ..models.tools import ToolSpec
+from ..models.tools import ToolCall, ToolSpec
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +25,10 @@ REASONING_LEVELS_DEFAULT = {
 }
 
 TOOL_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
+
+OnDelta = Callable[[str], None]
+OnToolCall = Callable[[ToolCall], None]
+OnDone = Callable[[ChatResponse], None]
 
 
 @dataclass
@@ -70,6 +74,33 @@ class LLMAdapterBase(ABC):
     def chat(self, **kwargs) -> ChatResponse:
         """
         Generates a response based on the provided conversation.
+        """
+        raise NotImplementedError
+
+    def stream_chat(
+        self,
+        messages: Any,
+        max_tokens: Optional[int] = None,
+        temperature: float = 1.0,
+        top_p: float = 1.0,
+        reasoning_level: Optional[str | int] = None,
+        timeout_s: Optional[float] = None,
+        tools: Optional[List[ToolSpec]] = None,
+        tool_choice: Any = None,
+        parallel_tool_calls: Optional[bool] = None,
+        previous_response: Optional[ChatResponse] = None,
+        json_schema: Optional[dict] = None,
+        response_model: Optional[Any] = None,
+        on_delta: Optional[OnDelta] = None,
+        on_tool_call: Optional[OnToolCall] = None,
+        on_done: Optional[OnDone] = None,
+    ) -> Iterator[str]:
+        """Stream text deltas synchronously.
+
+        Provider adapters implement the transport and normalization in a
+        later layer.  Keeping the typed contract here preserves the existing
+        facade delegation while allowing the first streaming transport commit
+        to remain backward compatible with current adapters.
         """
         raise NotImplementedError
 

--- a/src/llm_api_adapter/adapters/base_adapter.py
+++ b/src/llm_api_adapter/adapters/base_adapter.py
@@ -9,7 +9,12 @@ import re
 from typing import Any, Callable, Dict, Iterator, List, Optional
 import warnings
 
-from ..errors.llm_api_error import InvalidToolSchemaError, JSONSchemaError, ToolChoiceError
+from ..errors.llm_api_error import (
+    InvalidToolSchemaError,
+    JSONSchemaError,
+    LLMAPIError,
+    ToolChoiceError,
+)
 from ..llm_registry.llm_registry import Pricing, LLM_REGISTRY
 from ..models.messages.chat_message import Messages
 from ..models.responses.chat_response import ChatResponse
@@ -77,6 +82,7 @@ class LLMAdapterBase(ABC):
         """
         raise NotImplementedError
 
+    @abstractmethod
     def stream_chat(
         self,
         messages: Any,
@@ -95,13 +101,7 @@ class LLMAdapterBase(ABC):
         on_tool_call: Optional[OnToolCall] = None,
         on_done: Optional[OnDone] = None,
     ) -> Iterator[str]:
-        """Stream text deltas synchronously.
-
-        Provider adapters implement the transport and normalization in a
-        later layer.  Keeping the typed contract here preserves the existing
-        facade delegation while allowing the first streaming transport commit
-        to remain backward compatible with current adapters.
-        """
+        """Stream normalized text deltas synchronously."""
         raise NotImplementedError
 
     @abstractmethod
@@ -344,6 +344,57 @@ class LLMAdapterBase(ABC):
                 return response_model.model_validate(parsed_json, strict=False)
             except Exception as e:
                 raise JSONSchemaError(detail=f"Response failed Pydantic validation: {e}")
+
+    def _iter_provider_stream_events(self, events: Iterator[Any]) -> Iterator[Any]:
+        """Yield provider events while preserving the adapter error contract.
+
+        Callback invocation deliberately happens in the provider adapter,
+        outside this generator, so user callback exceptions are not reported
+        as provider failures.
+        """
+        try:
+            yield from events
+        except LLMAPIError as error:
+            self.handle_error(error)
+        except Exception as error:
+            error_message = getattr(error, "text", None) or str(error)
+            self.handle_error(error=error, error_message=error_message)
+
+    def _finalize_stream_response(
+        self,
+        chat_response: ChatResponse,
+        effective_schema: Optional[dict],
+        response_model: Optional[Any],
+        on_tool_call: Optional[OnToolCall],
+        on_done: Optional[OnDone],
+    ) -> None:
+        """Apply normal response post-processing, then invoke stream callbacks."""
+        try:
+            chat_response.parsed_json = self._parse_json_response(
+                chat_response.content,
+                effective_schema,
+            )
+            chat_response.parsed_model = self._parse_response_model(
+                chat_response.parsed_json,
+                response_model,
+            )
+            if self.pricing:
+                chat_response.apply_pricing(
+                    price_input_per_token=self.pricing.in_per_token,
+                    price_output_per_token=self.pricing.out_per_token,
+                    currency=self.pricing.currency,
+                )
+        except LLMAPIError as error:
+            self.handle_error(error)
+        except Exception as error:
+            error_message = getattr(error, "text", None) or str(error)
+            self.handle_error(error=error, error_message=error_message)
+
+        for tool_call in chat_response.tool_calls or []:
+            if on_tool_call is not None:
+                on_tool_call(tool_call)
+        if on_done is not None:
+            on_done(chat_response)
 
     def handle_error(self, error: Exception, error_message: Optional[str] = None):
         err_msg = (

--- a/src/llm_api_adapter/adapters/google_adapter.py
+++ b/src/llm_api_adapter/adapters/google_adapter.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterator, List, Mapping, Optional
 import warnings
 
-from ..adapters.base_adapter import LLMAdapterBase
+from ..adapters.base_adapter import LLMAdapterBase, OnDelta, OnDone, OnToolCall
 from ..errors.llm_api_error import LLMAPIError
 from ..llms.google.sync_client import GeminiSyncClient
 from ..models.messages.chat_message import Message, Messages
@@ -117,6 +117,172 @@ class GoogleAdapter(LLMAdapterBase):
         except Exception as e:
             error_message = getattr(e, "text", None) or str(e)
             self.handle_error(error=e, error_message=error_message)
+
+    def stream_chat(
+        self,
+        messages: List[Message] | Messages,
+        max_tokens: Optional[int] = None,
+        temperature: float = 1.0,
+        top_p: float = 1.0,
+        reasoning_level: Optional[str | int] = None,
+        timeout_s: Optional[float] = None,
+        *,
+        tools: Optional[List[ToolSpec]] = None,
+        tool_choice: Optional[str | dict] = None,
+        parallel_tool_calls: Optional[bool] = None,
+        previous_response: Optional[ChatResponse] = None,
+        json_schema: Optional[dict] = None,
+        response_model: Optional[Any] = None,
+        on_delta: Optional[OnDelta] = None,
+        on_tool_call: Optional[OnToolCall] = None,
+        on_done: Optional[OnDone] = None,
+    ) -> Iterator[str]:
+        temperature = self._validate_parameter("temperature", temperature, 0, 2)
+        top_p = self._validate_parameter("top_p", top_p, 0, 1)
+        self._validate_tools(tools)
+        effective_schema = self._resolve_json_schema(json_schema, response_model, tools)
+        normalized_tool_choice = self._normalize_tool_choice(tool_choice, tools)
+        normalized_messages = self._normalize_messages(messages)
+        _ = previous_response
+        payload = self._build_stream_payload(
+            normalized_messages=normalized_messages,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
+            reasoning_level=reasoning_level,
+            tools=tools,
+            normalized_tool_choice=normalized_tool_choice,
+            effective_schema=effective_schema,
+        )
+        _ = parallel_tool_calls
+        client = GeminiSyncClient(self.api_key)
+        events = client.stream(model=self.model, timeout_s=timeout_s, **payload)
+        yield from self._consume_stream(
+            events,
+            effective_schema,
+            response_model,
+            on_delta,
+            on_tool_call,
+            on_done,
+        )
+
+    def _build_stream_payload(
+        self,
+        *,
+        normalized_messages: Messages,
+        max_tokens: Optional[int],
+        temperature: float,
+        top_p: float,
+        reasoning_level: Optional[str | int],
+        tools: Optional[List[ToolSpec]],
+        normalized_tool_choice: Optional[str],
+        effective_schema: Optional[dict],
+    ) -> Dict[str, Any]:
+        system_prompt, transformed_messages = normalized_messages.to_google()
+        generation_config: Dict[str, Any] = {
+            "maxOutputTokens": max_tokens,
+            "temperature": temperature,
+            "topP": top_p,
+        }
+        if effective_schema is not None:
+            generation_config["responseMimeType"] = "application/json"
+            generation_config["responseSchema"] = self._to_google_schema(effective_schema)
+        if reasoning_level:
+            normalized_reasoning_level = self._normalize_reasoning_level(reasoning_level)
+            if normalized_reasoning_level is not None:
+                generation_config["thinkingConfig"] = {
+                    "thinkingBudget": normalized_reasoning_level,
+                    "includeThoughts": False,
+                }
+        payload: Dict[str, Any] = {
+            "contents": transformed_messages,
+            "generationConfig": generation_config,
+        }
+        if system_prompt:
+            payload["system_instruction"] = {"parts": [{"text": system_prompt}]}
+        if tools:
+            payload["tools"] = [{
+                "functionDeclarations": [
+                    self._to_google_function_declaration(tool) for tool in tools
+                ]
+            }]
+        tool_config = self._to_google_tool_config(normalized_tool_choice)
+        if tool_config is not None:
+            payload["toolConfig"] = tool_config
+        return payload
+
+    def _consume_stream(
+        self,
+        events: Iterator[Any],
+        effective_schema: Optional[dict],
+        response_model: Optional[Any],
+        on_delta: Optional[OnDelta],
+        on_tool_call: Optional[OnToolCall],
+        on_done: Optional[OnDone],
+    ) -> Iterator[str]:
+        text_parts: List[str] = []
+        function_parts: List[Dict[str, Any]] = []
+        finish_reason: Optional[str] = None
+        usage_metadata: Dict[str, Any] = {}
+        response_metadata: Dict[str, Any] = {}
+
+        for event in self._iter_provider_stream_events(events):
+            chunk = event.data if isinstance(event.data, Mapping) else {}
+            for field in ("modelVersion", "responseId", "promptFeedback"):
+                if field in chunk:
+                    response_metadata[field] = chunk[field]
+            chunk_usage = chunk.get("usageMetadata")
+            if isinstance(chunk_usage, Mapping):
+                usage_metadata.update(chunk_usage)
+            candidates = chunk.get("candidates")
+            if not isinstance(candidates, list) or not candidates:
+                continue
+            candidate = candidates[0]
+            if not isinstance(candidate, Mapping):
+                continue
+            if candidate.get("finishReason") is not None:
+                finish_reason = str(candidate["finishReason"])
+            content = candidate.get("content")
+            parts = content.get("parts") if isinstance(content, Mapping) else []
+            if not isinstance(parts, list):
+                continue
+            for part in parts:
+                if not isinstance(part, Mapping):
+                    continue
+                text = part.get("text")
+                if (
+                    isinstance(text, str)
+                    and text
+                    and not part.get("thought", False)
+                ):
+                    text_parts.append(text)
+                    if on_delta is not None:
+                        on_delta(text)
+                    yield text
+                if isinstance(part.get("functionCall"), Mapping):
+                    function_parts.append(dict(part))
+
+        final_parts: List[Dict[str, Any]] = []
+        if text_parts:
+            final_parts.append({"text": "".join(text_parts)})
+        final_parts.extend(function_parts)
+        final_candidate: Dict[str, Any] = {"content": {"parts": final_parts}}
+        if finish_reason is not None:
+            final_candidate["finishReason"] = finish_reason
+        final_response: Dict[str, Any] = {
+            **response_metadata,
+            "candidates": [final_candidate],
+        }
+        if usage_metadata:
+            final_response["usageMetadata"] = usage_metadata
+        chat_response = ChatResponse.from_google_response(final_response)
+        self._finalize_stream_response(
+            chat_response,
+            effective_schema,
+            response_model,
+            on_tool_call,
+            on_done,
+        )
 
     # Fields not supported by Google's responseSchema subset of JSON Schema.
     _GOOGLE_SCHEMA_UNSUPPORTED = frozenset({"additionalProperties", "$schema", "$id", "$ref"})

--- a/src/llm_api_adapter/adapters/openai_adapter.py
+++ b/src/llm_api_adapter/adapters/openai_adapter.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import json
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterator, List, Mapping, Optional
 import warnings
 
-from ..adapters.base_adapter import LLMAdapterBase
+from ..adapters.base_adapter import LLMAdapterBase, OnDelta, OnDone, OnToolCall
 from ..errors.llm_api_error import LLMAPIError
 from ..llms.openai.sync_client import OpenAISyncClient
 from ..models.messages.chat_message import Message, Messages
@@ -140,6 +141,265 @@ class OpenAIAdapter(LLMAdapterBase):
         except Exception as e:
             error_message = getattr(e, "text", None) or str(e)
             self.handle_error(error=e, error_message=error_message)
+
+    def stream_chat(
+        self,
+        messages: List[Message] | Messages,
+        max_tokens: Optional[int] = None,
+        temperature: float = 1.0,
+        top_p: float = 1.0,
+        reasoning_level: Optional[str | int] = None,
+        timeout_s: Optional[float] = None,
+        tools: Optional[List[ToolSpec]] = None,
+        tool_choice: Any = None,
+        parallel_tool_calls: Optional[bool] = None,
+        previous_response: Optional[ChatResponse] = None,
+        json_schema: Optional[dict] = None,
+        response_model: Optional[Any] = None,
+        on_delta: Optional[OnDelta] = None,
+        on_tool_call: Optional[OnToolCall] = None,
+        on_done: Optional[OnDone] = None,
+    ) -> Iterator[str]:
+        temperature = self._validate_parameter("temperature", temperature, 0, 2)
+        top_p = self._validate_parameter("top_p", top_p, 0, 1)
+        self._validate_tools(tools)
+        effective_schema = self._resolve_json_schema(json_schema, response_model, tools)
+        normalized_tool_choice = self._normalize_tool_choice(tool_choice, tools)
+        client = OpenAISyncClient(api_key=self.api_key)
+        normalized_messages = self._normalize_messages(messages)
+        use_responses_api = client._should_use_responses_api(self.model)
+        params = self._build_stream_params(
+            normalized_messages=normalized_messages,
+            use_responses_api=use_responses_api,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
+            reasoning_level=reasoning_level,
+            tools=tools,
+            normalized_tool_choice=normalized_tool_choice,
+            parallel_tool_calls=parallel_tool_calls,
+            previous_response=previous_response,
+            effective_schema=effective_schema,
+        )
+        events = client.stream(timeout=timeout_s, **params)
+        if use_responses_api:
+            yield from self._consume_responses_stream(
+                events,
+                effective_schema,
+                response_model,
+                on_delta,
+                on_tool_call,
+                on_done,
+            )
+            return
+        yield from self._consume_chat_completions_stream(
+            events,
+            effective_schema,
+            response_model,
+            on_delta,
+            on_tool_call,
+            on_done,
+        )
+
+    def _build_stream_params(
+        self,
+        *,
+        normalized_messages: Messages,
+        use_responses_api: bool,
+        max_tokens: Optional[int],
+        temperature: float,
+        top_p: float,
+        reasoning_level: Optional[str | int],
+        tools: Optional[List[ToolSpec]],
+        normalized_tool_choice: Optional[str],
+        parallel_tool_calls: Optional[bool],
+        previous_response: Optional[ChatResponse],
+        effective_schema: Optional[dict],
+    ) -> Dict[str, Any]:
+        params: Dict[str, Any] = {
+            "model": self.model,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "top_p": top_p,
+            "reasoning_effort": self._normalize_reasoning_level(reasoning_level),
+        }
+        if use_responses_api:
+            params["input"] = normalized_messages.to_openai_responses_input()
+            params["tools"] = self._map_tools_to_openai_responses(tools)
+            params["tool_choice"] = self._map_tool_choice_to_openai_responses(
+                normalized_tool_choice
+            )
+            instructions = normalized_messages.to_openai_responses_instructions()
+            if instructions is not None:
+                params["instructions"] = instructions
+            if previous_response is not None and previous_response.response_id is not None:
+                params["previous_response_id"] = previous_response.response_id
+            if effective_schema is not None:
+                params["text"] = {
+                    "format": {
+                        "type": "json_schema",
+                        "name": "response",
+                        "strict": True,
+                        "schema": self._enforce_strict_schema(effective_schema),
+                    }
+                }
+        else:
+            params["messages"] = normalized_messages.to_openai()
+            params["tools"] = self._map_tools_to_openai(tools)
+            params["tool_choice"] = self._map_tool_choice_to_openai(
+                normalized_tool_choice
+            )
+            params["parallel_tool_calls"] = parallel_tool_calls
+            if effective_schema is not None:
+                params["response_format"] = {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "response",
+                        "strict": True,
+                        "schema": self._enforce_strict_schema(effective_schema),
+                    },
+                }
+        return {key: value for key, value in params.items() if value is not None}
+
+    def _consume_responses_stream(
+        self,
+        events: Iterator[Any],
+        effective_schema: Optional[dict],
+        response_model: Optional[Any],
+        on_delta: Optional[OnDelta],
+        on_tool_call: Optional[OnToolCall],
+        on_done: Optional[OnDone],
+    ) -> Iterator[str]:
+        final_response: Optional[dict] = None
+        response_metadata: Dict[str, Any] = {}
+        text_parts: List[str] = []
+        function_calls: Dict[str, Dict[str, Any]] = {}
+        for event in self._iter_provider_stream_events(events):
+            payload = event.data if isinstance(event.data, Mapping) else {}
+            event_type = event.event or payload.get("type")
+            response_data = payload.get("response")
+            if isinstance(response_data, Mapping):
+                response_metadata.update(response_data)
+            if event_type == "response.output_text.delta":
+                delta = payload.get("delta")
+                if isinstance(delta, str) and delta:
+                    text_parts.append(delta)
+                    if on_delta is not None:
+                        on_delta(delta)
+                    yield delta
+            elif event_type in (
+                "response.function_call_arguments.delta",
+                "response.function_call_arguments.done",
+            ):
+                call_key = str(
+                    payload.get("call_id")
+                    or payload.get("item_id")
+                    or payload.get("output_index")
+                    or len(function_calls)
+                )
+                call = function_calls.setdefault(
+                    call_key,
+                    {"type": "function_call", "arguments": ""},
+                )
+                call["call_id"] = payload.get("call_id") or call.get("call_id")
+                call["id"] = payload.get("item_id") or call.get("id")
+                call["name"] = payload.get("name") or call.get("name")
+                if event_type.endswith(".delta") and isinstance(payload.get("delta"), str):
+                    call["arguments"] = f"{call.get('arguments', '')}{payload['delta']}"
+                elif "arguments" in payload:
+                    call["arguments"] = payload["arguments"]
+            elif event_type == "response.completed" and isinstance(response_data, Mapping):
+                final_response = dict(response_data)
+        if final_response is None:
+            output: List[Dict[str, Any]] = []
+            if text_parts:
+                output.append({
+                    "type": "message",
+                    "content": [{"type": "output_text", "text": "".join(text_parts)}],
+                })
+            output.extend(function_calls.values())
+            final_response = {
+                **response_metadata,
+                "model": response_metadata.get("model", self.model),
+                "output": output,
+                "status": response_metadata.get("status", "completed"),
+            }
+        self._finalize_stream_response(
+            ChatResponse.from_openai_responses_response(final_response),
+            effective_schema,
+            response_model,
+            on_tool_call,
+            on_done,
+        )
+
+    def _consume_chat_completions_stream(
+        self,
+        events: Iterator[Any],
+        effective_schema: Optional[dict],
+        response_model: Optional[Any],
+        on_delta: Optional[OnDelta],
+        on_tool_call: Optional[OnToolCall],
+        on_done: Optional[OnDone],
+    ) -> Iterator[str]:
+        text_parts: List[str] = []
+        tool_calls: Dict[int, Dict[str, Any]] = {}
+        legacy_response: Dict[str, Any] = {"model": self.model, "choices": []}
+        finish_reason: Optional[str] = None
+        for event in self._iter_provider_stream_events(events):
+            payload = event.data if isinstance(event.data, Mapping) else {}
+            for field in ("id", "model", "created", "usage"):
+                if field in payload:
+                    legacy_response[field] = payload[field]
+            choices = payload.get("choices")
+            if not isinstance(choices, list):
+                continue
+            for choice in choices:
+                if not isinstance(choice, Mapping) or choice.get("index", 0) != 0:
+                    continue
+                delta = choice.get("delta") or {}
+                if not isinstance(delta, Mapping):
+                    delta = {}
+                content = delta.get("content")
+                if isinstance(content, str) and content:
+                    text_parts.append(content)
+                    if on_delta is not None:
+                        on_delta(content)
+                    yield content
+                raw_tool_calls = delta.get("tool_calls")
+                if isinstance(raw_tool_calls, list):
+                    for raw_tool_call in raw_tool_calls:
+                        if not isinstance(raw_tool_call, Mapping):
+                            continue
+                        index = raw_tool_call.get("index")
+                        if not isinstance(index, int):
+                            index = len(tool_calls)
+                        tool_call = tool_calls.setdefault(index, {"function": {"arguments": ""}})
+                        for field in ("id", "type"):
+                            if raw_tool_call.get(field) is not None:
+                                tool_call[field] = raw_tool_call[field]
+                        function = raw_tool_call.get("function") or {}
+                        if isinstance(function, Mapping):
+                            target = tool_call["function"]
+                            if function.get("name") is not None:
+                                target["name"] = function["name"]
+                            arguments = function.get("arguments")
+                            if isinstance(arguments, str):
+                                target["arguments"] = f"{target.get('arguments', '')}{arguments}"
+                            elif isinstance(arguments, dict):
+                                target["arguments"] = arguments
+                if choice.get("finish_reason") is not None:
+                    finish_reason = choice["finish_reason"]
+        message: Dict[str, Any] = {"content": "".join(text_parts) or None}
+        if tool_calls:
+            message["tool_calls"] = [tool_calls[index] for index in sorted(tool_calls)]
+        legacy_response["choices"] = [{"message": message, "finish_reason": finish_reason}]
+        self._finalize_stream_response(
+            ChatResponse.from_openai_response(legacy_response),
+            effective_schema,
+            response_model,
+            on_tool_call,
+            on_done,
+        )
 
     def _map_tools_to_openai(
         self,

--- a/src/llm_api_adapter/llms/anthropic/sync_client.py
+++ b/src/llm_api_adapter/llms/anthropic/sync_client.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 import logging
+from typing import Iterator, Mapping
 
 import requests
 
@@ -11,6 +12,7 @@ from ...errors.llm_api_error import (
     LLMAPIServerError,
     LLMAPITimeoutError,
 )
+from ..streaming import SSEEvent, stream_request
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +38,15 @@ class ClaudeSyncClient:
         payload = self._prepare_chat_payload_for_model(model, kwargs)
         response = self._send_request(url, payload, timeout_s)
         return response.json()
+
+    def stream(
+        self, model: str, timeout_s: float | None = None, **kwargs
+    ) -> Iterator[SSEEvent]:
+        """Stream raw Messages API SSE events without interpreting content blocks."""
+        url = f"{self.endpoint}/messages"
+        payload = self._prepare_chat_payload_for_model(model, kwargs)
+        payload["stream"] = True
+        return self._stream_request(url, payload, timeout_s)
 
     def _prepare_chat_payload_for_model(self, model: str, kwargs: dict) -> dict:
         budget_tokens = kwargs.pop("budget_tokens", None)
@@ -73,6 +84,36 @@ class ClaudeSyncClient:
             raise LLMAPIClientError(detail=str(e))
         return response
 
+    def _stream_request(
+        self, url: str, payload: dict, timeout_s: float | None = None
+    ) -> Iterator[SSEEvent]:
+        events = stream_request(
+            url,
+            headers=self._headers(),
+            payload=payload,
+            timeout=timeout_s,
+            http_error_handler=self._handle_http_error,
+            stream_error_handler=self._handle_stream_error,
+        )
+        try:
+            yield from events
+        finally:
+            events.close()
+
+    def _handle_stream_error(self, event: SSEEvent) -> None:
+        payload = event.data if isinstance(event.data, Mapping) else {}
+        error = payload.get("error")
+        error = error if isinstance(error, Mapping) else payload
+
+        error_type = error.get("type") or error.get("code")
+        error_message = error.get("message")
+        detail = str(error_message or error_type or payload)
+        self._raise_mapped_error(
+            status_code=None,
+            error_type=str(error_type) if error_type else None,
+            detail=detail,
+        )
+
     def _handle_http_error(self, http_err):
         status_code = http_err.response.status_code
         try:
@@ -83,21 +124,39 @@ class ClaudeSyncClient:
             error_type = None
             error_message = None
         detail = error_message or str(http_err)
+        self._raise_mapped_error(status_code, error_type, detail)
+
+    @staticmethod
+    def _raise_mapped_error(
+        status_code: int | None, error_type: str | None, detail: str
+    ) -> None:
         error_map = {
             401: LLMAPIAuthorizationError,
             429: LLMAPIRateLimitError,
         }
         if status_code in error_map:
             raise error_map[status_code](detail=detail)
-        elif error_type in LLMAPIAuthorizationError.anthropic_api_errors:
+        if error_type in (
+            *LLMAPIAuthorizationError.anthropic_api_errors,
+            "authentication_error",
+            "permission_error",
+        ):
             raise LLMAPIAuthorizationError(detail=detail)
-        elif error_type in LLMAPIRateLimitError.anthropic_api_errors:
+        if error_type in (
+            *LLMAPIRateLimitError.anthropic_api_errors,
+            "rate_limit_error",
+        ):
             raise LLMAPIRateLimitError(detail=detail)
-        elif error_type in LLMAPITokenLimitError.anthropic_api_errors:
+        if error_type in LLMAPITokenLimitError.anthropic_api_errors:
             raise LLMAPITokenLimitError(detail=detail)
-        elif 400 <= status_code < 500:
-            raise LLMAPIClientError(detail=detail)
-        elif 500 <= status_code < 600:
+        if error_type in (
+            *LLMAPIServerError.anthropic_api_errors,
+            "api_error",
+            "overloaded_error",
+        ):
             raise LLMAPIServerError(detail=detail)
-        else:
+        if status_code is not None and 400 <= status_code < 500:
             raise LLMAPIClientError(detail=detail)
+        if status_code is not None and 500 <= status_code < 600:
+            raise LLMAPIServerError(detail=detail)
+        raise LLMAPIClientError(detail=detail)

--- a/src/llm_api_adapter/llms/google/sync_client.py
+++ b/src/llm_api_adapter/llms/google/sync_client.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 import logging
+from typing import Iterator, Mapping
 
 import requests
 
@@ -10,6 +11,7 @@ from ...errors.llm_api_error import (
     LLMAPIServerError,
     LLMAPITimeoutError,
 )
+from ..streaming import SSEEvent, stream_request
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +35,14 @@ class GeminiSyncClient:
         payload = self._prepare_chat_payload_for_model(model, kwargs)
         response = self._send_request(url, payload, timeout_s)
         return response.json()
+
+    def stream(
+        self, model: str, timeout_s: float | None = None, **kwargs
+    ) -> Iterator[SSEEvent]:
+        """Stream raw GenerateContentResponse chunks from Gemini."""
+        url = f"{self.endpoint}/models/{model}:streamGenerateContent?alt=sse"
+        payload = self._prepare_chat_payload_for_model(model, kwargs)
+        return self._stream_request(url, payload, timeout_s)
 
     def _prepare_chat_payload_for_model(self, model: str, kwargs: dict) -> dict:
         gen_cfg = kwargs.get("generationConfig", {})
@@ -69,6 +79,46 @@ class GeminiSyncClient:
             raise LLMAPIClientError(detail=str(e))
         return response
 
+    def _stream_request(
+        self, url: str, payload: dict, timeout_s: float | None = None
+    ) -> Iterator[SSEEvent]:
+        events = stream_request(
+            url,
+            headers=self._headers(),
+            payload=payload,
+            timeout=timeout_s,
+            http_error_handler=self._handle_http_error,
+            stream_error_handler=self._handle_stream_error,
+        )
+        try:
+            for event in events:
+                if self._is_failed_stream_event(event):
+                    self._handle_stream_error(event)
+                yield event
+        finally:
+            events.close()
+
+    @staticmethod
+    def _is_failed_stream_event(event: SSEEvent) -> bool:
+        return (
+            isinstance(event.data, Mapping)
+            and isinstance(event.data.get("error"), Mapping)
+        )
+
+    def _handle_stream_error(self, event: SSEEvent) -> None:
+        payload = event.data if isinstance(event.data, Mapping) else {}
+        error = payload.get("error")
+        error = error if isinstance(error, Mapping) else payload
+        error_status = error.get("status") or error.get("code")
+        error_message = error.get("message")
+        detail = str(error_message or error_status or payload)
+        self._raise_mapped_error(
+            status_code=None,
+            error_status=str(error_status) if error_status else None,
+            error_message=str(error_message) if error_message else None,
+            detail=detail,
+        )
+
     def _handle_http_error(self, http_err):
         status_code = http_err.response.status_code
         try:
@@ -80,21 +130,34 @@ class GeminiSyncClient:
             error_status = ""
             error_message = None
         detail = error_message or str(http_err)
+        self._raise_mapped_error(status_code, error_status, error_message, detail)
+
+    def _raise_mapped_error(
+        self,
+        status_code: int | None,
+        error_status: str | None,
+        error_message: str | None,
+        detail: str,
+    ) -> None:
         if self._is_google_auth_error(status_code, error_status, error_message):
             raise LLMAPIAuthorizationError(detail=detail)
-        elif status_code == 429 or error_status in LLMAPIRateLimitError.google_api_errors:
+        if status_code == 429 or error_status in LLMAPIRateLimitError.google_api_errors:
             raise LLMAPIRateLimitError(detail=detail)
-        elif 400 <= status_code < 500:
+        if status_code is not None and 400 <= status_code < 500:
             raise LLMAPIClientError(detail=detail)
-        elif (
-            500 <= status_code < 600
+        if (
+            (status_code is not None and 500 <= status_code < 600)
             or error_status in LLMAPIServerError.google_api_errors
         ):
             raise LLMAPIServerError(detail=detail)
-        else:
-            raise LLMAPIClientError(detail=detail)
+        raise LLMAPIClientError(detail=detail)
 
-    def _is_google_auth_error(self, status_code, error_status, error_message: str | None) -> bool:
+    @staticmethod
+    def _is_google_auth_error(
+        status_code: int | None,
+        error_status: str | None,
+        error_message: str | None,
+    ) -> bool:
         if status_code in (401, 403):
             return True
         if error_status in LLMAPIAuthorizationError.google_api_errors:

--- a/src/llm_api_adapter/llms/openai/sync_client.py
+++ b/src/llm_api_adapter/llms/openai/sync_client.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 import logging
+from typing import Iterator, Mapping
 import requests
 import warnings
 
@@ -10,7 +11,9 @@ from ...errors.llm_api_error import (
     LLMAPIClientError,
     LLMAPIServerError,
     LLMAPITimeoutError,
+    LLMAPIUsageLimitError,
 )
+from ..streaming import SSEEvent, stream_request
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +38,12 @@ class OpenAISyncClient:
             return self.responses(model=model, timeout=timeout, **kwargs)
         return self.chat_completion(model=model, timeout=timeout, **kwargs)
 
+    def stream(self, model: str, timeout: float | None = None, **kwargs) -> Iterator[SSEEvent]:
+        """Stream raw OpenAI events from the API appropriate for ``model``."""
+        if self._should_use_responses_api(model):
+            return self.stream_responses(model=model, timeout=timeout, **kwargs)
+        return self.stream_chat_completion(model=model, timeout=timeout, **kwargs)
+
     def chat_completion(self, model: str, timeout: float | None = None, **kwargs):
         url = f"{self.endpoint}/chat/completions"
         payload = self._prepare_chat_payload_for_model(model, kwargs)
@@ -46,6 +55,24 @@ class OpenAISyncClient:
         payload = self._prepare_responses_payload_for_model(model, kwargs)
         response = self._send_request(url, payload, timeout)
         return response.json()
+
+    def stream_chat_completion(
+        self, model: str, timeout: float | None = None, **kwargs
+    ) -> Iterator[SSEEvent]:
+        """Stream raw Chat Completions SSE events without interpreting them."""
+        url = f"{self.endpoint}/chat/completions"
+        payload = self._prepare_chat_payload_for_model(model, kwargs)
+        payload["stream"] = True
+        return self._stream_request(url, payload, timeout)
+
+    def stream_responses(
+        self, model: str, timeout: float | None = None, **kwargs
+    ) -> Iterator[SSEEvent]:
+        """Stream raw Responses API SSE events without interpreting them."""
+        url = f"{self.endpoint}/responses"
+        payload = self._prepare_responses_payload_for_model(model, kwargs)
+        payload["stream"] = True
+        return self._stream_request(url, payload, timeout)
 
     def _should_use_responses_api(self, model: str) -> bool:
         return model.startswith("gpt-5")
@@ -94,6 +121,47 @@ class OpenAISyncClient:
             raise LLMAPIClientError(detail=str(e))
         return response
 
+    def _stream_request(
+        self, url: str, payload: dict, timeout: float | None = None
+    ) -> Iterator[SSEEvent]:
+        events = stream_request(
+            url,
+            headers=self._headers(),
+            payload=payload,
+            timeout=timeout,
+            http_error_handler=self._handle_http_error,
+            stream_error_handler=self._handle_stream_error,
+        )
+        try:
+            for event in events:
+                if self._is_failed_stream_event(event):
+                    self._handle_stream_error(event)
+                yield event
+        finally:
+            events.close()
+
+    @staticmethod
+    def _is_failed_stream_event(event: SSEEvent) -> bool:
+        if event.event == "response.failed":
+            return True
+        return isinstance(event.data, Mapping) and event.data.get("type") == "response.failed"
+
+    def _handle_stream_error(self, event: SSEEvent) -> None:
+        payload = event.data if isinstance(event.data, Mapping) else {}
+        response = payload.get("response")
+        response_error = response.get("error") if isinstance(response, Mapping) else None
+        error = response_error if isinstance(response_error, Mapping) else payload.get("error")
+        error = error if isinstance(error, Mapping) else payload
+
+        error_type = error.get("type") or error.get("code")
+        error_message = error.get("message")
+        detail = str(error_message or error_type or payload)
+        self._raise_mapped_error(
+            status_code=None,
+            error_type=str(error_type) if error_type else None,
+            detail=detail,
+        )
+
     def _handle_http_error(self, http_err):
         status_code = http_err.response.status_code
         try:
@@ -106,21 +174,44 @@ class OpenAISyncClient:
             error_type = None
             error_message = None
         detail = error_message or str(http_err)
+        self._raise_mapped_error(status_code, error_type, detail)
+
+    @staticmethod
+    def _raise_mapped_error(
+        status_code: int | None, error_type: str | None, detail: str
+    ) -> None:
         error_map = {
             401: LLMAPIAuthorizationError,
             429: LLMAPIRateLimitError,
         }
         if status_code in error_map:
             raise error_map[status_code](detail=detail)
-        elif error_type in LLMAPIAuthorizationError.openai_api_errors:
+        if error_type in (
+            *LLMAPIAuthorizationError.openai_api_errors,
+            "invalid_api_key",
+            "authentication_error",
+        ):
             raise LLMAPIAuthorizationError(detail=detail)
-        elif error_type in LLMAPIRateLimitError.openai_api_errors:
+        if error_type in (
+            *LLMAPIRateLimitError.openai_api_errors,
+            "rate_limit_exceeded",
+        ):
             raise LLMAPIRateLimitError(detail=detail)
-        elif error_type in LLMAPITokenLimitError.openai_api_errors:
+        if error_type in LLMAPITokenLimitError.openai_api_errors:
             raise LLMAPITokenLimitError(detail=detail)
-        elif 400 <= status_code < 500:
-            raise LLMAPIClientError(detail=detail)
-        elif 500 <= status_code < 600:
+        if error_type in LLMAPIUsageLimitError.openai_api_errors:
+            raise LLMAPIUsageLimitError(detail=detail)
+        if error_type in (
+            *LLMAPIServerError.openai_api_errors,
+            "server_error",
+            "internal_error",
+            "overloaded_error",
+        ):
             raise LLMAPIServerError(detail=detail)
-        else:
+        if error_type in (*LLMAPITimeoutError.openai_api_errors, "timeout"):
+            raise LLMAPITimeoutError(detail=detail)
+        if status_code is not None and 400 <= status_code < 500:
             raise LLMAPIClientError(detail=detail)
+        if status_code is not None and 500 <= status_code < 600:
+            raise LLMAPIServerError(detail=detail)
+        raise LLMAPIClientError(detail=detail)

--- a/src/llm_api_adapter/llms/openai/sync_client.py
+++ b/src/llm_api_adapter/llms/openai/sync_client.py
@@ -95,6 +95,15 @@ class OpenAISyncClient:
             if model in ("gpt-5", "gpt-5-nano", "gpt-5-mini") and reasoning_effort == "none":
                 reasoning_effort = "minimal"
             payload["reasoning"] = {"effort": reasoning_effort}
+        if model.startswith("gpt-5-nano"):
+            temperature = payload.pop("temperature", None)
+            if temperature not in (None, 1.0):
+                warning_message = (
+                    f"Parameter 'temperature' is not supported for model '{model}' "
+                    "and will be ignored."
+                )
+                warnings.warn(warning_message, stacklevel=2)
+                logger.warning(warning_message)
         if model.startswith("gpt-5") and "top_p" in payload:
             warning_message = (
                 f"Parameter 'top_p' is not supported for model '{model}' and will be ignored."

--- a/src/llm_api_adapter/llms/streaming.py
+++ b/src/llm_api_adapter/llms/streaming.py
@@ -1,0 +1,226 @@
+"""Shared synchronous SSE transport for provider streaming clients.
+
+This module deliberately knows only about the Server-Sent Events transport.
+Provider clients remain responsible for interpreting the decoded payloads.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import logging
+from typing import Any, Callable, Iterator, Mapping, Optional
+
+import requests
+
+from ..errors.llm_api_error import (
+    LLMAPIClientError,
+    LLMAPIError,
+    LLMAPIAuthorizationError,
+    LLMAPIRateLimitError,
+    LLMAPIServerError,
+    LLMAPITimeoutError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SSEEvent:
+    """Decoded transport event produced by :func:`iter_sse_events`.
+
+    ``event`` is the optional SSE event name and ``data`` is the decoded JSON
+    value.  ``done`` marks the provider-independent ``data: [DONE]`` sentinel.
+    This is an internal transport representation, not the public stream API.
+    """
+
+    event: Optional[str]
+    data: Any = None
+    done: bool = False
+
+
+HTTPErrorHandler = Callable[[requests.exceptions.HTTPError], Any]
+StreamErrorHandler = Callable[[SSEEvent], Any]
+
+
+def _decode_line(line: bytes | str) -> str:
+    if isinstance(line, bytes):
+        return line.decode("utf-8")
+    return str(line)
+
+
+def _build_event(event_name: Optional[str], data_lines: list[str]) -> Optional[SSEEvent]:
+    if not data_lines:
+        return None
+
+    if event_name and event_name.lower() in {"ping", "keep-alive", "keep_alive"}:
+        return None
+
+    raw_data = "\n".join(data_lines)
+    if raw_data.strip() == "[DONE]":
+        return SSEEvent(event=event_name, done=True)
+
+    try:
+        decoded_data = json.loads(raw_data)
+    except json.JSONDecodeError as exc:
+        raise LLMAPIClientError(
+            detail=f"Malformed SSE JSON data: {exc}"
+        ) from exc
+
+    return SSEEvent(event=event_name, data=decoded_data)
+
+
+def iter_sse_events(response: requests.Response) -> Iterator[SSEEvent]:
+    """Yield decoded SSE events and close ``response`` on every exit path.
+
+    The parser handles only SSE framing.  It ignores comments and transport
+    keep-alives, joins multiple ``data:`` lines with a newline, decodes JSON,
+    and recognizes ``[DONE]``.  Unknown fields and event names are preserved
+    or ignored without provider-specific interpretation.
+    """
+
+    event_name: Optional[str] = None
+    data_lines: list[str] = []
+
+    try:
+        try:
+            lines = response.iter_lines(decode_unicode=True)
+        except TypeError:
+            # Small test doubles and compatible response implementations may
+            # expose iter_lines() without the requests keyword argument.
+            lines = response.iter_lines()
+
+        for raw_line in lines:
+            line = _decode_line(raw_line).rstrip("\r\n")
+
+            if line == "":
+                event = _build_event(event_name, data_lines)
+                event_name = None
+                data_lines = []
+                if event is not None:
+                    yield event
+                    if event.done:
+                        return
+                continue
+
+            if line.startswith(":"):
+                continue
+
+            field, separator, value = line.partition(":")
+            if separator and value.startswith(" "):
+                value = value[1:]
+
+            if field == "event":
+                event_name = value
+            elif field == "data":
+                data_lines.append(value)
+
+        event = _build_event(event_name, data_lines)
+        if event is not None:
+            yield event
+    finally:
+        response.close()
+
+
+def _default_http_error_handler(http_err: requests.exceptions.HTTPError) -> None:
+    response = getattr(http_err, "response", None)
+    status_code = getattr(response, "status_code", None)
+    detail = str(http_err)
+
+    if status_code in (401, 403):
+        raise LLMAPIAuthorizationError(detail=detail)
+    if status_code == 429:
+        raise LLMAPIRateLimitError(detail=detail)
+    if status_code in (408, 504):
+        raise LLMAPITimeoutError(detail=detail)
+    if status_code is not None and 500 <= status_code < 600:
+        raise LLMAPIServerError(detail=detail)
+    raise LLMAPIClientError(detail=detail)
+
+
+def _stream_error_detail(event: SSEEvent) -> str:
+    payload = event.data
+    if isinstance(payload, Mapping):
+        error = payload.get("error")
+        if isinstance(error, Mapping):
+            code = error.get("type") or error.get("code")
+            message = error.get("message")
+            if code and message:
+                return f"{code}: {message}"
+            if message:
+                return str(message)
+            if code:
+                return str(code)
+        message = payload.get("message")
+        if message:
+            return str(message)
+        code = payload.get("code") or payload.get("type")
+        if code:
+            return str(code)
+    return str(payload)
+
+
+def _default_stream_error_handler(event: SSEEvent) -> None:
+    raise LLMAPIClientError(detail=_stream_error_detail(event))
+
+
+def _is_generic_stream_error(event: SSEEvent) -> bool:
+    if event.event and event.event.lower() == "error":
+        return True
+    return isinstance(event.data, Mapping) and event.data.get("type") == "error"
+
+
+def stream_request(
+    url: str,
+    *,
+    headers: Optional[Mapping[str, str]] = None,
+    payload: Any = None,
+    timeout: Optional[float] = None,
+    http_error_handler: Optional[HTTPErrorHandler] = None,
+    stream_error_handler: Optional[StreamErrorHandler] = None,
+) -> Iterator[SSEEvent]:
+    """Perform a synchronous streaming POST and yield decoded SSE events.
+
+    The request is made when the returned iterator is first consumed.  HTTP
+    errors are mapped through the supplied provider handler when available;
+    otherwise the shared status-code mapping is used.  Generic in-stream
+    ``error`` events use the same unified error hierarchy.
+    """
+
+    response: Optional[requests.Response] = None
+    parser_owns_response = False
+    try:
+        response = requests.post(
+            url,
+            headers=dict(headers or {}),
+            json=payload,
+            timeout=timeout,
+            stream=True,
+        )
+        response.raise_for_status()
+
+        parser_owns_response = True
+        for event in iter_sse_events(response):
+            if event.done:
+                return
+            if _is_generic_stream_error(event):
+                handler = stream_error_handler or _default_stream_error_handler
+                handler(event)
+                _default_stream_error_handler(event)
+            yield event
+    except LLMAPIError:
+        raise
+    except requests.exceptions.Timeout as exc:
+        logger.error("Streaming request timed out: %s", exc)
+        raise LLMAPITimeoutError(detail=str(exc)) from exc
+    except requests.exceptions.HTTPError as exc:
+        logger.error("Streaming HTTP error: %s", exc)
+        handler = http_error_handler or _default_http_error_handler
+        handler(exc)
+        _default_http_error_handler(exc)
+    except requests.exceptions.RequestException as exc:
+        logger.error("Streaming request exception: %s", exc)
+        raise LLMAPIClientError(detail=str(exc)) from exc
+    finally:
+        if response is not None and not parser_owns_response:
+            response.close()

--- a/src/llm_api_adapter/models/responses/chat_response.py
+++ b/src/llm_api_adapter/models/responses/chat_response.py
@@ -270,6 +270,7 @@ class ChatResponse:
                     )
                 )
         return cls(
+            model=api_response.get("modelVersion"),
             usage=usage,
             content=text_content,
             tool_calls=parsed_tool_calls,

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -57,6 +57,25 @@ def chat_with_retry():
 
 
 @pytest.fixture(scope="session")
+def stream_with_retry():
+    """Returns a helper that retries a complete stream on transient provider errors."""
+    _delays = [2, 4, 8]
+    _max_attempts = len(_delays)
+
+    def _call(adapter, **kwargs):
+        for attempt in range(_max_attempts):
+            try:
+                return list(adapter.stream_chat(**kwargs))
+            except (LLMAPIServerError, LLMAPIRateLimitError):
+                if attempt == _max_attempts - 1:
+                    raise
+                time.sleep(_delays[attempt])
+        return []
+
+    return _call
+
+
+@pytest.fixture(scope="session")
 def vision_image_bytes() -> bytes:
     return (_FIXTURES_DIR / "test_image.png").read_bytes()
 

--- a/tests/e2e/test_streaming.py
+++ b/tests/e2e/test_streaming.py
@@ -1,0 +1,53 @@
+import os
+
+import pytest
+
+from llm_api_adapter.models.messages.chat_message import UserMessage
+from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
+
+
+_STREAMING_SCENARIOS = [
+    pytest.param("openai", "gpt-5-nano", "OPENAI_API_KEY", id="openai-responses"),
+    pytest.param("openai", "gpt-4.1-mini", "OPENAI_API_KEY", id="openai-chat-completions"),
+    pytest.param("anthropic", "claude-haiku-4-5", "ANTHROPIC_API_KEY", id="anthropic"),
+    pytest.param("google", "gemini-2.5-flash", "GOOGLE_API_KEY", id="google"),
+]
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize(("organization", "model", "api_key_env"), _STREAMING_SCENARIOS)
+def test_stream_chat_returns_text_and_finalized_response(
+    organization,
+    model,
+    api_key_env,
+    stream_with_retry,
+):
+    api_key = os.getenv(api_key_env)
+    if not api_key:
+        pytest.skip(f"{api_key_env} is not configured")
+
+    adapter = UniversalLLMAPIAdapter(
+        organization=organization,
+        model=model,
+        api_key=api_key,
+    )
+    completed_responses = []
+    chunks = stream_with_retry(
+        adapter,
+        messages=[UserMessage("Reply with exactly: OK")],
+        max_tokens=64,
+        temperature=0,
+        timeout_s=60,
+        on_done=completed_responses.append,
+    )
+
+    assert "".join(chunks).strip()
+    assert len(completed_responses) == 1
+
+    response = completed_responses[0]
+    assert isinstance(response.model, str) and response.model
+    assert response.usage is not None
+    assert response.usage.input_tokens >= 0
+    assert response.usage.output_tokens >= 0
+    assert response.usage.total_tokens >= response.usage.input_tokens
+    assert isinstance(response.finish_reason, str) and response.finish_reason

--- a/tests/e2e/test_tools_auto_loop.py
+++ b/tests/e2e/test_tools_auto_loop.py
@@ -11,35 +11,44 @@ from llm_api_adapter.models.tools import ToolSpec
 from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
 
 
+FRUIT_POPULARITY = {
+    "strawberry": 73,
+    "banana": 41,
+    "orange": 58,
+}
+
+
 def run_tool(name, args):
     if name == "get_fruit_popularity":
         fruit = args["fruit"]
-        popularity = {
-            "strawberry": 73,
-            "banana": 41,
-            "orange": 58,
-        }
-        if fruit not in popularity:
+        if fruit not in FRUIT_POPULARITY:
             raise ValueError(f"Unknown fruit {fruit}")
 
         return {
             "fruit": fruit,
-            "popularity": popularity[fruit],
+            "popularity": FRUIT_POPULARITY[fruit],
         }
 
     raise ValueError(f"Unknown tool {name}")
 
 
 @pytest.mark.e2e
-def test_basic_auto_tool_loop_with_previous_response(subtests, iter_provider_models, chat_with_retry):
+@pytest.mark.parametrize("fruit, popularity", FRUIT_POPULARITY.items())
+def test_basic_auto_tool_loop_with_previous_response(
+    subtests, iter_provider_models, chat_with_retry, fruit, popularity
+):
     tools = [
         ToolSpec(
             name="get_fruit_popularity",
-            description="Return the popularity rating for a fruit.",
+            description="Return the exact integer popularity rating for a fruit.",
             json_schema={
                 "type": "object",
                 "properties": {
-                    "fruit": {"type": "string"},
+                    "fruit": {
+                        "type": "string",
+                        "enum": list(FRUIT_POPULARITY),
+                        "description": "The fruit whose popularity is requested.",
+                    },
                 },
                 "required": ["fruit"],
                 "additionalProperties": False,
@@ -57,8 +66,9 @@ def test_basic_auto_tool_loop_with_previous_response(subtests, iter_provider_mod
 
             messages = [
                 UserMessage(
-                    'What is the popularity of the fruit "strawberry"? '
-                    "Use the available tool if needed."
+                    f'What is the popularity of the fruit "{fruit}"? '
+                    f"Call get_fruit_popularity with fruit set to {fruit}, then state "
+                    "the exact integer rating from the tool result in your final answer."
                 )
             ]
 
@@ -88,7 +98,7 @@ def test_basic_auto_tool_loop_with_previous_response(subtests, iter_provider_mod
             for tc in first.tool_calls:
                 assert tc.name == "get_fruit_popularity"
                 assert isinstance(tc.arguments, dict)
-                assert tc.arguments["fruit"] == "strawberry"
+                assert tc.arguments["fruit"] == fruit
 
                 result = run_tool(tc.name, tc.arguments)
 
@@ -113,7 +123,7 @@ def test_basic_auto_tool_loop_with_previous_response(subtests, iter_provider_mod
                 f"{p['name']} / {model}: expected final natural-language answer, "
                 f"got tool_calls: {final.tool_calls!r}"
             )
-            assert "73" in final.content, (
-                f"{p['name']} / {model}: expected final answer to mention 73, "
+            assert str(popularity) in final.content, (
+                f"{p['name']} / {model}: expected final answer to mention {popularity}, "
                 f"got: {final.content!r}"
             )

--- a/tests/e2e/test_tools_auto_loop.py
+++ b/tests/e2e/test_tools_auto_loop.py
@@ -63,7 +63,7 @@ def test_basic_auto_tool_loop_with_previous_response(subtests, iter_provider_mod
 
             messages = [
                 UserMessage(
-                    "What is the popularity of a fruit? "
+                    "What is the popularity of the fruit banana? "
                     "Use the available tool to look it up."
                 )
             ]
@@ -72,7 +72,7 @@ def test_basic_auto_tool_loop_with_previous_response(subtests, iter_provider_mod
                 adapter,
                 messages=messages,
                 tools=tools,
-                tool_choice="any",
+                tool_choice="get_fruit_popularity",
                 max_tokens=512,
                 timeout_s=60,
             )

--- a/tests/e2e/test_tools_auto_loop.py
+++ b/tests/e2e/test_tools_auto_loop.py
@@ -33,14 +33,11 @@ def run_tool(name, args):
 
 
 @pytest.mark.e2e
-@pytest.mark.parametrize("fruit, popularity", FRUIT_POPULARITY.items())
-def test_basic_auto_tool_loop_with_previous_response(
-    subtests, iter_provider_models, chat_with_retry, fruit, popularity
-):
+def test_basic_auto_tool_loop_with_previous_response(subtests, iter_provider_models, chat_with_retry):
     tools = [
         ToolSpec(
             name="get_fruit_popularity",
-            description="Return the exact integer popularity rating for a fruit.",
+            description="Return the popularity rating for a fruit.",
             json_schema={
                 "type": "object",
                 "properties": {
@@ -66,9 +63,8 @@ def test_basic_auto_tool_loop_with_previous_response(
 
             messages = [
                 UserMessage(
-                    f'What is the popularity of the fruit "{fruit}"? '
-                    f"Call get_fruit_popularity with fruit set to {fruit}, then state "
-                    "the exact integer rating from the tool result in your final answer."
+                    "What is the popularity of a fruit? "
+                    "Use the available tool to look it up."
                 )
             ]
 
@@ -98,9 +94,11 @@ def test_basic_auto_tool_loop_with_previous_response(
             for tc in first.tool_calls:
                 assert tc.name == "get_fruit_popularity"
                 assert isinstance(tc.arguments, dict)
-                assert tc.arguments["fruit"] == fruit
+                fruit = tc.arguments["fruit"]
+                assert fruit in FRUIT_POPULARITY
 
                 result = run_tool(tc.name, tc.arguments)
+                assert result["popularity"] == FRUIT_POPULARITY[fruit]
 
                 messages.append(
                     ToolMessage(
@@ -122,8 +120,4 @@ def test_basic_auto_tool_loop_with_previous_response(
             assert not final.tool_calls, (
                 f"{p['name']} / {model}: expected final natural-language answer, "
                 f"got tool_calls: {final.tool_calls!r}"
-            )
-            assert str(popularity) in final.content, (
-                f"{p['name']} / {model}: expected final answer to mention {popularity}, "
-                f"got: {final.content!r}"
             )

--- a/tests/integration/test_streaming.py
+++ b/tests/integration/test_streaming.py
@@ -1,0 +1,211 @@
+import json
+from unittest.mock import patch
+
+import pytest
+import requests
+import requests_mock
+
+from src.llm_api_adapter.models.messages.chat_message import UserMessage
+from src.llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
+
+
+def _sse(*events: tuple[str | None, dict]) -> str:
+    chunks = []
+    for event_name, payload in events:
+        lines = []
+        if event_name is not None:
+            lines.append(f"event: {event_name}")
+        lines.append(f"data: {json.dumps(payload)}")
+        chunks.append("\n".join(lines))
+    return "\n\n".join(chunks) + "\n\n"
+
+
+@pytest.mark.integration
+def test_openai_responses_streams_through_universal_adapter():
+    body = _sse(
+        (
+            "response.output_text.delta",
+            {"type": "response.output_text.delta", "delta": "Hello"},
+        ),
+        (
+            "response.completed",
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_123",
+                    "model": "gpt-5",
+                    "status": "completed",
+                    "usage": {
+                        "input_tokens": 2,
+                        "output_tokens": 1,
+                        "total_tokens": 3,
+                    },
+                    "output": [{
+                        "type": "message",
+                        "content": [{"type": "output_text", "text": "Hello"}],
+                    }],
+                },
+            },
+        ),
+    )
+    with (
+        requests_mock.Mocker() as mock,
+        patch(
+            "src.llm_api_adapter.llms.streaming.requests.post",
+            wraps=requests.post,
+        ) as mock_post,
+    ):
+        mock.post(
+            "https://api.openai.com/v1/responses",
+            text=body,
+            headers={"Content-Type": "text/event-stream"},
+        )
+        adapter = UniversalLLMAPIAdapter(
+            organization="openai",
+            model="gpt-5",
+            api_key="dummy_key",
+        )
+        done = []
+
+        with pytest.warns(
+            UserWarning,
+            match="Parameter 'top_p' is not supported for model 'gpt-5'",
+        ):
+            assert list(adapter.stream_chat([UserMessage("Hi")], on_done=done.append)) == ["Hello"]
+
+    request = mock.last_request
+    assert mock_post.call_args.args[0] == "https://api.openai.com/v1/responses"
+    assert mock_post.call_args.kwargs["stream"] is True
+    assert request.headers["Authorization"] == "Bearer dummy_key"
+    assert request.headers["Content-Type"] == "application/json"
+    assert request.json()["stream"] is True
+    assert request.json()["input"] == [{"role": "user", "content": "Hi"}]
+    assert done[0].response_id == "resp_123"
+    assert done[0].usage.total_tokens == 3
+
+
+@pytest.mark.integration
+def test_anthropic_messages_streams_through_universal_adapter():
+    body = _sse(
+        (
+            "message_start",
+            {
+                "type": "message_start",
+                "message": {
+                    "id": "msg_123",
+                    "model": "claude-sonnet-4-5",
+                    "content": [],
+                    "usage": {"input_tokens": 2, "output_tokens": 0},
+                },
+            },
+        ),
+        (
+            "content_block_start",
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "text", "text": ""},
+            },
+        ),
+        (
+            "content_block_delta",
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": "Hello"},
+            },
+        ),
+        (
+            "message_delta",
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": "end_turn"},
+                "usage": {"output_tokens": 1},
+            },
+        ),
+        ("message_stop", {"type": "message_stop"}),
+    )
+    with (
+        requests_mock.Mocker() as mock,
+        patch(
+            "src.llm_api_adapter.llms.streaming.requests.post",
+            wraps=requests.post,
+        ) as mock_post,
+    ):
+        mock.post(
+            "https://api.anthropic.com/v1/messages",
+            text=body,
+            headers={"Content-Type": "text/event-stream"},
+        )
+        adapter = UniversalLLMAPIAdapter(
+            organization="anthropic",
+            model="claude-sonnet-4-5",
+            api_key="dummy_key",
+        )
+        done = []
+
+        assert list(adapter.stream_chat(
+            [UserMessage("Hi")],
+            max_tokens=64,
+            on_done=done.append,
+        )) == ["Hello"]
+
+    request = mock.last_request
+    assert mock_post.call_args.args[0] == "https://api.anthropic.com/v1/messages"
+    assert mock_post.call_args.kwargs["stream"] is True
+    assert request.headers["x-api-key"] == "dummy_key"
+    assert request.headers["anthropic-version"] == "2023-06-01"
+    assert request.headers["Content-Type"] == "application/json"
+    assert request.json()["stream"] is True
+    assert request.json()["messages"] == [{"role": "user", "content": "Hi"}]
+    assert done[0].content == "Hello"
+    assert done[0].usage.total_tokens == 3
+
+
+@pytest.mark.integration
+def test_google_streams_through_universal_adapter():
+    body = _sse(
+        (
+            None,
+            {
+                "candidates": [{
+                    "content": {"parts": [{"text": "Hello"}]},
+                    "finishReason": "STOP",
+                }],
+                "usageMetadata": {
+                    "promptTokenCount": 2,
+                    "candidatesTokenCount": 1,
+                    "totalTokenCount": 3,
+                },
+            },
+        ),
+    )
+    url = (
+        "https://generativelanguage.googleapis.com/v1beta/"
+        "models/gemini-2.5-pro:streamGenerateContent?alt=sse"
+    )
+    with (
+        requests_mock.Mocker() as mock,
+        patch(
+            "src.llm_api_adapter.llms.streaming.requests.post",
+            wraps=requests.post,
+        ) as mock_post,
+    ):
+        mock.post(url, text=body, headers={"Content-Type": "text/event-stream"})
+        adapter = UniversalLLMAPIAdapter(
+            organization="google",
+            model="gemini-2.5-pro",
+            api_key="dummy_key",
+        )
+        done = []
+
+        assert list(adapter.stream_chat([UserMessage("Hi")], on_done=done.append)) == ["Hello"]
+
+    request = mock.last_request
+    assert mock_post.call_args.args[0] == url
+    assert mock_post.call_args.kwargs["stream"] is True
+    assert request.headers["x-goog-api-key"] == "dummy_key"
+    assert request.headers["Content-Type"] == "application/json"
+    assert request.json()["contents"] == [{"role": "user", "parts": [{"text": "Hi"}]}]
+    assert done[0].content == "Hello"
+    assert done[0].usage.total_tokens == 3

--- a/tests/unit/adapters/test_anthropic_adapter.py
+++ b/tests/unit/adapters/test_anthropic_adapter.py
@@ -7,6 +7,8 @@ from src.llm_api_adapter.errors.llm_api_error import LLMAPIError
 from src.llm_api_adapter.adapters.anthropic_adapter import ClaudeSyncClient
 from src.llm_api_adapter.models.messages.chat_message import Prompt, UserMessage
 from src.llm_api_adapter.models.responses.chat_response import ChatResponse
+from src.llm_api_adapter.models.tools import ToolSpec
+from src.llm_api_adapter.llms.streaming import SSEEvent
 
 @pytest.fixture
 def adapter():
@@ -172,3 +174,70 @@ def test_chat_omits_output_config_when_json_schema_is_none(adapter):
 
     kwargs = mock_chat.call_args.kwargs
     assert "output_config" not in kwargs
+
+
+@pytest.mark.unit
+def test_stream_chat_normalizes_text_and_completed_tool_use(adapter):
+    events = iter([
+        SSEEvent(
+            event="message_start",
+            data={"type": "message_start", "message": {
+                "id": "msg_123", "model": "claude-sonnet-4-5", "content": [],
+                "usage": {"input_tokens": 5, "output_tokens": 0},
+            }},
+        ),
+        SSEEvent(
+            event="content_block_start",
+            data={"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+        ),
+        SSEEvent(
+            event="content_block_delta",
+            data={"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Hello"}},
+        ),
+        SSEEvent(
+            event="content_block_start",
+            data={"type": "content_block_start", "index": 1, "content_block": {
+                "type": "tool_use", "id": "toolu_1", "name": "get_weather", "input": {},
+            }},
+        ),
+        SSEEvent(
+            event="content_block_delta",
+            data={"type": "content_block_delta", "index": 1, "delta": {
+                "type": "input_json_delta", "partial_json": "{\"city\": \"Tel",
+            }},
+        ),
+        SSEEvent(
+            event="content_block_delta",
+            data={"type": "content_block_delta", "index": 1, "delta": {
+                "type": "input_json_delta", "partial_json": " Aviv\"}",
+            }},
+        ),
+        SSEEvent(event="content_block_stop", data={"type": "content_block_stop", "index": 1}),
+        SSEEvent(
+            event="message_delta",
+            data={"type": "message_delta", "delta": {"stop_reason": "tool_use"}, "usage": {"output_tokens": 8}},
+        ),
+        SSEEvent(event="message_stop", data={"type": "message_stop"}),
+    ])
+    done = []
+    tool_calls = []
+    callbacks = []
+    tool = ToolSpec(name="get_weather", json_schema={"type": "object"})
+
+    with patch.object(ClaudeSyncClient, "stream", return_value=events) as mock_stream:
+        assert list(adapter.stream_chat(
+            [UserMessage("hi")],
+            max_tokens=64,
+            tools=[tool],
+            on_delta=lambda delta: callbacks.append(("delta", delta)),
+            on_tool_call=lambda call: (callbacks.append(("tool", call)), tool_calls.append(call)),
+            on_done=lambda response: (callbacks.append(("done", response)), done.append(response)),
+        )) == ["Hello"]
+
+    assert [kind for kind, _ in callbacks] == ["delta", "tool", "done"]
+    assert mock_stream.call_args.kwargs["messages"] == [{"role": "user", "content": "hi"}]
+    assert done[0].content == "Hello"
+    assert done[0].usage.total_tokens == 13
+    assert done[0].finish_reason == "tool_use"
+    assert tool_calls[0].name == "get_weather"
+    assert tool_calls[0].arguments == {"city": "Tel Aviv"}

--- a/tests/unit/adapters/test_base_adapter.py
+++ b/tests/unit/adapters/test_base_adapter.py
@@ -43,6 +43,9 @@ class _TestAdapter(LLMAdapterBase):
         except Exception as e:
             return self.handle_error(e)
 
+    def stream_chat(self, *args, **kwargs):
+        raise NotImplementedError
+
     def _normalize_reasoning_level(self, reasoning_level):
         return reasoning_level
 

--- a/tests/unit/adapters/test_base_adapter.py
+++ b/tests/unit/adapters/test_base_adapter.py
@@ -221,6 +221,16 @@ def test_base_abstract_chat_method_raises_not_implemented(adapter):
 
 
 @pytest.mark.unit
+def test_base_stream_chat_contract_raises_not_implemented(adapter):
+    with pytest.raises(NotImplementedError):
+        LLMAdapterBase.stream_chat(
+            adapter,
+            messages=[UserMessage("hello")],
+            on_delta=lambda delta: None,
+        )
+
+
+@pytest.mark.unit
 def test_base_abstract_normalize_reasoning_level_raises_not_implemented(adapter):
     with pytest.raises(NotImplementedError):
         LLMAdapterBase._normalize_reasoning_level(adapter, "low")

--- a/tests/unit/adapters/test_google_adapter.py
+++ b/tests/unit/adapters/test_google_adapter.py
@@ -7,6 +7,8 @@ from src.llm_api_adapter.errors.llm_api_error import LLMAPIError
 from src.llm_api_adapter.llms.google.sync_client import GeminiSyncClient
 from src.llm_api_adapter.models.messages.chat_message import Prompt, UserMessage
 from src.llm_api_adapter.models.responses.chat_response import ChatResponse
+from src.llm_api_adapter.models.tools import ToolSpec
+from src.llm_api_adapter.llms.streaming import SSEEvent
 
 @pytest.fixture
 def adapter():
@@ -201,3 +203,50 @@ def test_chat_omits_json_schema_fields_when_not_provided(adapter):
     gen_cfg = kwargs["generationConfig"]
     assert "responseMimeType" not in gen_cfg
     assert "responseSchema" not in gen_cfg
+
+
+@pytest.mark.unit
+def test_stream_chat_normalizes_chunks_excludes_thoughts_and_finalizes(adapter):
+    events = iter([
+        SSEEvent(data={
+            "candidates": [{"content": {"parts": [{"text": "Hello"}]}}],
+        }, event=None),
+        SSEEvent(data={
+            "candidates": [{"content": {"parts": [{"text": "secret", "thought": True}]}}],
+        }, event=None),
+        SSEEvent(data={
+            "candidates": [{
+                "content": {"parts": [
+                    {"text": "!"},
+                    {"functionCall": {"name": "get_weather", "args": {"city": "Tel Aviv"}}},
+                ]},
+                "finishReason": "STOP",
+            }],
+            "usageMetadata": {
+                "promptTokenCount": 3,
+                "candidatesTokenCount": 2,
+                "totalTokenCount": 5,
+            },
+        }, event=None),
+    ])
+    done = []
+    tool_calls = []
+    callbacks = []
+    tool = ToolSpec(name="get_weather", json_schema={"type": "object"})
+
+    with patch.object(GeminiSyncClient, "stream", return_value=events) as mock_stream:
+        assert list(adapter.stream_chat(
+            [UserMessage("hi")],
+            tools=[tool],
+            on_delta=lambda delta: callbacks.append(("delta", delta)),
+            on_tool_call=lambda call: (callbacks.append(("tool", call)), tool_calls.append(call)),
+            on_done=lambda response: (callbacks.append(("done", response)), done.append(response)),
+        )) == ["Hello", "!"]
+
+    assert [kind for kind, _ in callbacks] == ["delta", "delta", "tool", "done"]
+    assert mock_stream.call_args.kwargs["contents"] == [{"role": "user", "parts": [{"text": "hi"}]}]
+    assert done[0].content == "Hello!"
+    assert done[0].finish_reason == "STOP"
+    assert done[0].usage.total_tokens == 5
+    assert tool_calls[0].name == "get_weather"
+    assert tool_calls[0].arguments == {"city": "Tel Aviv"}

--- a/tests/unit/adapters/test_openai_adapter.py
+++ b/tests/unit/adapters/test_openai_adapter.py
@@ -8,6 +8,7 @@ from src.llm_api_adapter.llms.openai.sync_client import OpenAISyncClient
 from src.llm_api_adapter.models.messages.chat_message import Prompt, UserMessage
 from src.llm_api_adapter.models.responses.chat_response import ChatResponse
 from src.llm_api_adapter.models.tools import ToolSpec
+from src.llm_api_adapter.llms.streaming import SSEEvent
 
 
 @pytest.fixture
@@ -619,3 +620,150 @@ def test_chat_legacy_api_passes_json_schema_in_response_format(legacy_adapter):
     assert rf["json_schema"]["strict"] is True
     assert "schema" in rf["json_schema"]
     assert result.parsed_json == {"name": "test"}
+
+
+@pytest.mark.unit
+def test_stream_chat_legacy_normalizes_deltas_tool_calls_and_callbacks(legacy_adapter):
+    events = iter([
+        SSEEvent(data={
+            "id": "chatcmpl_123",
+            "model": "gpt-4o",
+            "created": 42,
+            "choices": [{"index": 0, "delta": {"content": "Hello"}}],
+        }, event=None),
+        SSEEvent(data={
+            "choices": [{
+                "index": 0,
+                "delta": {"content": "!", "tool_calls": [{
+                    "index": 0,
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": "{\"city\":"},
+                }]},
+            }],
+        }, event=None),
+        SSEEvent(data={
+            "choices": [{
+                "index": 0,
+                "delta": {"tool_calls": [{
+                    "index": 0,
+                    "function": {"arguments": "\"Tel Aviv\"}"},
+                }]},
+                "finish_reason": "tool_calls",
+            }],
+            "usage": {"prompt_tokens": 4, "completion_tokens": 3, "total_tokens": 7},
+        }, event=None),
+    ])
+    callbacks = []
+    done = []
+    tool = ToolSpec(name="get_weather", json_schema={"type": "object"})
+
+    with patch.object(OpenAISyncClient, "stream", return_value=events) as mock_stream:
+        deltas = list(legacy_adapter.stream_chat(
+            [UserMessage("hi")],
+            tools=[tool],
+            on_delta=lambda delta: callbacks.append(("delta", delta)),
+            on_tool_call=lambda call: callbacks.append(("tool", call)),
+            on_done=lambda response: (callbacks.append(("done", response)), done.append(response)),
+        ))
+
+    assert deltas == ["Hello", "!"]
+    assert [kind for kind, _ in callbacks] == ["delta", "delta", "tool", "done"]
+    response = done[0]
+    assert response.content == "Hello!"
+    assert response.finish_reason == "tool_calls"
+    assert response.usage.total_tokens == 7
+    assert response.tool_calls[0].name == "get_weather"
+    assert response.tool_calls[0].arguments == {"city": "Tel Aviv"}
+    assert mock_stream.call_args.kwargs["messages"] == [{"role": "user", "content": "hi"}]
+
+
+@pytest.mark.unit
+def test_stream_chat_responses_uses_completed_response(adapter):
+    events = iter([
+        SSEEvent(
+            event="response.output_text.delta",
+            data={"type": "response.output_text.delta", "delta": "Hello"},
+        ),
+        SSEEvent(
+            event="response.completed",
+            data={
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_123",
+                    "model": "gpt-5",
+                    "status": "completed",
+                    "usage": {"input_tokens": 2, "output_tokens": 1, "total_tokens": 3},
+                    "output": [{
+                        "type": "message",
+                        "content": [{"type": "output_text", "text": "Hello"}],
+                    }, {
+                        "type": "function_call",
+                        "call_id": "call_1",
+                        "name": "get_weather",
+                        "arguments": "{\"city\": \"Tel Aviv\"}",
+                    }],
+                },
+            },
+        ),
+    ])
+    done = []
+    tool_calls = []
+
+    with patch.object(OpenAISyncClient, "stream", return_value=events) as mock_stream:
+        assert list(adapter.stream_chat(
+            [UserMessage("hi")],
+            on_done=done.append,
+            on_tool_call=tool_calls.append,
+        )) == ["Hello"]
+
+    assert mock_stream.call_args.kwargs["input"] == [{"role": "user", "content": "hi"}]
+    assert done[0].response_id == "resp_123"
+    assert done[0].usage.total_tokens == 3
+    assert tool_calls[0].arguments == {"city": "Tel Aviv"}
+
+
+@pytest.mark.unit
+def test_stream_chat_does_not_treat_callback_errors_as_provider_errors(legacy_adapter):
+    events = iter([
+        SSEEvent(data={"choices": [{"index": 0, "delta": {"content": "Hello"}}]}, event=None),
+    ])
+
+    with (
+        patch.object(OpenAISyncClient, "stream", return_value=events),
+        patch.object(legacy_adapter, "handle_error") as handle_error,
+        pytest.raises(RuntimeError, match="callback failed"),
+    ):
+        list(legacy_adapter.stream_chat(
+            [UserMessage("hi")],
+            on_delta=lambda _: (_ for _ in ()).throw(RuntimeError("callback failed")),
+        ))
+
+    handle_error.assert_not_called()
+
+
+@pytest.mark.unit
+def test_stream_chat_skips_on_done_when_closed_early(legacy_adapter):
+    closed = []
+
+    def events():
+        try:
+            yield SSEEvent(
+                data={"choices": [{"index": 0, "delta": {"content": "Hello"}}]},
+                event=None,
+            )
+            yield SSEEvent(
+                data={"choices": [{"index": 0, "delta": {"content": " world"}}]},
+                event=None,
+            )
+        finally:
+            closed.append(True)
+
+    done = []
+    with patch.object(OpenAISyncClient, "stream", return_value=events()):
+        stream = legacy_adapter.stream_chat([UserMessage("hi")], on_done=done.append)
+        assert next(stream) == "Hello"
+        stream.close()
+
+    assert closed == [True]
+    assert done == []

--- a/tests/unit/llms/anthropic/test_sync_client.py
+++ b/tests/unit/llms/anthropic/test_sync_client.py
@@ -11,6 +11,25 @@ from src.llm_api_adapter.errors.llm_api_error import (
     LLMAPITimeoutError,
 )
 from src.llm_api_adapter.llms.anthropic.sync_client import ClaudeSyncClient
+from src.llm_api_adapter.llms.streaming import SSEEvent
+
+
+class StreamingResponse:
+    def __init__(self, lines, status_code=200, error_payload=None):
+        self.lines = lines
+        self.status_code = status_code
+        self.error_payload = error_payload or {}
+        self.close = Mock()
+
+    def iter_lines(self, decode_unicode=True):
+        return iter(self.lines)
+
+    def json(self):
+        return self.error_payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.exceptions.HTTPError(response=self)
 
 @pytest.fixture
 def client():
@@ -125,3 +144,172 @@ def test_prepare_payload_is_adaptive_thinking_never_in_result(client):
         kwargs = {"messages": [], "is_adaptive_thinking": flag}
         payload = client._prepare_chat_payload_for_model("claude-opus-4-8", kwargs)
         assert "is_adaptive_thinking" not in payload
+
+
+@pytest.mark.unit
+@patch("src.llm_api_adapter.llms.streaming.requests.post")
+def test_stream_yields_raw_messages_events_and_ignores_ping(mock_post, client):
+    response = StreamingResponse([
+        "event: message_start",
+        'data: {"type":"message_start","message":{"id":"msg_123","content":[]}}',
+        "",
+        "event: ping",
+        'data: {"type":"ping"}',
+        "",
+        "event: content_block_delta",
+        'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}',
+        "",
+        "event: message_stop",
+        'data: {"type":"message_stop"}',
+        "",
+    ])
+    mock_post.return_value = response
+
+    events = list(client.stream(
+        "claude-opus-4-8",
+        messages=[{"role": "user", "content": "Hi"}],
+        max_tokens=64,
+    ))
+
+    assert events == [
+        SSEEvent(
+            event="message_start",
+            data={"type": "message_start", "message": {"id": "msg_123", "content": []}},
+        ),
+        SSEEvent(
+            event="content_block_delta",
+            data={
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": "Hello"},
+            },
+        ),
+        SSEEvent(event="message_stop", data={"type": "message_stop"}),
+    ]
+    assert mock_post.call_args.args[0] == "https://api.anthropic.com/v1/messages"
+    assert mock_post.call_args.kwargs["json"] == {
+        "model": "claude-opus-4-8",
+        "messages": [{"role": "user", "content": "Hi"}],
+        "max_tokens": 64,
+        "stream": True,
+    }
+    assert mock_post.call_args.kwargs["stream"] is True
+    response.close.assert_called_once()
+
+
+@pytest.mark.unit
+@patch("src.llm_api_adapter.llms.streaming.requests.post")
+def test_stream_reuses_adaptive_thinking_payload_preparation(mock_post, client):
+    response = StreamingResponse([])
+    mock_post.return_value = response
+
+    assert list(client.stream(
+        "claude-opus-4-8",
+        messages=[],
+        top_p=1.0,
+        is_adaptive_thinking=True,
+        effort="high",
+    )) == []
+
+    assert mock_post.call_args.kwargs["json"] == {
+        "model": "claude-opus-4-8",
+        "messages": [],
+        "thinking": {"type": "adaptive"},
+        "output_config": {"effort": "high"},
+        "stream": True,
+    }
+
+
+@pytest.mark.unit
+@patch("src.llm_api_adapter.llms.streaming.requests.post")
+def test_stream_preserves_input_json_deltas_for_later_tool_assembly(mock_post, client):
+    response = StreamingResponse([
+        "event: content_block_delta",
+        'data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\\\"city\\\": \\\"Tel"}}',
+        "",
+        "event: content_block_delta",
+        'data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":" Aviv\\\"}"}}',
+        "",
+        "event: content_block_stop",
+        'data: {"type":"content_block_stop","index":1}',
+        "",
+    ])
+    mock_post.return_value = response
+
+    events = list(client.stream("claude-opus-4-8", messages=[]))
+
+    assert [event.data["delta"]["partial_json"] for event in events[:2]] == [
+        '{"city": "Tel',
+        ' Aviv"}',
+    ]
+    assert events[-1] == SSEEvent(
+        event="content_block_stop",
+        data={"type": "content_block_stop", "index": 1},
+    )
+
+
+@pytest.mark.unit
+@patch("src.llm_api_adapter.llms.streaming.requests.post")
+def test_stream_closes_response_when_consumer_stops_early(mock_post, client):
+    response = StreamingResponse([
+        "event: content_block_delta",
+        'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}',
+        "",
+        "event: content_block_delta",
+        'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" world"}}',
+        "",
+    ])
+    mock_post.return_value = response
+
+    events = client.stream("claude-opus-4-8", messages=[])
+    next(events)
+    events.close()
+
+    response.close.assert_called_once()
+
+
+@pytest.mark.unit
+@patch("src.llm_api_adapter.llms.streaming.requests.post")
+def test_stream_maps_http_errors_through_anthropic_error_handler(mock_post, client):
+    response = StreamingResponse(
+        [],
+        status_code=429,
+        error_payload={"error": {"type": "rate_limit_error", "message": "Slow down"}},
+    )
+    mock_post.return_value = response
+
+    with pytest.raises(LLMAPIRateLimitError, match="Slow down"):
+        list(client.stream("claude-opus-4-8", messages=[]))
+
+    response.close.assert_called_once()
+
+
+@pytest.mark.unit
+@patch("src.llm_api_adapter.llms.streaming.requests.post")
+def test_stream_maps_in_stream_error_through_anthropic_error_handler(mock_post, client):
+    response = StreamingResponse([
+        "event: error",
+        'data: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+        "",
+    ])
+    mock_post.return_value = response
+
+    with pytest.raises(LLMAPIServerError, match="Overloaded"):
+        list(client.stream("claude-opus-4-8", messages=[]))
+
+    response.close.assert_called_once()
+
+
+@pytest.mark.unit
+@patch("src.llm_api_adapter.llms.streaming.requests.post")
+def test_stream_passes_unknown_event_types_through(mock_post, client):
+    response = StreamingResponse([
+        "event: future_event",
+        'data: {"type":"future_event","value":"kept"}',
+        "",
+    ])
+    mock_post.return_value = response
+
+    assert list(client.stream("claude-opus-4-8", messages=[])) == [
+        SSEEvent(event="future_event", data={"type": "future_event", "value": "kept"})
+    ]

--- a/tests/unit/llms/google/test_sync_client.py
+++ b/tests/unit/llms/google/test_sync_client.py
@@ -11,6 +11,25 @@ from src.llm_api_adapter.errors.llm_api_error import (
     LLMAPITimeoutError,
 )
 from src.llm_api_adapter.llms.google.sync_client import GeminiSyncClient
+from src.llm_api_adapter.llms.streaming import SSEEvent
+
+
+class StreamingResponse:
+    def __init__(self, lines, status_code=200, error_payload=None):
+        self.lines = lines
+        self.status_code = status_code
+        self.error_payload = error_payload or {}
+        self.close = Mock()
+
+    def iter_lines(self, decode_unicode=True):
+        return iter(self.lines)
+
+    def json(self):
+        return self.error_payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.exceptions.HTTPError(response=self)
 
 @pytest.fixture
 def client():
@@ -40,6 +59,9 @@ def test_chat_completion_success(client, mock_post_success):
     candidate_content = result["candidates"][0]["content"]
     assert candidate_content == "Hello"
     mock_post.assert_called_once()
+    assert mock_post.call_args.args[0] == (
+        "https://generativelanguage.googleapis.com/v1beta/models/gemini-1:generateContent"
+    )
     headers = mock_post.call_args[1]["headers"]
     assert headers["x-goog-api-key"] == "test_api_key"
 
@@ -87,3 +109,119 @@ def test_send_request_fallback_error_parsing(mock_post, client):
     mock_post.side_effect = http_err
     with pytest.raises(LLMAPIClientError):
         client._send_request("http://example.com", {})
+
+
+@pytest.mark.unit
+@patch("src.llm_api_adapter.llms.streaming.requests.post")
+def test_stream_uses_stream_generate_content_and_yields_raw_chunks(mock_post, client):
+    response = StreamingResponse([
+        'data: {"candidates":[{"content":{"parts":[{"text":"Hello"}]}}]}',
+        "",
+        'data: {"candidates":[{"content":{"parts":[{"functionCall":{"name":"get_weather","args":{"city":"Tel Aviv"}}}]},"finishReason":"STOP"}],"usageMetadata":{"totalTokenCount":12}}',
+        "",
+    ])
+    mock_post.return_value = response
+
+    events = list(client.stream(
+        "gemini-2.5-flash",
+        contents=[{"role": "user", "parts": [{"text": "Hi"}]}],
+        generationConfig={"maxOutputTokens": 64},
+    ))
+
+    assert events == [
+        SSEEvent(
+            event=None,
+            data={"candidates": [{"content": {"parts": [{"text": "Hello"}]}}]},
+        ),
+        SSEEvent(
+            event=None,
+            data={
+                "candidates": [{
+                    "content": {"parts": [{"functionCall": {
+                        "name": "get_weather", "args": {"city": "Tel Aviv"},
+                    }}]},
+                    "finishReason": "STOP",
+                }],
+                "usageMetadata": {"totalTokenCount": 12},
+            },
+        ),
+    ]
+    assert mock_post.call_args.args[0] == (
+        "https://generativelanguage.googleapis.com/v1beta/"
+        "models/gemini-2.5-flash:streamGenerateContent?alt=sse"
+    )
+    assert mock_post.call_args.kwargs["json"] == {
+        "model": "gemini-2.5-flash",
+        "contents": [{"role": "user", "parts": [{"text": "Hi"}]}],
+        "generationConfig": {},
+    }
+    assert mock_post.call_args.kwargs["stream"] is True
+    response.close.assert_called_once()
+
+
+@pytest.mark.unit
+@patch("src.llm_api_adapter.llms.streaming.requests.post")
+def test_stream_reuses_model_specific_thinking_payload_preparation(mock_post, client):
+    response = StreamingResponse([])
+    mock_post.return_value = response
+
+    assert list(client.stream(
+        "gemini-2.5-flash-lite",
+        contents=[],
+        generationConfig={"thinkingConfig": {"thinkingBudget": 1}},
+    )) == []
+
+    assert mock_post.call_args.kwargs["json"] == {
+        "model": "gemini-2.5-flash-lite",
+        "contents": [],
+        "generationConfig": {"thinkingConfig": {"thinkingBudget": 512}},
+    }
+
+
+@pytest.mark.unit
+@patch("src.llm_api_adapter.llms.streaming.requests.post")
+def test_stream_closes_response_when_consumer_stops_early(mock_post, client):
+    response = StreamingResponse([
+        'data: {"candidates":[{"content":{"parts":[{"text":"Hello"}]}}]}',
+        "",
+        'data: {"candidates":[{"content":{"parts":[{"text":" world"}]}}]}',
+        "",
+    ])
+    mock_post.return_value = response
+
+    events = client.stream("gemini-2.5-flash", contents=[])
+    next(events)
+    events.close()
+
+    response.close.assert_called_once()
+
+
+@pytest.mark.unit
+@patch("src.llm_api_adapter.llms.streaming.requests.post")
+def test_stream_maps_http_errors_through_google_error_handler(mock_post, client):
+    response = StreamingResponse(
+        [],
+        status_code=429,
+        error_payload={"error": {"status": "RESOURCE_EXHAUSTED", "message": "Slow down"}},
+    )
+    mock_post.return_value = response
+
+    with pytest.raises(LLMAPIRateLimitError, match="Slow down"):
+        list(client.stream("gemini-2.5-flash", contents=[]))
+
+    response.close.assert_called_once()
+
+
+@pytest.mark.unit
+@patch("src.llm_api_adapter.llms.streaming.requests.post")
+def test_stream_maps_error_chunks_through_google_error_handler(mock_post, client):
+    response = StreamingResponse([
+        'data: {"error":{"status":"UNAVAILABLE","message":"Temporarily unavailable"}}',
+        "",
+    ])
+    mock_post.return_value = response
+
+    with pytest.raises(LLMAPIServerError, match="Temporarily unavailable"):
+        list(client.stream("gemini-2.5-flash", contents=[]))
+
+    response.close.assert_called_once()

--- a/tests/unit/llms/openai/test_sync_client.py
+++ b/tests/unit/llms/openai/test_sync_client.py
@@ -167,6 +167,30 @@ def test_stream_uses_responses_api_and_preserves_named_events(mock_post, client)
 
 
 @pytest.mark.unit
+def test_prepare_responses_payload_warns_when_ignoring_temperature_for_gpt5_nano(client):
+    with pytest.warns(
+        UserWarning,
+        match="Parameter 'temperature' is not supported for model 'gpt-5-nano'",
+    ):
+        payload = client._prepare_responses_payload_for_model(
+            "gpt-5-nano",
+            {"temperature": 0},
+        )
+
+    assert "temperature" not in payload
+
+
+@pytest.mark.unit
+def test_prepare_responses_payload_preserves_temperature_for_other_gpt5_models(client):
+    payload = client._prepare_responses_payload_for_model(
+        "gpt-5",
+        {"temperature": 0},
+    )
+
+    assert payload["temperature"] == 0
+
+
+@pytest.mark.unit
 @patch("src.llm_api_adapter.llms.streaming.requests.post")
 def test_stream_closes_response_when_consumer_stops_early(mock_post, client):
     response = StreamingResponse([

--- a/tests/unit/llms/openai/test_sync_client.py
+++ b/tests/unit/llms/openai/test_sync_client.py
@@ -11,6 +11,25 @@ from src.llm_api_adapter.errors.llm_api_error import (
     LLMAPITimeoutError,
 )
 from src.llm_api_adapter.llms.openai.sync_client import OpenAISyncClient
+from src.llm_api_adapter.llms.streaming import SSEEvent
+
+
+class StreamingResponse:
+    def __init__(self, lines, status_code=200, error_payload=None):
+        self.lines = lines
+        self.status_code = status_code
+        self.error_payload = error_payload or {}
+        self.close = Mock()
+
+    def iter_lines(self, decode_unicode=True):
+        return iter(self.lines)
+
+    def json(self):
+        return self.error_payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.exceptions.HTTPError(response=self)
 
 @pytest.fixture
 def client():
@@ -87,3 +106,127 @@ def test_send_request_fallback_error_parsing(mock_post, client):
     mock_post.side_effect = http_err
     with pytest.raises(LLMAPIClientError):
         client._send_request("http://example.com", {})
+
+
+@pytest.mark.unit
+@patch("src.llm_api_adapter.llms.streaming.requests.post")
+def test_stream_uses_chat_completions_and_yields_raw_chunks(mock_post, client):
+    response = StreamingResponse([
+        'data: {"choices":[{"delta":{"content":"Hello"}}]}',
+        "",
+        "data: [DONE]",
+        "",
+    ])
+    mock_post.return_value = response
+
+    events = list(client.stream("gpt-4o", messages=[{"role": "user", "content": "Hi"}]))
+
+    assert events == [
+        SSEEvent(event=None, data={"choices": [{"delta": {"content": "Hello"}}]})
+    ]
+    assert mock_post.call_args.args[0] == "https://api.openai.com/v1/chat/completions"
+    assert mock_post.call_args.kwargs["json"] == {
+        "model": "gpt-4o",
+        "messages": [{"role": "user", "content": "Hi"}],
+        "stream": True,
+    }
+    assert mock_post.call_args.kwargs["stream"] is True
+    response.close.assert_called_once()
+
+
+@pytest.mark.unit
+@patch("src.llm_api_adapter.llms.streaming.requests.post")
+def test_stream_uses_responses_api_and_preserves_named_events(mock_post, client):
+    response = StreamingResponse([
+        "event: response.output_text.delta",
+        'data: {"type":"response.output_text.delta","delta":"Hello"}',
+        "",
+    ])
+    mock_post.return_value = response
+
+    events = list(client.stream(
+        "gpt-5",
+        messages=[{"role": "user", "content": "Hi"}],
+        max_tokens=10,
+    ))
+
+    assert events == [
+        SSEEvent(
+            event="response.output_text.delta",
+            data={"type": "response.output_text.delta", "delta": "Hello"},
+        )
+    ]
+    assert mock_post.call_args.args[0] == "https://api.openai.com/v1/responses"
+    assert mock_post.call_args.kwargs["json"] == {
+        "model": "gpt-5",
+        "input": [{"role": "user", "content": "Hi"}],
+        "max_output_tokens": 10,
+        "stream": True,
+    }
+    response.close.assert_called_once()
+
+
+@pytest.mark.unit
+@patch("src.llm_api_adapter.llms.streaming.requests.post")
+def test_stream_closes_response_when_consumer_stops_early(mock_post, client):
+    response = StreamingResponse([
+        'data: {"choices":[{"delta":{"content":"Hello"}}]}',
+        "",
+        'data: {"choices":[{"delta":{"content":" world"}}]}',
+        "",
+    ])
+    mock_post.return_value = response
+
+    events = client.stream("gpt-4o", messages=[])
+    next(events)
+    events.close()
+
+    response.close.assert_called_once()
+
+
+@pytest.mark.unit
+@patch("src.llm_api_adapter.llms.streaming.requests.post")
+def test_stream_maps_http_errors_through_openai_error_handler(mock_post, client):
+    response = StreamingResponse(
+        [],
+        status_code=429,
+        error_payload={"error": {"type": "rate_limit_exceeded", "message": "Slow down"}},
+    )
+    mock_post.return_value = response
+
+    with pytest.raises(LLMAPIRateLimitError, match="Slow down"):
+        list(client.stream("gpt-4o", messages=[]))
+
+    response.close.assert_called_once()
+
+
+@pytest.mark.unit
+@patch("src.llm_api_adapter.llms.streaming.requests.post")
+def test_stream_maps_generic_error_events_through_openai_error_handler(mock_post, client):
+    response = StreamingResponse([
+        "event: error",
+        'data: {"error":{"code":"rate_limit_exceeded","message":"Slow down"}}',
+        "",
+    ])
+    mock_post.return_value = response
+
+    with pytest.raises(LLMAPIRateLimitError, match="Slow down"):
+        list(client.stream("gpt-4o", messages=[]))
+
+    response.close.assert_called_once()
+
+
+@pytest.mark.unit
+@patch("src.llm_api_adapter.llms.streaming.requests.post")
+def test_stream_maps_responses_failed_events_through_openai_error_handler(mock_post, client):
+    response = StreamingResponse([
+        "event: response.failed",
+        'data: {"type":"response.failed","response":{"error":{"code":"server_error","message":"Unavailable"}}}',
+        "",
+    ])
+    mock_post.return_value = response
+
+    with pytest.raises(LLMAPIServerError, match="Unavailable"):
+        list(client.stream("gpt-5", messages=[]))
+
+    response.close.assert_called_once()

--- a/tests/unit/models/responses/test_chat_response.py
+++ b/tests/unit/models/responses/test_chat_response.py
@@ -539,6 +539,7 @@ def test_from_anthropic_response_invalid_tool_input_raises():
 @pytest.mark.unit
 def test_from_google_response():
     api_response = {
+        "modelVersion": "gemini-2.5-flash",
         "candidates": [
             {
                 "content": {"parts": [{"text": "Hello from Google!"}]},
@@ -548,6 +549,7 @@ def test_from_google_response():
         "usageMetadata": {"totalTokenCount": 42},
     }
     response = ChatResponse.from_google_response(api_response)
+    assert response.model == "gemini-2.5-flash"
     assert response.usage.total_tokens == 42
     assert response.content == "Hello from Google!"
     assert response.finish_reason == "length"

--- a/tests/unit/streaming/test_sse.py
+++ b/tests/unit/streaming/test_sse.py
@@ -1,0 +1,191 @@
+from unittest.mock import patch
+
+import pytest
+import requests
+
+from src.llm_api_adapter.errors.llm_api_error import (
+    LLMAPIClientError,
+    LLMAPIAuthorizationError,
+    LLMAPIServerError,
+)
+from src.llm_api_adapter.llms.streaming import (
+    SSEEvent,
+    iter_sse_events,
+    stream_request,
+)
+
+
+class FakeResponse:
+    def __init__(self, lines, status_code=200, iter_error=None):
+        self.lines = lines
+        self.status_code = status_code
+        self.iter_error = iter_error
+        self.closed = False
+        self.close_calls = 0
+
+    def iter_lines(self, decode_unicode=True):
+        if self.iter_error:
+            raise self.iter_error
+        return iter(self.lines)
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.exceptions.HTTPError(
+                f"HTTP {self.status_code}", response=self
+            )
+
+    def close(self):
+        self.close_calls += 1
+        self.closed = True
+
+
+@pytest.mark.unit
+def test_iter_sse_events_parses_event_and_multiline_json_data():
+    response = FakeResponse(
+        [
+            b"event: message",
+            b'data: {"text":',
+            b'data: "hello"}',
+            b"",
+        ]
+    )
+
+    assert list(iter_sse_events(response)) == [
+        SSEEvent(event="message", data={"text": "hello"})
+    ]
+    assert response.closed is True
+
+
+@pytest.mark.unit
+def test_iter_sse_events_ignores_comments_and_ping_events():
+    response = FakeResponse(
+        [
+            b": keep-alive",
+            b"event: ping",
+            b'data: {"type":"ping"}',
+            b"",
+            b'data: {"text":"ok"}',
+            b"",
+        ]
+    )
+
+    assert list(iter_sse_events(response)) == [
+        SSEEvent(event=None, data={"text": "ok"})
+    ]
+
+
+@pytest.mark.unit
+def test_iter_sse_events_recognizes_done_sentinel():
+    response = FakeResponse([b"data: [DONE]", b"", b'data: {"ignored": true}', b""])
+
+    assert list(iter_sse_events(response)) == [SSEEvent(event=None, done=True)]
+    assert response.closed is True
+
+
+@pytest.mark.unit
+def test_iter_sse_events_flushes_complete_event_at_eof():
+    response = FakeResponse([b'data: {"text":"eof"}'])
+
+    assert list(iter_sse_events(response)) == [
+        SSEEvent(event=None, data={"text": "eof"})
+    ]
+    assert response.closed is True
+
+
+@pytest.mark.unit
+def test_iter_sse_events_maps_malformed_json_and_closes_response():
+    response = FakeResponse([b"data: not-json", b""])
+
+    with pytest.raises(LLMAPIClientError, match="Malformed SSE JSON data"):
+        list(iter_sse_events(response))
+
+    assert response.closed is True
+
+
+@pytest.mark.unit
+def test_iter_sse_events_closes_response_when_consumer_stops_early():
+    response = FakeResponse([b'data: {"text":"first"}', b"", b'data: {"text":"second"}', b""])
+    events = iter_sse_events(response)
+
+    assert next(events).data == {"text": "first"}
+    events.close()
+    assert response.closed is True
+
+
+@pytest.mark.unit
+def test_stream_request_uses_stream_true_and_closes_response():
+    response = FakeResponse([b'data: {"text":"hello"}', b""])
+
+    with patch(
+        "src.llm_api_adapter.llms.streaming.requests.post", return_value=response
+    ) as mock_post:
+        events = list(
+            stream_request(
+                "https://example.test/stream",
+                headers={"Authorization": "Bearer test"},
+                payload={"prompt": "hello"},
+                timeout=3.0,
+            )
+        )
+
+    assert events == [SSEEvent(event=None, data={"text": "hello"})]
+    assert response.closed is True
+    assert response.close_calls == 1
+    mock_post.assert_called_once_with(
+        "https://example.test/stream",
+        headers={"Authorization": "Bearer test"},
+        json={"prompt": "hello"},
+        timeout=3.0,
+        stream=True,
+    )
+
+
+@pytest.mark.unit
+def test_stream_request_maps_http_errors_to_unified_hierarchy():
+    response = FakeResponse([], status_code=401)
+
+    with patch(
+        "src.llm_api_adapter.llms.streaming.requests.post", return_value=response
+    ), pytest.raises(LLMAPIAuthorizationError):
+        list(stream_request("https://example.test/stream"))
+
+    assert response.closed is True
+
+
+@pytest.mark.unit
+def test_stream_request_uses_provider_http_error_handler():
+    response = FakeResponse([], status_code=500)
+    provider_error = LLMAPIServerError(detail="provider-specific")
+
+    def handle_http_error(error):
+        raise provider_error
+
+    with patch(
+        "src.llm_api_adapter.llms.streaming.requests.post", return_value=response
+    ), pytest.raises(LLMAPIServerError, match="provider-specific"):
+        list(
+            stream_request(
+                "https://example.test/stream",
+                http_error_handler=handle_http_error,
+            )
+        )
+
+    assert response.closed is True
+
+
+@pytest.mark.unit
+def test_stream_request_maps_generic_in_stream_error():
+    response = FakeResponse(
+        [
+            b"event: error",
+            b'data: {"error":{"type":"overloaded_error","message":"Overloaded"}}',
+            b"",
+        ]
+    )
+
+    with patch(
+        "src.llm_api_adapter.llms.streaming.requests.post", return_value=response
+    ), pytest.raises(LLMAPIClientError, match="overloaded_error: Overloaded"):
+        list(stream_request("https://example.test/stream"))
+
+    assert response.closed is True

--- a/tests/unit/test_universal_adapter.py
+++ b/tests/unit/test_universal_adapter.py
@@ -16,6 +16,9 @@ def test_selects_adapter_and_delegates(monkeypatch):
         def chat(self, *args, **kwargs):
             return {"response": "ok"}
 
+        def stream_chat(self, *args, **kwargs):
+            yield "streamed"
+
         def greet(self, name: str) -> str:
             return f"hello {name} from {self.company}"
 
@@ -35,6 +38,7 @@ def test_selects_adapter_and_delegates(monkeypatch):
     assert ua.adapter.model == "claude-sonnet-4-5"
     assert ua.adapter.api_key == "sk-test"
     assert ua.greet("Alice") == "hello Alice from anthropic"
+    assert list(ua.stream_chat()) == ["streamed"]
 
 @pytest.mark.unit
 def test_unsupported_organization_raises(monkeypatch):
@@ -46,6 +50,12 @@ def test_unsupported_organization_raises(monkeypatch):
 
         def chat(self, *args, **kwargs):
             return {"response": "openai"}
+
+        def stream_chat(self, *args, **kwargs):
+            yield "streamed"
+
+        def _normalize_reasoning_level(self, reasoning_level):
+            return reasoning_level
 
     monkeypatch.setattr(
         universal_module.LLMAdapterBase,
@@ -77,6 +87,9 @@ def test_getattr_missing_raises_attribute_error(monkeypatch):
 
         def chat(self, *args, **kwargs):
             return {"response": "ok"}
+
+        def stream_chat(self, *args, **kwargs):
+            yield "streamed"
         
         def _normalize_reasoning_level(self, reasoning_level):
             return reasoning_level


### PR DESCRIPTION
Adds provider-neutral synchronous streaming in v0.6.0.

- Adds `stream_chat()` to the base adapter and all providers.
- Adds shared SSE transport plus raw streaming clients for OpenAI, Anthropic, and Google.
- Normalizes provider events into visible text deltas.
- Adds `on_delta`, `on_tool_call`, and `on_done` callbacks.
- Finalizes a normal `ChatResponse` after the stream, including usage, pricing, structured-output parsing, and completed tool calls.
- Adds mocked integration coverage, real-provider E2E coverage, and README documentation.
- Bumps package version to `0.6.0`.

## Provider support

- OpenAI: Chat Completions and Responses API streams.
- Anthropic: Messages API SSE streams.
- Google: `streamGenerateContent` SSE streams.

## Scope

This release is synchronous and text-first. Async streaming, backpressure controls, universal provider events, partial tool arguments, and advanced tool-call sequencing are deferred.
