### PR TITLE
feat(streaming): add buffered chunks and usage metadata across providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This table is a positioning snapshot. Provider capabilities change independently
 
 ## Features
 
-- **Synchronous Streaming**: Iterate normalized text deltas with `stream_chat()` across OpenAI, Anthropic, and Google; receive completed tool calls and the final normalized `ChatResponse` through optional callbacks.
+- **Synchronous Streaming**: Iterate normalized text with `stream_chat()` across OpenAI, Anthropic, and Google. Optionally coalesce it into bounded chunks and observe per-chunk metadata without changing the yielded `str` contract.
 - **Provider-Neutral Messages and Responses**: Use the same typed messages, `ChatResponse`, usage, pricing, parsed output, and tool-call fields regardless of the provider.
 - **Vision Input**: Send images alongside text via `ImagePart` — URL or raw bytes, all providers handled automatically.
 - **PDF Documents**: Send PDF URLs or bytes via `DocumentPart`; provider-specific file/document payloads are generated automatically.
@@ -147,7 +147,9 @@ print(response.content)
 
 ## Streaming
 
-`stream_chat()` is the synchronous streaming counterpart to `chat()`. It yields normalized visible text deltas as `str`, independently of the provider's native streaming event format.
+`stream_chat()` is the synchronous streaming counterpart to `chat()`. It always yields normalized visible text as `str`, independently of the provider's native streaming event format.
+
+By default, `buffer_chars=None` preserves provider text-delta behavior. Set a positive `buffer_chars` value when a consumer prefers bounded, coalesced text; `on_chunk` then receives a `StreamChunk` with the same text and observability metadata.
 
 ```python
 from llm_api_adapter import UniversalLLMAPIAdapter
@@ -158,21 +160,30 @@ adapter = UniversalLLMAPIAdapter(
     api_key="...",
 )
 
-chunks = []
-for delta in adapter.stream_chat(
+chunk_metadata = []
+for text in adapter.stream_chat(
     messages=[{"role": "user", "content": "Explain SSE in one sentence."}],
-    on_delta=chunks.append,
+    buffer_chars=80,
+    on_chunk=chunk_metadata.append,
     on_tool_call=lambda call: print(call.name, call.arguments),
     on_done=lambda response: print(response.usage),
 ):
-    print(delta, end="", flush=True)
+    print(text, end="", flush=True)  # `text` is still a str.
+
+for chunk in chunk_metadata:
+    print(chunk.index, chunk.elapsed_s, chunk.usage, chunk.output_tokens_delta)
 ```
 
-- `on_delta(delta)` is called for every yielded visible text delta.
+- `buffer_chars` accepts `None` (the default) or a positive integer. Buffered chunks never exceed the configured size; any remaining text is emitted during normal completion.
+- `on_chunk(chunk)` receives a `StreamChunk` with `text`, monotonic `index`, local `elapsed_s` / `delta_s`, and optional `usage` / `output_tokens_delta` fields.
+- `on_delta(text)` is called for every yielded visible text chunk. The order is always `on_chunk` → `on_delta` → `yield`.
 - `on_tool_call(tool_call)` receives only completed, normalized `ToolCall` objects after the provider stream finishes.
-- `on_done(response)` receives the finalized `ChatResponse`, including usage, pricing, parsed structured output, and any tool calls.
+- `on_done(response)` receives the finalized `ChatResponse`, including usage, pricing, parsed structured output, and any tool calls, after the final buffer flush.
+- Token metadata is optional and comes only from provider usage payloads. When a provider reports cumulative output usage, `output_tokens_delta` is the local increment; no token estimation is performed.
 
-Streaming in v0.6.0 is synchronous and text-first. Async streaming, buffer/backpressure controls, a universal provider-event type, partial tool arguments, and tool-call sequencing are deferred to later releases.
+Buffering is pull-based and has no background worker or time-based flush. If the stream fails or a caller closes the iterator early, pending text is not emitted as a successful final chunk and `on_done` is not called.
+
+Streaming in v0.6.1 is synchronous and text-first. Async streaming, a universal provider-event type, partial tool arguments, and tool-call sequencing are deferred to later releases.
 
 Provider event references: [OpenAI Responses streaming](https://platform.openai.com/docs/api-reference/responses-streaming), [Anthropic streaming](https://platform.claude.com/docs/en/build-with-claude/streaming), and [Google `streamGenerateContent`](https://ai.google.dev/api/generate-content).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-api-adapter"
-version = "0.6.0"
+version = "0.6.1"
 description = "Lightweight, pluggable adapter for multiple LLM APIs (OpenAI, Anthropic, Google)"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/llm_api_adapter/adapters/anthropic_adapter.py
+++ b/src/llm_api_adapter/adapters/anthropic_adapter.py
@@ -10,9 +10,9 @@ from ..adapters.base_adapter import LLMAdapterBase, OnChunk, OnDelta, OnDone, On
 from ..errors.llm_api_error import InvalidToolArgumentsError, LLMAPIError
 from ..errors.config_errors import LLMReasoningLevelError
 from ..llms.anthropic.sync_client import ClaudeSyncClient
-from ..llms.streaming import StreamChunkBuffer
+from ..llms.streaming import StreamChunkBuffer, StreamUsageTracker
 from ..models.messages.chat_message import Message, Messages
-from ..models.responses.chat_response import ChatResponse
+from ..models.responses.chat_response import ChatResponse, Usage
 from ..models.tools.tool_spec import ToolSpec
 
 logger = logging.getLogger(__name__)
@@ -244,12 +244,17 @@ class AnthropicAdapter(LLMAdapterBase):
         usage: Dict[str, Any] = {}
         message_delta: Dict[str, Any] = {}
         chunk_buffer = StreamChunkBuffer(buffer_chars)
+        usage_tracker = StreamUsageTracker()
 
         for event in self._iter_provider_stream_events(events):
             payload = event.data if isinstance(event.data, Mapping) else {}
             event_type = event.event or payload.get("type")
             if event_type == "message_start":
                 message_data = self._handle_message_start(payload, usage, message_data)
+                usage_tracker.record(
+                    chunk_buffer,
+                    self._normalize_stream_usage(usage),
+                )
             elif event_type == "content_block_start":
                 self._start_content_block(payload, content_blocks)
             elif event_type == "content_block_delta":
@@ -269,6 +274,10 @@ class AnthropicAdapter(LLMAdapterBase):
                 )
             elif event_type == "message_delta":
                 self._handle_message_delta(payload, message_delta, usage)
+                usage_tracker.record(
+                    chunk_buffer,
+                    self._normalize_stream_usage(usage),
+                )
 
         chat_response = ChatResponse.from_anthropic_response(
             self._build_stream_response(message_data, content_blocks, message_delta, usage)
@@ -394,6 +403,24 @@ class AnthropicAdapter(LLMAdapterBase):
         delta_usage = payload.get("usage")
         if isinstance(delta_usage, Mapping):
             usage.update(delta_usage)
+
+    @staticmethod
+    def _normalize_stream_usage(raw_usage: Mapping[str, Any]) -> Optional[Usage]:
+        input_tokens = AnthropicAdapter._token_count(raw_usage.get("input_tokens"))
+        output_tokens = AnthropicAdapter._token_count(raw_usage.get("output_tokens"))
+        if input_tokens is None and output_tokens is None:
+            return None
+        return Usage(
+            input_tokens=input_tokens or 0,
+            output_tokens=output_tokens or 0,
+            total_tokens=(input_tokens or 0) + (output_tokens or 0),
+        )
+
+    @staticmethod
+    def _token_count(value: Any) -> Optional[int]:
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+            return value
+        return None
 
     def _build_stream_response(
         self,

--- a/src/llm_api_adapter/adapters/anthropic_adapter.py
+++ b/src/llm_api_adapter/adapters/anthropic_adapter.py
@@ -6,10 +6,11 @@ import logging
 from typing import Any, Dict, Iterator, List, Mapping, Optional
 import warnings
 
-from ..adapters.base_adapter import LLMAdapterBase, OnDelta, OnDone, OnToolCall
+from ..adapters.base_adapter import LLMAdapterBase, OnChunk, OnDelta, OnDone, OnToolCall
 from ..errors.llm_api_error import InvalidToolArgumentsError, LLMAPIError
 from ..errors.config_errors import LLMReasoningLevelError
 from ..llms.anthropic.sync_client import ClaudeSyncClient
+from ..llms.streaming import StreamChunkBuffer
 from ..models.messages.chat_message import Message, Messages
 from ..models.responses.chat_response import ChatResponse
 from ..models.tools.tool_spec import ToolSpec
@@ -133,6 +134,8 @@ class AnthropicAdapter(LLMAdapterBase):
         on_delta: Optional[OnDelta] = None,
         on_tool_call: Optional[OnToolCall] = None,
         on_done: Optional[OnDone] = None,
+        buffer_chars: Optional[int] = None,
+        on_chunk: Optional[OnChunk] = None,
     ) -> Iterator[str]:
         temperature = self._validate_parameter("temperature", temperature, 0, 2)
         top_p = self._validate_parameter("top_p", top_p, 0, 1)
@@ -162,6 +165,8 @@ class AnthropicAdapter(LLMAdapterBase):
             on_delta,
             on_tool_call,
             on_done,
+            buffer_chars,
+            on_chunk,
         )
 
     def _build_stream_params(
@@ -230,12 +235,15 @@ class AnthropicAdapter(LLMAdapterBase):
         on_delta: Optional[OnDelta],
         on_tool_call: Optional[OnToolCall],
         on_done: Optional[OnDone],
+        buffer_chars: Optional[int],
+        on_chunk: Optional[OnChunk],
     ) -> Iterator[str]:
         message_data: Dict[str, Any] = {"model": self.model, "content": []}
         content_blocks: Dict[int, Dict[str, Any]] = {}
         input_json_fragments: Dict[int, List[str]] = {}
         usage: Dict[str, Any] = {}
         message_delta: Dict[str, Any] = {}
+        chunk_buffer = StreamChunkBuffer(buffer_chars)
 
         for event in self._iter_provider_stream_events(events):
             payload = event.data if isinstance(event.data, Mapping) else {}
@@ -249,6 +257,8 @@ class AnthropicAdapter(LLMAdapterBase):
                     payload,
                     content_blocks,
                     input_json_fragments,
+                    chunk_buffer,
+                    on_chunk,
                     on_delta,
                 )
             elif event_type == "content_block_stop":
@@ -263,10 +273,18 @@ class AnthropicAdapter(LLMAdapterBase):
         chat_response = ChatResponse.from_anthropic_response(
             self._build_stream_response(message_data, content_blocks, message_delta, usage)
         )
-        self._finalize_stream_response(
+        self._prepare_stream_response(
             chat_response,
             effective_schema,
             response_model,
+        )
+        yield from self._emit_stream_chunks(
+            chunk_buffer.flush(),
+            on_chunk,
+            on_delta,
+        )
+        self._invoke_stream_completion_callbacks(
+            chat_response,
             on_tool_call,
             on_done,
         )
@@ -308,6 +326,8 @@ class AnthropicAdapter(LLMAdapterBase):
         payload: Mapping[str, Any],
         content_blocks: Dict[int, Dict[str, Any]],
         input_json_fragments: Dict[int, List[str]],
+        chunk_buffer: StreamChunkBuffer,
+        on_chunk: Optional[OnChunk],
         on_delta: Optional[OnDelta],
     ) -> Iterator[str]:
         index = payload.get("index")
@@ -321,9 +341,11 @@ class AnthropicAdapter(LLMAdapterBase):
             text = delta.get("text")
             if isinstance(text, str) and text:
                 block["text"] = f"{block.get('text', '')}{text}"
-                if on_delta is not None:
-                    on_delta(text)
-                yield text
+                yield from self._emit_stream_chunks(
+                    chunk_buffer.add(text),
+                    on_chunk,
+                    on_delta,
+                )
         elif delta.get("type") == "input_json_delta":
             partial_json = delta.get("partial_json")
             if isinstance(partial_json, str):

--- a/src/llm_api_adapter/adapters/base_adapter.py
+++ b/src/llm_api_adapter/adapters/base_adapter.py
@@ -18,6 +18,7 @@ from ..errors.llm_api_error import (
 from ..llm_registry.llm_registry import Pricing, LLM_REGISTRY
 from ..models.messages.chat_message import Messages
 from ..models.responses.chat_response import ChatResponse
+from ..models.responses.stream_chunk import StreamChunk
 from ..models.tools import ToolCall, ToolSpec
 
 logger = logging.getLogger(__name__)
@@ -32,6 +33,7 @@ REASONING_LEVELS_DEFAULT = {
 TOOL_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
 
 OnDelta = Callable[[str], None]
+OnChunk = Callable[[StreamChunk], None]
 OnToolCall = Callable[[ToolCall], None]
 OnDone = Callable[[ChatResponse], None]
 

--- a/src/llm_api_adapter/adapters/base_adapter.py
+++ b/src/llm_api_adapter/adapters/base_adapter.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 import json
 import logging
 import re
-from typing import Any, Callable, Dict, Iterator, List, Optional
+from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional
 import warnings
 
 from ..errors.llm_api_error import (
@@ -102,8 +102,15 @@ class LLMAdapterBase(ABC):
         on_delta: Optional[OnDelta] = None,
         on_tool_call: Optional[OnToolCall] = None,
         on_done: Optional[OnDone] = None,
+        buffer_chars: Optional[int] = None,
+        on_chunk: Optional[OnChunk] = None,
     ) -> Iterator[str]:
-        """Stream normalized text deltas synchronously."""
+        """Stream normalized text deltas synchronously.
+
+        ``buffer_chars`` optionally coalesces visible text into bounded
+        chunks.  ``on_chunk`` receives each emitted :class:`StreamChunk`
+        before the corresponding ``on_delta`` callback and yielded text.
+        """
         raise NotImplementedError
 
     @abstractmethod
@@ -362,15 +369,13 @@ class LLMAdapterBase(ABC):
             error_message = getattr(error, "text", None) or str(error)
             self.handle_error(error=error, error_message=error_message)
 
-    def _finalize_stream_response(
+    def _prepare_stream_response(
         self,
         chat_response: ChatResponse,
         effective_schema: Optional[dict],
         response_model: Optional[Any],
-        on_tool_call: Optional[OnToolCall],
-        on_done: Optional[OnDone],
     ) -> None:
-        """Apply normal response post-processing, then invoke stream callbacks."""
+        """Apply final response processing before delivering stream callbacks."""
         try:
             chat_response.parsed_json = self._parse_json_response(
                 chat_response.content,
@@ -392,11 +397,52 @@ class LLMAdapterBase(ABC):
             error_message = getattr(error, "text", None) or str(error)
             self.handle_error(error=error, error_message=error_message)
 
+    def _invoke_stream_completion_callbacks(
+        self,
+        chat_response: ChatResponse,
+        on_tool_call: Optional[OnToolCall],
+        on_done: Optional[OnDone],
+    ) -> None:
+        """Deliver finalized tool calls and the completed response."""
         for tool_call in chat_response.tool_calls or []:
             if on_tool_call is not None:
                 on_tool_call(tool_call)
         if on_done is not None:
             on_done(chat_response)
+
+    def _emit_stream_chunks(
+        self,
+        chunks: Iterable[StreamChunk],
+        on_chunk: Optional[OnChunk],
+        on_delta: Optional[OnDelta],
+    ) -> Iterator[str]:
+        """Invoke streaming callbacks in contract order and yield visible text."""
+        for chunk in chunks:
+            if on_chunk is not None:
+                on_chunk(chunk)
+            if on_delta is not None:
+                on_delta(chunk.text)
+            yield chunk.text
+
+    def _finalize_stream_response(
+        self,
+        chat_response: ChatResponse,
+        effective_schema: Optional[dict],
+        response_model: Optional[Any],
+        on_tool_call: Optional[OnToolCall],
+        on_done: Optional[OnDone],
+    ) -> None:
+        """Apply normal response post-processing, then invoke stream callbacks."""
+        self._prepare_stream_response(
+            chat_response,
+            effective_schema,
+            response_model,
+        )
+        self._invoke_stream_completion_callbacks(
+            chat_response,
+            on_tool_call,
+            on_done,
+        )
 
     def handle_error(self, error: Exception, error_message: Optional[str] = None):
         err_msg = (

--- a/src/llm_api_adapter/adapters/google_adapter.py
+++ b/src/llm_api_adapter/adapters/google_adapter.py
@@ -5,9 +5,10 @@ import logging
 from typing import Any, Dict, Iterator, List, Mapping, Optional
 import warnings
 
-from ..adapters.base_adapter import LLMAdapterBase, OnDelta, OnDone, OnToolCall
+from ..adapters.base_adapter import LLMAdapterBase, OnChunk, OnDelta, OnDone, OnToolCall
 from ..errors.llm_api_error import LLMAPIError
 from ..llms.google.sync_client import GeminiSyncClient
+from ..llms.streaming import StreamChunkBuffer
 from ..models.messages.chat_message import Message, Messages
 from ..models.responses.chat_response import ChatResponse
 from ..models.tools import ToolSpec
@@ -136,6 +137,8 @@ class GoogleAdapter(LLMAdapterBase):
         on_delta: Optional[OnDelta] = None,
         on_tool_call: Optional[OnToolCall] = None,
         on_done: Optional[OnDone] = None,
+        buffer_chars: Optional[int] = None,
+        on_chunk: Optional[OnChunk] = None,
     ) -> Iterator[str]:
         temperature = self._validate_parameter("temperature", temperature, 0, 2)
         top_p = self._validate_parameter("top_p", top_p, 0, 1)
@@ -164,6 +167,8 @@ class GoogleAdapter(LLMAdapterBase):
             on_delta,
             on_tool_call,
             on_done,
+            buffer_chars,
+            on_chunk,
         )
 
     def _build_stream_payload(
@@ -219,12 +224,15 @@ class GoogleAdapter(LLMAdapterBase):
         on_delta: Optional[OnDelta],
         on_tool_call: Optional[OnToolCall],
         on_done: Optional[OnDone],
+        buffer_chars: Optional[int],
+        on_chunk: Optional[OnChunk],
     ) -> Iterator[str]:
         text_parts: List[str] = []
         function_parts: List[Dict[str, Any]] = []
         finish_reason: Optional[str] = None
         usage_metadata: Dict[str, Any] = {}
         response_metadata: Dict[str, Any] = {}
+        chunk_buffer = StreamChunkBuffer(buffer_chars)
 
         for event in self._iter_provider_stream_events(events):
             chunk = event.data if isinstance(event.data, Mapping) else {}
@@ -256,9 +264,11 @@ class GoogleAdapter(LLMAdapterBase):
                     and not part.get("thought", False)
                 ):
                     text_parts.append(text)
-                    if on_delta is not None:
-                        on_delta(text)
-                    yield text
+                    yield from self._emit_stream_chunks(
+                        chunk_buffer.add(text),
+                        on_chunk,
+                        on_delta,
+                    )
                 if isinstance(part.get("functionCall"), Mapping):
                     function_parts.append(dict(part))
 
@@ -276,10 +286,18 @@ class GoogleAdapter(LLMAdapterBase):
         if usage_metadata:
             final_response["usageMetadata"] = usage_metadata
         chat_response = ChatResponse.from_google_response(final_response)
-        self._finalize_stream_response(
+        self._prepare_stream_response(
             chat_response,
             effective_schema,
             response_model,
+        )
+        yield from self._emit_stream_chunks(
+            chunk_buffer.flush(),
+            on_chunk,
+            on_delta,
+        )
+        self._invoke_stream_completion_callbacks(
+            chat_response,
             on_tool_call,
             on_done,
         )

--- a/src/llm_api_adapter/adapters/google_adapter.py
+++ b/src/llm_api_adapter/adapters/google_adapter.py
@@ -8,9 +8,9 @@ import warnings
 from ..adapters.base_adapter import LLMAdapterBase, OnChunk, OnDelta, OnDone, OnToolCall
 from ..errors.llm_api_error import LLMAPIError
 from ..llms.google.sync_client import GeminiSyncClient
-from ..llms.streaming import StreamChunkBuffer
+from ..llms.streaming import StreamChunkBuffer, StreamUsageTracker
 from ..models.messages.chat_message import Message, Messages
-from ..models.responses.chat_response import ChatResponse
+from ..models.responses.chat_response import ChatResponse, Usage
 from ..models.tools import ToolSpec
 
 logger = logging.getLogger(__name__)
@@ -233,6 +233,7 @@ class GoogleAdapter(LLMAdapterBase):
         usage_metadata: Dict[str, Any] = {}
         response_metadata: Dict[str, Any] = {}
         chunk_buffer = StreamChunkBuffer(buffer_chars)
+        usage_tracker = StreamUsageTracker()
 
         for event in self._iter_provider_stream_events(events):
             chunk = event.data if isinstance(event.data, Mapping) else {}
@@ -242,6 +243,10 @@ class GoogleAdapter(LLMAdapterBase):
             chunk_usage = chunk.get("usageMetadata")
             if isinstance(chunk_usage, Mapping):
                 usage_metadata.update(chunk_usage)
+                usage_tracker.record(
+                    chunk_buffer,
+                    self._normalize_stream_usage(usage_metadata),
+                )
             candidates = chunk.get("candidates")
             if not isinstance(candidates, list) or not candidates:
                 continue
@@ -301,6 +306,33 @@ class GoogleAdapter(LLMAdapterBase):
             on_tool_call,
             on_done,
         )
+
+    @staticmethod
+    def _normalize_stream_usage(raw_usage: Mapping[str, Any]) -> Optional[Usage]:
+        input_tokens = GoogleAdapter._token_count(raw_usage.get("promptTokenCount"))
+        candidate_tokens = GoogleAdapter._token_count(
+            raw_usage.get("candidatesTokenCount")
+        )
+        thoughts_tokens = GoogleAdapter._token_count(raw_usage.get("thoughtsTokenCount"))
+        total_tokens = GoogleAdapter._token_count(raw_usage.get("totalTokenCount"))
+        if (
+            input_tokens is None
+            and candidate_tokens is None
+            and thoughts_tokens is None
+            and total_tokens is None
+        ):
+            return None
+        return Usage(
+            input_tokens=input_tokens or 0,
+            output_tokens=(candidate_tokens or 0) + (thoughts_tokens or 0),
+            total_tokens=total_tokens or 0,
+        )
+
+    @staticmethod
+    def _token_count(value: Any) -> Optional[int]:
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+            return value
+        return None
 
     # Fields not supported by Google's responseSchema subset of JSON Schema.
     _GOOGLE_SCHEMA_UNSUPPORTED = frozenset({"additionalProperties", "$schema", "$id", "$ref"})

--- a/src/llm_api_adapter/adapters/openai_adapter.py
+++ b/src/llm_api_adapter/adapters/openai_adapter.py
@@ -6,8 +6,9 @@ import logging
 from typing import Any, Dict, Iterator, List, Mapping, Optional
 import warnings
 
-from ..adapters.base_adapter import LLMAdapterBase, OnDelta, OnDone, OnToolCall
+from ..adapters.base_adapter import LLMAdapterBase, OnChunk, OnDelta, OnDone, OnToolCall
 from ..errors.llm_api_error import LLMAPIError
+from ..llms.streaming import StreamChunkBuffer
 from ..llms.openai.sync_client import OpenAISyncClient
 from ..models.messages.chat_message import Message, Messages
 from ..models.responses.chat_response import ChatResponse
@@ -159,6 +160,8 @@ class OpenAIAdapter(LLMAdapterBase):
         on_delta: Optional[OnDelta] = None,
         on_tool_call: Optional[OnToolCall] = None,
         on_done: Optional[OnDone] = None,
+        buffer_chars: Optional[int] = None,
+        on_chunk: Optional[OnChunk] = None,
     ) -> Iterator[str]:
         temperature = self._validate_parameter("temperature", temperature, 0, 2)
         top_p = self._validate_parameter("top_p", top_p, 0, 1)
@@ -190,6 +193,8 @@ class OpenAIAdapter(LLMAdapterBase):
                 on_delta,
                 on_tool_call,
                 on_done,
+                buffer_chars,
+                on_chunk,
             )
             return
         yield from self._consume_chat_completions_stream(
@@ -199,6 +204,8 @@ class OpenAIAdapter(LLMAdapterBase):
             on_delta,
             on_tool_call,
             on_done,
+            buffer_chars,
+            on_chunk,
         )
 
     def _build_stream_params(
@@ -269,11 +276,14 @@ class OpenAIAdapter(LLMAdapterBase):
         on_delta: Optional[OnDelta],
         on_tool_call: Optional[OnToolCall],
         on_done: Optional[OnDone],
+        buffer_chars: Optional[int],
+        on_chunk: Optional[OnChunk],
     ) -> Iterator[str]:
         final_response: Optional[dict] = None
         response_metadata: Dict[str, Any] = {}
         text_parts: List[str] = []
         function_calls: Dict[str, Dict[str, Any]] = {}
+        chunk_buffer = StreamChunkBuffer(buffer_chars)
         for event in self._iter_provider_stream_events(events):
             payload = event.data if isinstance(event.data, Mapping) else {}
             event_type = event.event or payload.get("type")
@@ -284,9 +294,11 @@ class OpenAIAdapter(LLMAdapterBase):
                 delta = payload.get("delta")
                 if isinstance(delta, str) and delta:
                     text_parts.append(delta)
-                    if on_delta is not None:
-                        on_delta(delta)
-                    yield delta
+                    yield from self._emit_stream_chunks(
+                        chunk_buffer.add(delta),
+                        on_chunk,
+                        on_delta,
+                    )
             elif event_type in (
                 "response.function_call_arguments.delta",
                 "response.function_call_arguments.done",
@@ -324,10 +336,19 @@ class OpenAIAdapter(LLMAdapterBase):
                 "output": output,
                 "status": response_metadata.get("status", "completed"),
             }
-        self._finalize_stream_response(
-            ChatResponse.from_openai_responses_response(final_response),
+        chat_response = ChatResponse.from_openai_responses_response(final_response)
+        self._prepare_stream_response(
+            chat_response,
             effective_schema,
             response_model,
+        )
+        yield from self._emit_stream_chunks(
+            chunk_buffer.flush(),
+            on_chunk,
+            on_delta,
+        )
+        self._invoke_stream_completion_callbacks(
+            chat_response,
             on_tool_call,
             on_done,
         )
@@ -340,66 +361,128 @@ class OpenAIAdapter(LLMAdapterBase):
         on_delta: Optional[OnDelta],
         on_tool_call: Optional[OnToolCall],
         on_done: Optional[OnDone],
+        buffer_chars: Optional[int],
+        on_chunk: Optional[OnChunk],
     ) -> Iterator[str]:
         text_parts: List[str] = []
         tool_calls: Dict[int, Dict[str, Any]] = {}
         legacy_response: Dict[str, Any] = {"model": self.model, "choices": []}
         finish_reason: Optional[str] = None
+        chunk_buffer = StreamChunkBuffer(buffer_chars)
         for event in self._iter_provider_stream_events(events):
             payload = event.data if isinstance(event.data, Mapping) else {}
-            for field in ("id", "model", "created", "usage"):
-                if field in payload:
-                    legacy_response[field] = payload[field]
+            self._update_legacy_stream_metadata(payload, legacy_response)
             choices = payload.get("choices")
             if not isinstance(choices, list):
                 continue
             for choice in choices:
-                if not isinstance(choice, Mapping) or choice.get("index", 0) != 0:
-                    continue
-                delta = choice.get("delta") or {}
-                if not isinstance(delta, Mapping):
-                    delta = {}
-                content = delta.get("content")
-                if isinstance(content, str) and content:
-                    text_parts.append(content)
-                    if on_delta is not None:
-                        on_delta(content)
-                    yield content
-                raw_tool_calls = delta.get("tool_calls")
-                if isinstance(raw_tool_calls, list):
-                    for raw_tool_call in raw_tool_calls:
-                        if not isinstance(raw_tool_call, Mapping):
-                            continue
-                        index = raw_tool_call.get("index")
-                        if not isinstance(index, int):
-                            index = len(tool_calls)
-                        tool_call = tool_calls.setdefault(index, {"function": {"arguments": ""}})
-                        for field in ("id", "type"):
-                            if raw_tool_call.get(field) is not None:
-                                tool_call[field] = raw_tool_call[field]
-                        function = raw_tool_call.get("function") or {}
-                        if isinstance(function, Mapping):
-                            target = tool_call["function"]
-                            if function.get("name") is not None:
-                                target["name"] = function["name"]
-                            arguments = function.get("arguments")
-                            if isinstance(arguments, str):
-                                target["arguments"] = f"{target.get('arguments', '')}{arguments}"
-                            elif isinstance(arguments, dict):
-                                target["arguments"] = arguments
-                if choice.get("finish_reason") is not None:
-                    finish_reason = choice["finish_reason"]
+                text, choice_finish_reason = self._consume_legacy_stream_choice(
+                    choice,
+                    text_parts,
+                    tool_calls,
+                )
+                if text is not None:
+                    yield from self._emit_stream_chunks(
+                        chunk_buffer.add(text),
+                        on_chunk,
+                        on_delta,
+                    )
+                if choice_finish_reason is not None:
+                    finish_reason = choice_finish_reason
+        chat_response = self._build_legacy_stream_response(
+            legacy_response,
+            text_parts,
+            tool_calls,
+            finish_reason,
+        )
+        self._prepare_stream_response(
+            chat_response,
+            effective_schema,
+            response_model,
+        )
+        yield from self._emit_stream_chunks(
+            chunk_buffer.flush(),
+            on_chunk,
+            on_delta,
+        )
+        self._invoke_stream_completion_callbacks(
+            chat_response,
+            on_tool_call,
+            on_done,
+        )
+
+    @staticmethod
+    def _update_legacy_stream_metadata(
+        payload: Mapping[str, Any],
+        legacy_response: Dict[str, Any],
+    ) -> None:
+        for field in ("id", "model", "created", "usage"):
+            if field in payload:
+                legacy_response[field] = payload[field]
+
+    def _consume_legacy_stream_choice(
+        self,
+        choice: Any,
+        text_parts: List[str],
+        tool_calls: Dict[int, Dict[str, Any]],
+    ) -> tuple[Optional[str], Optional[str]]:
+        if not isinstance(choice, Mapping) or choice.get("index", 0) != 0:
+            return None, None
+
+        delta = choice.get("delta") or {}
+        if not isinstance(delta, Mapping):
+            delta = {}
+        content = delta.get("content")
+        text = content if isinstance(content, str) and content else None
+        if text is not None:
+            text_parts.append(text)
+
+        raw_tool_calls = delta.get("tool_calls")
+        if isinstance(raw_tool_calls, list):
+            self._accumulate_legacy_tool_calls(raw_tool_calls, tool_calls)
+
+        finish_reason = choice.get("finish_reason")
+        return text, finish_reason
+
+    @staticmethod
+    def _accumulate_legacy_tool_calls(
+        raw_tool_calls: List[Any],
+        tool_calls: Dict[int, Dict[str, Any]],
+    ) -> None:
+        for raw_tool_call in raw_tool_calls:
+            if not isinstance(raw_tool_call, Mapping):
+                continue
+            index = raw_tool_call.get("index")
+            if not isinstance(index, int):
+                index = len(tool_calls)
+            tool_call = tool_calls.setdefault(index, {"function": {"arguments": ""}})
+            for field in ("id", "type"):
+                if raw_tool_call.get(field) is not None:
+                    tool_call[field] = raw_tool_call[field]
+            function = raw_tool_call.get("function") or {}
+            if not isinstance(function, Mapping):
+                continue
+            target = tool_call["function"]
+            if function.get("name") is not None:
+                target["name"] = function["name"]
+            arguments = function.get("arguments")
+            if isinstance(arguments, str):
+                target["arguments"] = f"{target.get('arguments', '')}{arguments}"
+            elif isinstance(arguments, dict):
+                target["arguments"] = arguments
+
+    @staticmethod
+    def _build_legacy_stream_response(
+        legacy_response: Dict[str, Any],
+        text_parts: List[str],
+        tool_calls: Dict[int, Dict[str, Any]],
+        finish_reason: Optional[str],
+    ) -> ChatResponse:
         message: Dict[str, Any] = {"content": "".join(text_parts) or None}
         if tool_calls:
             message["tool_calls"] = [tool_calls[index] for index in sorted(tool_calls)]
         legacy_response["choices"] = [{"message": message, "finish_reason": finish_reason}]
-        self._finalize_stream_response(
-            ChatResponse.from_openai_response(legacy_response),
-            effective_schema,
-            response_model,
-            on_tool_call,
-            on_done,
-        )
+        return ChatResponse.from_openai_response(legacy_response)
 
     def _map_tools_to_openai(
         self,

--- a/src/llm_api_adapter/adapters/openai_adapter.py
+++ b/src/llm_api_adapter/adapters/openai_adapter.py
@@ -8,64 +8,13 @@ import warnings
 
 from ..adapters.base_adapter import LLMAdapterBase, OnChunk, OnDelta, OnDone, OnToolCall
 from ..errors.llm_api_error import LLMAPIError
-from ..llms.streaming import StreamChunkBuffer
+from ..llms.streaming import StreamChunkBuffer, StreamUsageTracker
 from ..llms.openai.sync_client import OpenAISyncClient
 from ..models.messages.chat_message import Message, Messages
 from ..models.responses.chat_response import ChatResponse, Usage
 from ..models.tools import ToolSpec
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass
-class _OpenAIStreamUsageTracker:
-    """Attach provider usage snapshots to future emitted stream chunks."""
-
-    input_field: str
-    output_field: str
-    _last_output_tokens: Optional[int] = None
-
-    def record(self, buffer: StreamChunkBuffer, raw_usage: Any) -> None:
-        usage = self._normalize(raw_usage)
-        if usage is None:
-            return
-
-        previous_output_tokens = self._last_output_tokens
-        output_tokens_delta = (
-            usage.output_tokens
-            if previous_output_tokens is None
-            else max(0, usage.output_tokens - previous_output_tokens)
-        )
-        self._last_output_tokens = (
-            usage.output_tokens
-            if previous_output_tokens is None
-            else max(previous_output_tokens, usage.output_tokens)
-        )
-        buffer.update_metadata(
-            usage=usage,
-            output_tokens_delta=output_tokens_delta,
-        )
-
-    def _normalize(self, raw_usage: Any) -> Optional[Usage]:
-        if not isinstance(raw_usage, Mapping):
-            return None
-
-        input_tokens = self._token_count(raw_usage.get(self.input_field))
-        output_tokens = self._token_count(raw_usage.get(self.output_field))
-        total_tokens = self._token_count(raw_usage.get("total_tokens"))
-        if input_tokens is None and output_tokens is None and total_tokens is None:
-            return None
-        return Usage(
-            input_tokens=input_tokens or 0,
-            output_tokens=output_tokens or 0,
-            total_tokens=total_tokens or 0,
-        )
-
-    @staticmethod
-    def _token_count(value: Any) -> Optional[int]:
-        if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
-            return value
-        return None
 
 
 @dataclass(repr=False)
@@ -335,10 +284,7 @@ class OpenAIAdapter(LLMAdapterBase):
         text_parts: List[str] = []
         function_calls: Dict[str, Dict[str, Any]] = {}
         chunk_buffer = StreamChunkBuffer(buffer_chars)
-        usage_tracker = _OpenAIStreamUsageTracker(
-            input_field="input_tokens",
-            output_field="output_tokens",
-        )
+        usage_tracker = StreamUsageTracker()
         for event in self._iter_provider_stream_events(events):
             payload = event.data if isinstance(event.data, Mapping) else {}
             event_type = event.event or payload.get("type")
@@ -347,7 +293,11 @@ class OpenAIAdapter(LLMAdapterBase):
                 response_metadata.update(response_data)
             usage_tracker.record(
                 chunk_buffer,
-                self._response_event_usage(payload, response_data),
+                self._normalize_stream_usage(
+                    self._response_event_usage(payload, response_data),
+                    input_field="input_tokens",
+                    output_field="output_tokens",
+                ),
             )
             if event_type == "response.output_text.delta":
                 delta = payload.get("delta")
@@ -428,14 +378,18 @@ class OpenAIAdapter(LLMAdapterBase):
         legacy_response: Dict[str, Any] = {"model": self.model, "choices": []}
         finish_reason: Optional[str] = None
         chunk_buffer = StreamChunkBuffer(buffer_chars)
-        usage_tracker = _OpenAIStreamUsageTracker(
-            input_field="prompt_tokens",
-            output_field="completion_tokens",
-        )
+        usage_tracker = StreamUsageTracker()
         for event in self._iter_provider_stream_events(events):
             payload = event.data if isinstance(event.data, Mapping) else {}
             self._update_legacy_stream_metadata(payload, legacy_response)
-            usage_tracker.record(chunk_buffer, payload.get("usage"))
+            usage_tracker.record(
+                chunk_buffer,
+                self._normalize_stream_usage(
+                    payload.get("usage"),
+                    input_field="prompt_tokens",
+                    output_field="completion_tokens",
+                ),
+            )
             choices = payload.get("choices")
             if not isinstance(choices, list):
                 continue
@@ -493,6 +447,33 @@ class OpenAIAdapter(LLMAdapterBase):
             return payload["usage"]
         if isinstance(response_data, Mapping):
             return response_data.get("usage")
+        return None
+
+    @staticmethod
+    def _normalize_stream_usage(
+        raw_usage: Any,
+        *,
+        input_field: str,
+        output_field: str,
+    ) -> Optional[Usage]:
+        if not isinstance(raw_usage, Mapping):
+            return None
+
+        input_tokens = OpenAIAdapter._token_count(raw_usage.get(input_field))
+        output_tokens = OpenAIAdapter._token_count(raw_usage.get(output_field))
+        total_tokens = OpenAIAdapter._token_count(raw_usage.get("total_tokens"))
+        if input_tokens is None and output_tokens is None and total_tokens is None:
+            return None
+        return Usage(
+            input_tokens=input_tokens or 0,
+            output_tokens=output_tokens or 0,
+            total_tokens=total_tokens or 0,
+        )
+
+    @staticmethod
+    def _token_count(value: Any) -> Optional[int]:
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+            return value
         return None
 
     def _consume_legacy_stream_choice(

--- a/src/llm_api_adapter/adapters/openai_adapter.py
+++ b/src/llm_api_adapter/adapters/openai_adapter.py
@@ -11,10 +11,61 @@ from ..errors.llm_api_error import LLMAPIError
 from ..llms.streaming import StreamChunkBuffer
 from ..llms.openai.sync_client import OpenAISyncClient
 from ..models.messages.chat_message import Message, Messages
-from ..models.responses.chat_response import ChatResponse
+from ..models.responses.chat_response import ChatResponse, Usage
 from ..models.tools import ToolSpec
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _OpenAIStreamUsageTracker:
+    """Attach provider usage snapshots to future emitted stream chunks."""
+
+    input_field: str
+    output_field: str
+    _last_output_tokens: Optional[int] = None
+
+    def record(self, buffer: StreamChunkBuffer, raw_usage: Any) -> None:
+        usage = self._normalize(raw_usage)
+        if usage is None:
+            return
+
+        previous_output_tokens = self._last_output_tokens
+        output_tokens_delta = (
+            usage.output_tokens
+            if previous_output_tokens is None
+            else max(0, usage.output_tokens - previous_output_tokens)
+        )
+        self._last_output_tokens = (
+            usage.output_tokens
+            if previous_output_tokens is None
+            else max(previous_output_tokens, usage.output_tokens)
+        )
+        buffer.update_metadata(
+            usage=usage,
+            output_tokens_delta=output_tokens_delta,
+        )
+
+    def _normalize(self, raw_usage: Any) -> Optional[Usage]:
+        if not isinstance(raw_usage, Mapping):
+            return None
+
+        input_tokens = self._token_count(raw_usage.get(self.input_field))
+        output_tokens = self._token_count(raw_usage.get(self.output_field))
+        total_tokens = self._token_count(raw_usage.get("total_tokens"))
+        if input_tokens is None and output_tokens is None and total_tokens is None:
+            return None
+        return Usage(
+            input_tokens=input_tokens or 0,
+            output_tokens=output_tokens or 0,
+            total_tokens=total_tokens or 0,
+        )
+
+    @staticmethod
+    def _token_count(value: Any) -> Optional[int]:
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+            return value
+        return None
 
 
 @dataclass(repr=False)
@@ -284,12 +335,20 @@ class OpenAIAdapter(LLMAdapterBase):
         text_parts: List[str] = []
         function_calls: Dict[str, Dict[str, Any]] = {}
         chunk_buffer = StreamChunkBuffer(buffer_chars)
+        usage_tracker = _OpenAIStreamUsageTracker(
+            input_field="input_tokens",
+            output_field="output_tokens",
+        )
         for event in self._iter_provider_stream_events(events):
             payload = event.data if isinstance(event.data, Mapping) else {}
             event_type = event.event or payload.get("type")
             response_data = payload.get("response")
             if isinstance(response_data, Mapping):
                 response_metadata.update(response_data)
+            usage_tracker.record(
+                chunk_buffer,
+                self._response_event_usage(payload, response_data),
+            )
             if event_type == "response.output_text.delta":
                 delta = payload.get("delta")
                 if isinstance(delta, str) and delta:
@@ -369,9 +428,14 @@ class OpenAIAdapter(LLMAdapterBase):
         legacy_response: Dict[str, Any] = {"model": self.model, "choices": []}
         finish_reason: Optional[str] = None
         chunk_buffer = StreamChunkBuffer(buffer_chars)
+        usage_tracker = _OpenAIStreamUsageTracker(
+            input_field="prompt_tokens",
+            output_field="completion_tokens",
+        )
         for event in self._iter_provider_stream_events(events):
             payload = event.data if isinstance(event.data, Mapping) else {}
             self._update_legacy_stream_metadata(payload, legacy_response)
+            usage_tracker.record(chunk_buffer, payload.get("usage"))
             choices = payload.get("choices")
             if not isinstance(choices, list):
                 continue
@@ -419,6 +483,17 @@ class OpenAIAdapter(LLMAdapterBase):
         for field in ("id", "model", "created", "usage"):
             if field in payload:
                 legacy_response[field] = payload[field]
+
+    @staticmethod
+    def _response_event_usage(
+        payload: Mapping[str, Any],
+        response_data: Any,
+    ) -> Any:
+        if isinstance(payload.get("usage"), Mapping):
+            return payload["usage"]
+        if isinstance(response_data, Mapping):
+            return response_data.get("usage")
+        return None
 
     def _consume_legacy_stream_choice(
         self,

--- a/src/llm_api_adapter/llm_registry/llm_registry.json
+++ b/src/llm_api_adapter/llm_registry/llm_registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 7,
-  "effective_date": "2026-07-14",
+  "effective_date": "2026-07-27",
   "providers": {
     "openai": {
       "currency": "USD",
@@ -68,8 +68,13 @@
           "is_reasoning": true,
           "is_adaptive_thinking": true
         },
+        "claude-opus-5": {
+          "pricing": {"in_per_1m": 5.0, "out_per_1m": 25.0},
+          "is_reasoning": true,
+          "is_adaptive_thinking": true
+        },
         "claude-sonnet-5": {
-          "pricing": {"in_per_1m": 3.0, "out_per_1m": 15.0},
+          "pricing": {"in_per_1m": 2.0, "out_per_1m": 10.0},
           "is_reasoning": true,
           "is_adaptive_thinking": true
         },

--- a/src/llm_api_adapter/llms/streaming.py
+++ b/src/llm_api_adapter/llms/streaming.py
@@ -110,6 +110,15 @@ class StreamChunkBuffer:
             self._pending_text = self._pending_text[self._buffer_chars :]
             yield self._build_chunk(chunk_text, emitted_at)
 
+    def update_metadata(
+        self,
+        *,
+        usage: Optional[Usage] = None,
+        output_tokens_delta: Optional[int] = None,
+    ) -> None:
+        """Store metadata for the next emitted chunk without adding text."""
+        self._update_metadata(usage, output_tokens_delta)
+
     def flush(self) -> Iterator[StreamChunk]:
         """Emit pending text, if any, at normal stream completion."""
         if not self._pending_text:

--- a/src/llm_api_adapter/llms/streaming.py
+++ b/src/llm_api_adapter/llms/streaming.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import json
 import logging
+import time
 from typing import Any, Callable, Iterator, Mapping, Optional
 
 import requests
@@ -21,6 +22,8 @@ from ..errors.llm_api_error import (
     LLMAPIServerError,
     LLMAPITimeoutError,
 )
+from ..models.responses.chat_response import Usage
+from ..models.responses.stream_chunk import StreamChunk
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +44,108 @@ class SSEEvent:
 
 HTTPErrorHandler = Callable[[requests.exceptions.HTTPError], Any]
 StreamErrorHandler = Callable[[SSEEvent], Any]
+Clock = Callable[[], float]
+
+
+class StreamChunkBuffer:
+    """Buffer visible text and emit :class:`StreamChunk` values.
+
+    With ``buffer_chars=None`` each non-empty input is emitted immediately.
+    A positive ``buffer_chars`` coalesces text until full chunks can be
+    emitted; :meth:`flush` emits the remaining text.  The class deliberately
+    has no provider-specific parsing or background work.
+    """
+
+    def __init__(
+        self,
+        buffer_chars: Optional[int] = None,
+        *,
+        clock: Clock = time.perf_counter,
+    ) -> None:
+        if (
+            buffer_chars is not None
+            and (
+                isinstance(buffer_chars, bool)
+                or not isinstance(buffer_chars, int)
+                or buffer_chars <= 0
+            )
+        ):
+            raise ValueError("buffer_chars must be None or a positive integer")
+
+        self._buffer_chars = buffer_chars
+        self._clock = clock
+        self._started_at = clock()
+        self._last_emitted_at = self._started_at
+        self._next_index = 0
+        self._pending_text = ""
+        self._usage: Optional[Usage] = None
+        self._output_tokens_delta: Optional[int] = None
+
+    def add(
+        self,
+        text: str,
+        *,
+        usage: Optional[Usage] = None,
+        output_tokens_delta: Optional[int] = None,
+    ) -> Iterator[StreamChunk]:
+        """Accept provider-normalized text and yield every completed chunk."""
+        if not isinstance(text, str):
+            raise TypeError("text must be a string")
+
+        self._update_metadata(usage, output_tokens_delta)
+        if not text:
+            return
+
+        if self._buffer_chars is None:
+            yield self._build_chunk(text, self._clock())
+            return
+
+        self._pending_text += text
+        if len(self._pending_text) < self._buffer_chars:
+            return
+
+        emitted_at = self._clock()
+        while len(self._pending_text) >= self._buffer_chars:
+            chunk_text = self._pending_text[: self._buffer_chars]
+            self._pending_text = self._pending_text[self._buffer_chars :]
+            yield self._build_chunk(chunk_text, emitted_at)
+
+    def flush(self) -> Iterator[StreamChunk]:
+        """Emit pending text, if any, at normal stream completion."""
+        if not self._pending_text:
+            return
+
+        pending_text = self._pending_text
+        self._pending_text = ""
+        yield self._build_chunk(pending_text, self._clock())
+
+    def _update_metadata(
+        self,
+        usage: Optional[Usage],
+        output_tokens_delta: Optional[int],
+    ) -> None:
+        if usage is not None:
+            self._usage = Usage(
+                input_tokens=usage.input_tokens,
+                output_tokens=usage.output_tokens,
+                total_tokens=usage.total_tokens,
+            )
+        if output_tokens_delta is not None:
+            self._output_tokens_delta = output_tokens_delta
+
+    def _build_chunk(self, text: str, emitted_at: float) -> StreamChunk:
+        chunk = StreamChunk(
+            text=text,
+            index=self._next_index,
+            elapsed_s=emitted_at - self._started_at,
+            delta_s=emitted_at - self._last_emitted_at,
+            usage=self._usage,
+            output_tokens_delta=self._output_tokens_delta,
+        )
+        self._next_index += 1
+        self._last_emitted_at = emitted_at
+        self._output_tokens_delta = None
+        return chunk
 
 
 def _decode_line(line: bytes | str) -> str:

--- a/src/llm_api_adapter/llms/streaming.py
+++ b/src/llm_api_adapter/llms/streaming.py
@@ -157,6 +157,38 @@ class StreamChunkBuffer:
         return chunk
 
 
+class StreamUsageTracker:
+    """Attach cumulative provider usage snapshots to future stream chunks."""
+
+    def __init__(self) -> None:
+        self._last_output_tokens: Optional[int] = None
+
+    def record(
+        self,
+        buffer: StreamChunkBuffer,
+        usage: Optional[Usage],
+    ) -> None:
+        """Store ``usage`` and its output-token increment for the next chunk."""
+        if usage is None:
+            return
+
+        previous_output_tokens = self._last_output_tokens
+        output_tokens_delta = (
+            usage.output_tokens
+            if previous_output_tokens is None
+            else max(0, usage.output_tokens - previous_output_tokens)
+        )
+        self._last_output_tokens = (
+            usage.output_tokens
+            if previous_output_tokens is None
+            else max(previous_output_tokens, usage.output_tokens)
+        )
+        buffer.update_metadata(
+            usage=usage,
+            output_tokens_delta=output_tokens_delta,
+        )
+
+
 def _decode_line(line: bytes | str) -> str:
     if isinstance(line, bytes):
         return line.decode("utf-8")

--- a/src/llm_api_adapter/models/__init__.py
+++ b/src/llm_api_adapter/models/__init__.py
@@ -1,0 +1,3 @@
+from .responses import ChatResponse, StreamChunk, Usage
+
+__all__ = ["ChatResponse", "StreamChunk", "Usage"]

--- a/src/llm_api_adapter/models/responses/__init__.py
+++ b/src/llm_api_adapter/models/responses/__init__.py
@@ -1,0 +1,4 @@
+from .chat_response import ChatResponse, Usage
+from .stream_chunk import StreamChunk
+
+__all__ = ["ChatResponse", "StreamChunk", "Usage"]

--- a/src/llm_api_adapter/models/responses/stream_chunk.py
+++ b/src/llm_api_adapter/models/responses/stream_chunk.py
@@ -1,0 +1,36 @@
+"""Public value object for visible streaming chunks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from .chat_response import Usage
+
+
+@dataclass(frozen=True)
+class StreamChunk:
+    """A visible text chunk with local stream-observability metadata.
+
+    ``usage`` is copied when a chunk is created.  A chunk therefore never
+    exposes a mutable usage object held by an adapter's internal accumulator.
+    """
+
+    text: str
+    index: int
+    elapsed_s: float
+    delta_s: float
+    usage: Optional[Usage] = None
+    output_tokens_delta: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        if self.usage is not None:
+            object.__setattr__(
+                self,
+                "usage",
+                Usage(
+                    input_tokens=self.usage.input_tokens,
+                    output_tokens=self.usage.output_tokens,
+                    total_tokens=self.usage.total_tokens,
+                ),
+            )

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -8,6 +8,10 @@ import pytest
 
 from llm_api_adapter.errors import LLMAPIRateLimitError, LLMAPIServerError
 from llm_api_adapter.llm_registry.llm_registry import LLM_REGISTRY
+from src.llm_api_adapter.errors import (
+    LLMAPIRateLimitError as SourceLLMAPIRateLimitError,
+    LLMAPIServerError as SourceLLMAPIServerError,
+)
 
 _FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
 
@@ -38,7 +42,7 @@ def chat_with_retry():
     Delays follow exponential backoff: 2s, 4s, 8s.
     """
     _delays = [2, 4, 8]
-    _max_attempts = len(_delays)
+    _max_attempts = len(_delays) + 1
 
     def _call(adapter, **kwargs):
         for attempt in range(_max_attempts):
@@ -58,17 +62,29 @@ def chat_with_retry():
 
 @pytest.fixture(scope="session")
 def stream_with_retry():
-    """Returns a helper that retries a complete stream on transient provider errors."""
+    """Returns a helper that retries a complete stream on transient provider errors.
+
+    ``on_retry`` may reset callback observers after a partial failed attempt.
+    """
     _delays = [2, 4, 8]
-    _max_attempts = len(_delays)
+    _max_attempts = len(_delays) + 1
+    _transient_errors = (
+        LLMAPIServerError,
+        LLMAPIRateLimitError,
+        SourceLLMAPIServerError,
+        SourceLLMAPIRateLimitError,
+    )
 
     def _call(adapter, **kwargs):
+        on_retry = kwargs.pop("on_retry", None)
         for attempt in range(_max_attempts):
             try:
                 return list(adapter.stream_chat(**kwargs))
-            except (LLMAPIServerError, LLMAPIRateLimitError):
+            except _transient_errors:
                 if attempt == _max_attempts - 1:
                     raise
+                if on_retry is not None:
+                    on_retry()
                 time.sleep(_delays[attempt])
         return []
 

--- a/tests/e2e/test_streaming.py
+++ b/tests/e2e/test_streaming.py
@@ -2,8 +2,8 @@ import os
 
 import pytest
 
-from llm_api_adapter.models.messages.chat_message import UserMessage
-from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
+from src.llm_api_adapter.models.messages.chat_message import UserMessage
+from src.llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
 
 
 _STREAMING_SCENARIOS = [
@@ -32,22 +32,40 @@ def test_stream_chat_returns_text_and_finalized_response(
         api_key=api_key,
     )
     completed_responses = []
-    chunks = stream_with_retry(
+    observed_chunks = []
+    text_chunks = stream_with_retry(
         adapter,
         messages=[UserMessage("Reply with exactly: OK")],
         max_tokens=64,
         temperature=0,
         timeout_s=60,
+        buffer_chars=8,
+        on_chunk=observed_chunks.append,
         on_done=completed_responses.append,
     )
 
-    assert "".join(chunks).strip()
+    streamed_text = "".join(text_chunks)
+    assert streamed_text.strip()
+    assert [chunk.text for chunk in observed_chunks] == text_chunks
+    assert [chunk.index for chunk in observed_chunks] == list(range(len(observed_chunks)))
+    assert [chunk.elapsed_s for chunk in observed_chunks] == sorted(
+        chunk.elapsed_s for chunk in observed_chunks
+    )
+    assert all(chunk.delta_s >= 0 for chunk in observed_chunks)
     assert len(completed_responses) == 1
 
     response = completed_responses[0]
     assert isinstance(response.model, str) and response.model
-    assert response.usage is not None
-    assert response.usage.input_tokens >= 0
-    assert response.usage.output_tokens >= 0
-    assert response.usage.total_tokens >= response.usage.input_tokens
+    assert response.content == streamed_text
+    if response.usage is not None:
+        assert response.usage.input_tokens >= 0
+        assert response.usage.output_tokens >= 0
+        assert response.usage.total_tokens >= response.usage.input_tokens
+    for chunk in observed_chunks:
+        if chunk.usage is not None:
+            assert chunk.usage.input_tokens >= 0
+            assert chunk.usage.output_tokens >= 0
+            assert chunk.usage.total_tokens >= chunk.usage.input_tokens
+        if chunk.output_tokens_delta is not None:
+            assert chunk.output_tokens_delta >= 0
     assert isinstance(response.finish_reason, str) and response.finish_reason

--- a/tests/e2e/test_streaming.py
+++ b/tests/e2e/test_streaming.py
@@ -1,71 +1,73 @@
-import os
-
 import pytest
 
 from src.llm_api_adapter.models.messages.chat_message import UserMessage
 from src.llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
 
-
-_STREAMING_SCENARIOS = [
-    pytest.param("openai", "gpt-5-nano", "OPENAI_API_KEY", id="openai-responses"),
-    pytest.param("openai", "gpt-4.1-mini", "OPENAI_API_KEY", id="openai-chat-completions"),
-    pytest.param("anthropic", "claude-haiku-4-5", "ANTHROPIC_API_KEY", id="anthropic"),
-    pytest.param("google", "gemini-2.5-flash", "GOOGLE_API_KEY", id="google"),
-]
-
-
 @pytest.mark.e2e
-@pytest.mark.parametrize(("organization", "model", "api_key_env"), _STREAMING_SCENARIOS)
 def test_stream_chat_returns_text_and_finalized_response(
-    organization,
-    model,
-    api_key_env,
+    subtests,
+    iter_provider_models,
     stream_with_retry,
 ):
-    api_key = os.getenv(api_key_env)
-    if not api_key:
-        pytest.skip(f"{api_key_env} is not configured")
+    configured_models = 0
 
-    adapter = UniversalLLMAPIAdapter(
-        organization=organization,
-        model=model,
-        api_key=api_key,
-    )
-    completed_responses = []
-    observed_chunks = []
-    text_chunks = stream_with_retry(
-        adapter,
-        messages=[UserMessage("Reply with exactly: OK")],
-        max_tokens=64,
-        temperature=0,
-        timeout_s=60,
-        buffer_chars=8,
-        on_chunk=observed_chunks.append,
-        on_done=completed_responses.append,
-    )
+    for provider, model in iter_provider_models():
+        if not provider["api_key"]:
+            continue
+        configured_models += 1
 
-    streamed_text = "".join(text_chunks)
-    assert streamed_text.strip()
-    assert [chunk.text for chunk in observed_chunks] == text_chunks
-    assert [chunk.index for chunk in observed_chunks] == list(range(len(observed_chunks)))
-    assert [chunk.elapsed_s for chunk in observed_chunks] == sorted(
-        chunk.elapsed_s for chunk in observed_chunks
-    )
-    assert all(chunk.delta_s >= 0 for chunk in observed_chunks)
-    assert len(completed_responses) == 1
+        with subtests.test(provider=provider["name"], model=model):
+            adapter = UniversalLLMAPIAdapter(
+                organization=provider["name"],
+                model=model,
+                api_key=provider["api_key"],
+            )
+            completed_responses = []
+            observed_chunks = []
 
-    response = completed_responses[0]
-    assert isinstance(response.model, str) and response.model
-    assert response.content == streamed_text
-    if response.usage is not None:
-        assert response.usage.input_tokens >= 0
-        assert response.usage.output_tokens >= 0
-        assert response.usage.total_tokens >= response.usage.input_tokens
-    for chunk in observed_chunks:
-        if chunk.usage is not None:
-            assert chunk.usage.input_tokens >= 0
-            assert chunk.usage.output_tokens >= 0
-            assert chunk.usage.total_tokens >= chunk.usage.input_tokens
-        if chunk.output_tokens_delta is not None:
-            assert chunk.output_tokens_delta >= 0
-    assert isinstance(response.finish_reason, str) and response.finish_reason
+            def reset_observers():
+                completed_responses.clear()
+                observed_chunks.clear()
+
+            text_chunks = stream_with_retry(
+                adapter,
+                messages=[UserMessage("Reply with exactly: OK")],
+                max_tokens=1026,
+                timeout_s=60,
+                buffer_chars=8,
+                on_chunk=observed_chunks.append,
+                on_done=completed_responses.append,
+                on_retry=reset_observers,
+            )
+
+            streamed_text = "".join(text_chunks)
+            assert streamed_text.strip()
+            assert [chunk.text for chunk in observed_chunks] == text_chunks
+            assert all(len(chunk.text) <= 8 for chunk in observed_chunks)
+            assert [chunk.index for chunk in observed_chunks] == list(
+                range(len(observed_chunks))
+            )
+            assert [chunk.elapsed_s for chunk in observed_chunks] == sorted(
+                chunk.elapsed_s for chunk in observed_chunks
+            )
+            assert all(chunk.delta_s >= 0 for chunk in observed_chunks)
+            assert len(completed_responses) == 1
+
+            response = completed_responses[0]
+            assert isinstance(response.model, str) and response.model
+            assert response.content == streamed_text
+            if response.usage is not None:
+                assert response.usage.input_tokens >= 0
+                assert response.usage.output_tokens >= 0
+                assert response.usage.total_tokens >= response.usage.input_tokens
+            for chunk in observed_chunks:
+                if chunk.usage is not None:
+                    assert chunk.usage.input_tokens >= 0
+                    assert chunk.usage.output_tokens >= 0
+                    assert chunk.usage.total_tokens >= chunk.usage.input_tokens
+                if chunk.output_tokens_delta is not None:
+                    assert chunk.output_tokens_delta >= 0
+            assert isinstance(response.finish_reason, str) and response.finish_reason
+
+    if configured_models == 0:
+        pytest.skip("No provider API keys are configured")

--- a/tests/integration/test_streaming.py
+++ b/tests/integration/test_streaming.py
@@ -6,6 +6,7 @@ import requests
 import requests_mock
 
 from src.llm_api_adapter.models.messages.chat_message import UserMessage
+from src.llm_api_adapter.models.responses.chat_response import Usage
 from src.llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
 
 
@@ -209,3 +210,199 @@ def test_google_streams_through_universal_adapter():
     assert request.json()["contents"] == [{"role": "user", "parts": [{"text": "Hi"}]}]
     assert done[0].content == "Hello"
     assert done[0].usage.total_tokens == 3
+
+
+_BUFFERED_STREAM_SCENARIOS = [
+    pytest.param(
+        "openai",
+        "gpt-5",
+        "https://api.openai.com/v1/responses",
+        [
+            (
+                "response.output_text.delta",
+                {"type": "response.output_text.delta", "delta": "Hel"},
+            ),
+            (
+                "response.output_text.delta",
+                {"type": "response.output_text.delta", "delta": "lo!"},
+            ),
+            (
+                "response.completed",
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "id": "resp_123",
+                        "model": "gpt-5",
+                        "status": "completed",
+                        "usage": {
+                            "input_tokens": 2,
+                            "output_tokens": 2,
+                            "total_tokens": 4,
+                        },
+                        "output": [{
+                            "type": "message",
+                            "content": [{"type": "output_text", "text": "Hello!"}],
+                        }],
+                    },
+                },
+            ),
+        ],
+        {},
+        Usage(input_tokens=2, output_tokens=2, total_tokens=4),
+        id="openai-responses",
+    ),
+    pytest.param(
+        "anthropic",
+        "claude-sonnet-4-5",
+        "https://api.anthropic.com/v1/messages",
+        [
+            (
+                "message_start",
+                {
+                    "type": "message_start",
+                    "message": {
+                        "id": "msg_123",
+                        "model": "claude-sonnet-4-5",
+                        "content": [],
+                        "usage": {"input_tokens": 2, "output_tokens": 0},
+                    },
+                },
+            ),
+            (
+                "content_block_start",
+                {
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": {"type": "text", "text": ""},
+                },
+            ),
+            (
+                "content_block_delta",
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": "Hel"},
+                },
+            ),
+            (
+                "content_block_delta",
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": "lo!"},
+                },
+            ),
+            (
+                "message_delta",
+                {
+                    "type": "message_delta",
+                    "delta": {"stop_reason": "end_turn"},
+                    "usage": {"output_tokens": 2},
+                },
+            ),
+            ("message_stop", {"type": "message_stop"}),
+        ],
+        {"max_tokens": 64},
+        Usage(input_tokens=2, output_tokens=2, total_tokens=4),
+        id="anthropic",
+    ),
+    pytest.param(
+        "google",
+        "gemini-2.5-pro",
+        (
+            "https://generativelanguage.googleapis.com/v1beta/"
+            "models/gemini-2.5-pro:streamGenerateContent?alt=sse"
+        ),
+        [
+            (
+                None,
+                {"candidates": [{"content": {"parts": [{"text": "Hel"}]}}]},
+            ),
+            (
+                None,
+                {
+                    "candidates": [{
+                        "content": {"parts": [{"text": "lo!"}]},
+                        "finishReason": "STOP",
+                    }],
+                    "usageMetadata": {
+                        "promptTokenCount": 2,
+                        "candidatesTokenCount": 2,
+                        "totalTokenCount": 4,
+                    },
+                },
+            ),
+        ],
+        {},
+        Usage(input_tokens=2, output_tokens=2, total_tokens=4),
+        id="google",
+    ),
+]
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    ("organization", "model", "url", "events", "stream_kwargs", "expected_usage"),
+    _BUFFERED_STREAM_SCENARIOS,
+)
+def test_streaming_contract_is_consistent_for_all_providers(
+    organization,
+    model,
+    url,
+    events,
+    stream_kwargs,
+    expected_usage,
+):
+    body = _sse(*events)
+    with requests_mock.Mocker() as mock:
+        mock.post(url, text=body, headers={"Content-Type": "text/event-stream"})
+        adapter = UniversalLLMAPIAdapter(
+            organization=organization,
+            model=model,
+            api_key="dummy_key",
+        )
+        chunks = []
+        completed_responses = []
+        callback_order = []
+        yielded = []
+
+        def on_chunk(chunk):
+            chunks.append(chunk)
+            callback_order.append(("chunk", chunk.text))
+
+        def on_done(response):
+            completed_responses.append(response)
+            callback_order.append(("done", response.content))
+
+        for text in adapter.stream_chat(
+            [UserMessage("Hi")],
+            buffer_chars=4,
+            on_chunk=on_chunk,
+            on_delta=lambda text: callback_order.append(("delta", text)),
+            on_done=on_done,
+            **stream_kwargs,
+        ):
+            yielded.append(text)
+            callback_order.append(("yield", text))
+
+    assert yielded == ["Hell", "o!"]
+    assert "".join(yielded) == "Hello!"
+    assert [chunk.text for chunk in chunks] == yielded
+    assert all(len(chunk.text) <= 4 for chunk in chunks)
+    assert [chunk.index for chunk in chunks] == [0, 1]
+    assert [chunk.elapsed_s for chunk in chunks] == sorted(
+        chunk.elapsed_s for chunk in chunks
+    )
+    assert all(chunk.delta_s >= 0 for chunk in chunks)
+    assert chunks[-1].usage == expected_usage
+    assert any(chunk.output_tokens_delta is not None for chunk in chunks)
+    assert completed_responses[0].usage == expected_usage
+    assert callback_order == [
+        ("chunk", "Hell"),
+        ("delta", "Hell"),
+        ("yield", "Hell"),
+        ("chunk", "o!"),
+        ("delta", "o!"),
+        ("yield", "o!"),
+        ("done", "Hello!"),
+    ]

--- a/tests/unit/adapters/test_anthropic_adapter.py
+++ b/tests/unit/adapters/test_anthropic_adapter.py
@@ -241,3 +241,56 @@ def test_stream_chat_normalizes_text_and_completed_tool_use(adapter):
     assert done[0].finish_reason == "tool_use"
     assert tool_calls[0].name == "get_weather"
     assert tool_calls[0].arguments == {"city": "Tel Aviv"}
+
+
+@pytest.mark.unit
+def test_stream_chat_buffers_text_and_orders_chunk_callbacks(adapter):
+    events = iter([
+        SSEEvent(
+            event="message_start",
+            data={"type": "message_start", "message": {"content": []}},
+        ),
+        SSEEvent(
+            event="content_block_start",
+            data={"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+        ),
+        SSEEvent(
+            event="content_block_delta",
+            data={"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "He"}},
+        ),
+        SSEEvent(
+            event="content_block_delta",
+            data={"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "llo"}},
+        ),
+        SSEEvent(
+            event="content_block_delta",
+            data={"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "!"}},
+        ),
+        SSEEvent(event="message_stop", data={"type": "message_stop"}),
+    ])
+    order = []
+    yielded = []
+
+    with patch.object(ClaudeSyncClient, "stream", return_value=events):
+        for text in adapter.stream_chat(
+            [UserMessage("hi")],
+            max_tokens=64,
+            buffer_chars=4,
+            on_chunk=lambda chunk: order.append(("chunk", chunk.text)),
+            on_delta=lambda text: order.append(("delta", text)),
+            on_done=lambda response: order.append(("done", response.content)),
+        ):
+            yielded.append(text)
+            order.append(("yield", text))
+
+    assert yielded == ["Hell", "o!"]
+    assert "".join(yielded) == "Hello!"
+    assert order == [
+        ("chunk", "Hell"),
+        ("delta", "Hell"),
+        ("yield", "Hell"),
+        ("chunk", "o!"),
+        ("delta", "o!"),
+        ("yield", "o!"),
+        ("done", "Hello!"),
+    ]

--- a/tests/unit/adapters/test_anthropic_adapter.py
+++ b/tests/unit/adapters/test_anthropic_adapter.py
@@ -6,7 +6,7 @@ from src.llm_api_adapter.adapters.anthropic_adapter import AnthropicAdapter
 from src.llm_api_adapter.errors.llm_api_error import LLMAPIError
 from src.llm_api_adapter.adapters.anthropic_adapter import ClaudeSyncClient
 from src.llm_api_adapter.models.messages.chat_message import Prompt, UserMessage
-from src.llm_api_adapter.models.responses.chat_response import ChatResponse
+from src.llm_api_adapter.models.responses.chat_response import ChatResponse, Usage
 from src.llm_api_adapter.models.tools import ToolSpec
 from src.llm_api_adapter.llms.streaming import SSEEvent
 
@@ -241,6 +241,49 @@ def test_stream_chat_normalizes_text_and_completed_tool_use(adapter):
     assert done[0].finish_reason == "tool_use"
     assert tool_calls[0].name == "get_weather"
     assert tool_calls[0].arguments == {"city": "Tel Aviv"}
+
+
+@pytest.mark.unit
+def test_stream_chat_attaches_late_usage_to_final_buffered_chunk(adapter):
+    events = iter([
+        SSEEvent(
+            event="message_start",
+            data={"type": "message_start", "message": {
+                "model": "claude-sonnet-4-5",
+                "content": [],
+                "usage": {"input_tokens": 3, "output_tokens": 0},
+            }},
+        ),
+        SSEEvent(
+            event="content_block_start",
+            data={"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+        ),
+        SSEEvent(
+            event="content_block_delta",
+            data={"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Hello"}},
+        ),
+        SSEEvent(
+            event="message_delta",
+            data={"type": "message_delta", "usage": {"output_tokens": 4}},
+        ),
+        SSEEvent(event="message_stop", data={"type": "message_stop"}),
+    ])
+    chunks = []
+    done = []
+
+    with patch.object(ClaudeSyncClient, "stream", return_value=events):
+        output = list(adapter.stream_chat(
+            [UserMessage("hi")],
+            max_tokens=64,
+            buffer_chars=10,
+            on_chunk=chunks.append,
+            on_done=done.append,
+        ))
+
+    assert output == ["Hello"]
+    assert chunks[0].usage == Usage(input_tokens=3, output_tokens=4, total_tokens=7)
+    assert chunks[0].output_tokens_delta == 4
+    assert done[0].usage == Usage(input_tokens=3, output_tokens=4, total_tokens=7)
 
 
 @pytest.mark.unit

--- a/tests/unit/adapters/test_google_adapter.py
+++ b/tests/unit/adapters/test_google_adapter.py
@@ -250,3 +250,46 @@ def test_stream_chat_normalizes_chunks_excludes_thoughts_and_finalizes(adapter):
     assert done[0].usage.total_tokens == 5
     assert tool_calls[0].name == "get_weather"
     assert tool_calls[0].arguments == {"city": "Tel Aviv"}
+
+
+@pytest.mark.unit
+def test_stream_chat_buffers_text_and_orders_chunk_callbacks(adapter):
+    events = iter([
+        SSEEvent(data={
+            "candidates": [{"content": {"parts": [{"text": "He"}]}}],
+        }, event=None),
+        SSEEvent(data={
+            "candidates": [{"content": {"parts": [{"text": "llo"}]}}],
+        }, event=None),
+        SSEEvent(data={
+            "candidates": [{
+                "content": {"parts": [{"text": "!"}]},
+                "finishReason": "STOP",
+            }],
+        }, event=None),
+    ])
+    order = []
+    yielded = []
+
+    with patch.object(GeminiSyncClient, "stream", return_value=events):
+        for text in adapter.stream_chat(
+            [UserMessage("hi")],
+            buffer_chars=4,
+            on_chunk=lambda chunk: order.append(("chunk", chunk.text)),
+            on_delta=lambda text: order.append(("delta", text)),
+            on_done=lambda response: order.append(("done", response.content)),
+        ):
+            yielded.append(text)
+            order.append(("yield", text))
+
+    assert yielded == ["Hell", "o!"]
+    assert "".join(yielded) == "Hello!"
+    assert order == [
+        ("chunk", "Hell"),
+        ("delta", "Hell"),
+        ("yield", "Hell"),
+        ("chunk", "o!"),
+        ("delta", "o!"),
+        ("yield", "o!"),
+        ("done", "Hello!"),
+    ]

--- a/tests/unit/adapters/test_google_adapter.py
+++ b/tests/unit/adapters/test_google_adapter.py
@@ -6,7 +6,7 @@ from src.llm_api_adapter.adapters.google_adapter import GoogleAdapter
 from src.llm_api_adapter.errors.llm_api_error import LLMAPIError
 from src.llm_api_adapter.llms.google.sync_client import GeminiSyncClient
 from src.llm_api_adapter.models.messages.chat_message import Prompt, UserMessage
-from src.llm_api_adapter.models.responses.chat_response import ChatResponse
+from src.llm_api_adapter.models.responses.chat_response import ChatResponse, Usage
 from src.llm_api_adapter.models.tools import ToolSpec
 from src.llm_api_adapter.llms.streaming import SSEEvent
 
@@ -250,6 +250,39 @@ def test_stream_chat_normalizes_chunks_excludes_thoughts_and_finalizes(adapter):
     assert done[0].usage.total_tokens == 5
     assert tool_calls[0].name == "get_weather"
     assert tool_calls[0].arguments == {"city": "Tel Aviv"}
+
+
+@pytest.mark.unit
+def test_stream_chat_attaches_usage_with_thought_tokens_to_buffered_chunk(adapter):
+    events = iter([
+        SSEEvent(data={
+            "candidates": [{"content": {"parts": [{"text": "Hello"}]}}],
+        }, event=None),
+        SSEEvent(data={
+            "candidates": [{"content": {"parts": []}, "finishReason": "STOP"}],
+            "usageMetadata": {
+                "promptTokenCount": 2,
+                "candidatesTokenCount": 3,
+                "thoughtsTokenCount": 4,
+                "totalTokenCount": 9,
+            },
+        }, event=None),
+    ])
+    chunks = []
+    done = []
+
+    with patch.object(GeminiSyncClient, "stream", return_value=events):
+        output = list(adapter.stream_chat(
+            [UserMessage("hi")],
+            buffer_chars=10,
+            on_chunk=chunks.append,
+            on_done=done.append,
+        ))
+
+    assert output == ["Hello"]
+    assert chunks[0].usage == Usage(input_tokens=2, output_tokens=7, total_tokens=9)
+    assert chunks[0].output_tokens_delta == 7
+    assert done[0].usage == Usage(input_tokens=2, output_tokens=7, total_tokens=9)
 
 
 @pytest.mark.unit

--- a/tests/unit/adapters/test_openai_adapter.py
+++ b/tests/unit/adapters/test_openai_adapter.py
@@ -6,7 +6,7 @@ from src.llm_api_adapter.adapters.openai_adapter import OpenAIAdapter
 from src.llm_api_adapter.errors.llm_api_error import JSONSchemaError, LLMAPIError
 from src.llm_api_adapter.llms.openai.sync_client import OpenAISyncClient
 from src.llm_api_adapter.models.messages.chat_message import Prompt, UserMessage
-from src.llm_api_adapter.models.responses.chat_response import ChatResponse
+from src.llm_api_adapter.models.responses.chat_response import ChatResponse, Usage
 from src.llm_api_adapter.models.tools import ToolSpec
 from src.llm_api_adapter.llms.streaming import SSEEvent
 
@@ -721,6 +721,132 @@ def test_stream_chat_responses_uses_completed_response(adapter):
     assert done[0].response_id == "resp_123"
     assert done[0].usage.total_tokens == 3
     assert tool_calls[0].arguments == {"city": "Tel Aviv"}
+
+
+@pytest.mark.unit
+def test_stream_chat_responses_attaches_late_usage_to_final_buffered_chunk(adapter):
+    events = iter([
+        SSEEvent(
+            event="response.output_text.delta",
+            data={"type": "response.output_text.delta", "delta": "Hello"},
+        ),
+        SSEEvent(
+            event="response.completed",
+            data={
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_123",
+                    "model": "gpt-5",
+                    "status": "completed",
+                    "usage": {"input_tokens": 2, "output_tokens": 4, "total_tokens": 6},
+                    "output": [{
+                        "type": "message",
+                        "content": [{"type": "output_text", "text": "Hello"}],
+                    }],
+                },
+            },
+        ),
+    ])
+    chunks = []
+    done = []
+
+    with patch.object(OpenAISyncClient, "stream", return_value=events):
+        output = list(adapter.stream_chat(
+            [UserMessage("hi")],
+            buffer_chars=10,
+            on_chunk=chunks.append,
+            on_done=done.append,
+        ))
+
+    assert output == ["Hello"]
+    assert chunks[0].usage == Usage(input_tokens=2, output_tokens=4, total_tokens=6)
+    assert chunks[0].output_tokens_delta == 4
+    assert done[0].content == "Hello"
+    assert done[0].usage == Usage(input_tokens=2, output_tokens=4, total_tokens=6)
+
+
+@pytest.mark.unit
+def test_stream_chat_legacy_keeps_chunk_usage_optional_when_absent(legacy_adapter):
+    events = iter([
+        SSEEvent(
+            data={"choices": [{"index": 0, "delta": {"content": "Hello"}}]},
+            event=None,
+        ),
+    ])
+    chunks = []
+    done = []
+
+    with patch.object(OpenAISyncClient, "stream", return_value=events):
+        output = list(legacy_adapter.stream_chat(
+            [UserMessage("hi")],
+            buffer_chars=10,
+            on_chunk=chunks.append,
+            on_done=done.append,
+        ))
+
+    assert output == ["Hello"]
+    assert chunks[0].usage is None
+    assert chunks[0].output_tokens_delta is None
+    assert done[0].content == "Hello"
+
+
+@pytest.mark.unit
+def test_stream_chat_legacy_calculates_cumulative_usage_deltas(legacy_adapter):
+    events = iter([
+        SSEEvent(
+            data={"choices": [{"index": 0, "delta": {"content": "He"}}]},
+            event=None,
+        ),
+        SSEEvent(
+            data={
+                "usage": {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5},
+                "choices": [],
+            },
+            event=None,
+        ),
+        SSEEvent(
+            data={"choices": [{"index": 0, "delta": {"content": "llo"}}]},
+            event=None,
+        ),
+        SSEEvent(
+            data={
+                "usage": {"prompt_tokens": 3, "completion_tokens": 5, "total_tokens": 8},
+                "choices": [],
+            },
+            event=None,
+        ),
+        SSEEvent(
+            data={"choices": [{"index": 0, "delta": {"content": "world"}}]},
+            event=None,
+        ),
+        SSEEvent(
+            data={
+                "usage": {"prompt_tokens": 3, "completion_tokens": 5, "total_tokens": 8},
+                "choices": [],
+            },
+            event=None,
+        ),
+    ])
+    chunks = []
+    done = []
+
+    with patch.object(OpenAISyncClient, "stream", return_value=events):
+        output = list(legacy_adapter.stream_chat(
+            [UserMessage("hi")],
+            buffer_chars=4,
+            on_chunk=chunks.append,
+            on_done=done.append,
+        ))
+
+    assert output == ["Hell", "owor", "ld"]
+    assert [chunk.usage for chunk in chunks] == [
+        Usage(input_tokens=3, output_tokens=2, total_tokens=5),
+        Usage(input_tokens=3, output_tokens=5, total_tokens=8),
+        Usage(input_tokens=3, output_tokens=5, total_tokens=8),
+    ]
+    assert [chunk.output_tokens_delta for chunk in chunks] == [2, 3, 0]
+    assert done[0].content == "Helloworld"
+    assert done[0].usage == Usage(input_tokens=3, output_tokens=5, total_tokens=8)
 
 
 @pytest.mark.unit

--- a/tests/unit/adapters/test_openai_adapter.py
+++ b/tests/unit/adapters/test_openai_adapter.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 import pytest
 
 from src.llm_api_adapter.adapters.openai_adapter import OpenAIAdapter
-from src.llm_api_adapter.errors.llm_api_error import LLMAPIError
+from src.llm_api_adapter.errors.llm_api_error import JSONSchemaError, LLMAPIError
 from src.llm_api_adapter.llms.openai.sync_client import OpenAISyncClient
 from src.llm_api_adapter.models.messages.chat_message import Prompt, UserMessage
 from src.llm_api_adapter.models.responses.chat_response import ChatResponse
@@ -724,6 +724,46 @@ def test_stream_chat_responses_uses_completed_response(adapter):
 
 
 @pytest.mark.unit
+def test_stream_chat_buffers_text_and_orders_chunk_callbacks(legacy_adapter):
+    events = iter([
+        SSEEvent(data={"choices": [{"index": 0, "delta": {"content": "He"}}]}, event=None),
+        SSEEvent(data={"choices": [{"index": 0, "delta": {"content": "llo"}}]}, event=None),
+        SSEEvent(data={
+            "choices": [{
+                "index": 0,
+                "delta": {"content": "!"},
+                "finish_reason": "stop",
+            }],
+        }, event=None),
+    ])
+    order = []
+    yielded = []
+
+    with patch.object(OpenAISyncClient, "stream", return_value=events):
+        for text in legacy_adapter.stream_chat(
+            [UserMessage("hi")],
+            buffer_chars=4,
+            on_chunk=lambda chunk: order.append(("chunk", chunk.text)),
+            on_delta=lambda text: order.append(("delta", text)),
+            on_done=lambda response: order.append(("done", response.content)),
+        ):
+            yielded.append(text)
+            order.append(("yield", text))
+
+    assert yielded == ["Hell", "o!"]
+    assert "".join(yielded) == "Hello!"
+    assert order == [
+        ("chunk", "Hell"),
+        ("delta", "Hell"),
+        ("yield", "Hell"),
+        ("chunk", "o!"),
+        ("delta", "o!"),
+        ("yield", "o!"),
+        ("done", "Hello!"),
+    ]
+
+
+@pytest.mark.unit
 def test_stream_chat_does_not_treat_callback_errors_as_provider_errors(legacy_adapter):
     events = iter([
         SSEEvent(data={"choices": [{"index": 0, "delta": {"content": "Hello"}}]}, event=None),
@@ -766,4 +806,70 @@ def test_stream_chat_skips_on_done_when_closed_early(legacy_adapter):
         stream.close()
 
     assert closed == [True]
+    assert done == []
+
+
+@pytest.mark.unit
+def test_stream_chat_does_not_flush_buffer_when_closed_early(legacy_adapter):
+    closed = []
+
+    def events():
+        try:
+            yield SSEEvent(
+                data={"choices": [{"index": 0, "delta": {"content": "Hell"}}]},
+                event=None,
+            )
+            yield SSEEvent(
+                data={"choices": [{"index": 0, "delta": {"content": "o"}}]},
+                event=None,
+            )
+            yield SSEEvent(
+                data={"choices": [{"index": 0, "delta": {"content": "world"}}]},
+                event=None,
+            )
+        finally:
+            closed.append(True)
+
+    done = []
+    with patch.object(OpenAISyncClient, "stream", return_value=events()):
+        stream = legacy_adapter.stream_chat(
+            [UserMessage("hi")],
+            buffer_chars=4,
+            on_done=done.append,
+        )
+        assert next(stream) == "Hell"
+        assert next(stream) == "owor"
+        stream.close()
+
+    assert closed == [True]
+    assert done == []
+
+
+@pytest.mark.unit
+def test_stream_chat_does_not_flush_buffer_when_finalization_fails(legacy_adapter):
+    events = iter([
+        SSEEvent(
+            data={"choices": [{"index": 0, "delta": {"content": "not JSON"}}]},
+            event=None,
+        ),
+    ])
+    chunks = []
+    deltas = []
+    done = []
+
+    with (
+        patch.object(OpenAISyncClient, "stream", return_value=events),
+        pytest.raises(JSONSchemaError),
+    ):
+        list(legacy_adapter.stream_chat(
+            [UserMessage("hi")],
+            buffer_chars=16,
+            json_schema={"type": "object"},
+            on_chunk=chunks.append,
+            on_delta=deltas.append,
+            on_done=done.append,
+        ))
+
+    assert chunks == []
+    assert deltas == []
     assert done == []

--- a/tests/unit/llm_registry/test_llm_registry.py
+++ b/tests/unit/llm_registry/test_llm_registry.py
@@ -1,4 +1,5 @@
 import json
+from datetime import date
 from pathlib import Path
 
 import pytest
@@ -6,6 +7,8 @@ import pytest
 from src.llm_api_adapter.llm_registry.llm_registry import (
     DEFAULT_REGISTRY_PATH, ModelSpec, Pricing, ProviderSpec, RegistrySpec
 )
+
+SONNET_5_STANDARD_PRICING_DATE = date(2026, 9, 1)
 
 @pytest.mark.unit
 def test_pricing_setters():
@@ -65,3 +68,14 @@ def test_default_registry_json_exists():
     assert isinstance(DEFAULT_REGISTRY_PATH, Path)
     assert DEFAULT_REGISTRY_PATH.exists(), f"Expected JSON at {DEFAULT_REGISTRY_PATH}"
     assert DEFAULT_REGISTRY_PATH.is_file(), f"Expected a file at {DEFAULT_REGISTRY_PATH}"
+
+@pytest.mark.unit
+def test_sonnet_5_temporary_pricing_is_updated_after_promotion():
+    registry = RegistrySpec(path=str(DEFAULT_REGISTRY_PATH))
+    sonnet_5 = registry.providers["anthropic"].models["claude-sonnet-5"]
+    if date.today() < SONNET_5_STANDARD_PRICING_DATE:
+        expected_input, expected_output = 2.0, 10.0
+    else:
+        expected_input, expected_output = 3.0, 15.0
+    assert pytest.approx(sonnet_5.pricing.in_per_token * 1_000_000) == expected_input
+    assert pytest.approx(sonnet_5.pricing.out_per_token * 1_000_000) == expected_output

--- a/tests/unit/streaming/test_chunk_buffer.py
+++ b/tests/unit/streaming/test_chunk_buffer.py
@@ -4,7 +4,7 @@ import pytest
 
 from src.llm_api_adapter.models import StreamChunk
 from src.llm_api_adapter.models.responses.chat_response import Usage
-from src.llm_api_adapter.llms.streaming import StreamChunkBuffer
+from src.llm_api_adapter.llms.streaming import StreamChunkBuffer, StreamUsageTracker
 
 
 class FakeClock:
@@ -79,3 +79,25 @@ def test_buffer_updates_metadata_without_text_until_a_chunk_is_emitted():
 
     assert chunk.usage == usage
     assert chunk.output_tokens_delta == 1
+
+
+@pytest.mark.unit
+def test_usage_tracker_calculates_cumulative_output_token_deltas():
+    buffer = StreamChunkBuffer(clock=FakeClock(0.0, 0.1, 0.2, 0.3))
+    tracker = StreamUsageTracker()
+
+    tracker.record(buffer, Usage(input_tokens=2, output_tokens=1, total_tokens=3))
+    first_chunk = next(buffer.add("one"))
+    tracker.record(buffer, Usage(input_tokens=2, output_tokens=4, total_tokens=6))
+    second_chunk = next(buffer.add("two"))
+    tracker.record(buffer, Usage(input_tokens=2, output_tokens=3, total_tokens=5))
+    third_chunk = next(buffer.add("three"))
+
+    assert [chunk.usage for chunk in (first_chunk, second_chunk, third_chunk)] == [
+        Usage(input_tokens=2, output_tokens=1, total_tokens=3),
+        Usage(input_tokens=2, output_tokens=4, total_tokens=6),
+        Usage(input_tokens=2, output_tokens=3, total_tokens=5),
+    ]
+    assert [
+        chunk.output_tokens_delta for chunk in (first_chunk, second_chunk, third_chunk)
+    ] == [1, 3, 0]

--- a/tests/unit/streaming/test_chunk_buffer.py
+++ b/tests/unit/streaming/test_chunk_buffer.py
@@ -1,0 +1,81 @@
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from src.llm_api_adapter.models import StreamChunk
+from src.llm_api_adapter.models.responses.chat_response import Usage
+from src.llm_api_adapter.llms.streaming import StreamChunkBuffer
+
+
+class FakeClock:
+    def __init__(self, *values):
+        self._values = iter(values)
+
+    def __call__(self):
+        return next(self._values)
+
+
+@pytest.mark.unit
+def test_stream_chunk_is_exported_from_models_package():
+    assert StreamChunk.__name__ == "StreamChunk"
+
+
+@pytest.mark.unit
+def test_buffer_default_passthrough_preserves_text_and_reports_timing():
+    buffer = StreamChunkBuffer(clock=FakeClock(10.0, 10.2, 10.7))
+
+    chunks = [*buffer.add("hello"), *buffer.add(" world")]
+
+    assert [chunk.text for chunk in chunks] == ["hello", " world"]
+    assert [chunk.index for chunk in chunks] == [0, 1]
+    assert [chunk.elapsed_s for chunk in chunks] == pytest.approx([0.2, 0.7])
+    assert [chunk.delta_s for chunk in chunks] == pytest.approx([0.2, 0.5])
+
+
+@pytest.mark.unit
+def test_buffer_coalesces_splits_and_flushes_remaining_text():
+    buffer = StreamChunkBuffer(buffer_chars=4, clock=FakeClock(0.0, 1.0, 2.0))
+
+    chunks = [*buffer.add("ab"), *buffer.add("cdefghi"), *buffer.flush()]
+
+    assert [chunk.text for chunk in chunks] == ["abcd", "efgh", "i"]
+    assert [chunk.index for chunk in chunks] == [0, 1, 2]
+    assert [chunk.elapsed_s for chunk in chunks] == [1.0, 1.0, 2.0]
+    assert [chunk.delta_s for chunk in chunks] == [1.0, 0.0, 1.0]
+
+
+@pytest.mark.unit
+def test_buffer_preserves_usage_as_a_snapshot_and_consumes_token_delta():
+    usage = Usage(input_tokens=3, output_tokens=5, total_tokens=8)
+    buffer = StreamChunkBuffer(clock=FakeClock(0.0, 0.1, 0.2))
+
+    first_chunk = next(buffer.add("first", usage=usage, output_tokens_delta=5))
+    usage.output_tokens = 99
+    second_chunk = next(buffer.add("second"))
+
+    assert first_chunk.usage == Usage(3, 5, 8)
+    assert second_chunk.usage == Usage(3, 5, 8)
+    assert first_chunk.usage is not second_chunk.usage
+    assert first_chunk.output_tokens_delta == 5
+    assert second_chunk.output_tokens_delta is None
+    with pytest.raises(FrozenInstanceError):
+        first_chunk.index = 1
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("buffer_chars", [0, -1, True, 1.5, "4"])
+def test_buffer_rejects_invalid_buffer_chars(buffer_chars):
+    with pytest.raises(ValueError, match="buffer_chars must be None or a positive integer"):
+        StreamChunkBuffer(buffer_chars)
+
+
+@pytest.mark.unit
+def test_buffer_records_usage_without_text_until_a_chunk_is_emitted():
+    usage = Usage(input_tokens=2, output_tokens=1, total_tokens=3)
+    buffer = StreamChunkBuffer(clock=FakeClock(0.0, 0.4))
+
+    assert list(buffer.add("", usage=usage, output_tokens_delta=1)) == []
+    chunk = next(buffer.add("text"))
+
+    assert chunk.usage == usage
+    assert chunk.output_tokens_delta == 1

--- a/tests/unit/streaming/test_chunk_buffer.py
+++ b/tests/unit/streaming/test_chunk_buffer.py
@@ -70,11 +70,11 @@ def test_buffer_rejects_invalid_buffer_chars(buffer_chars):
 
 
 @pytest.mark.unit
-def test_buffer_records_usage_without_text_until_a_chunk_is_emitted():
+def test_buffer_updates_metadata_without_text_until_a_chunk_is_emitted():
     usage = Usage(input_tokens=2, output_tokens=1, total_tokens=3)
     buffer = StreamChunkBuffer(clock=FakeClock(0.0, 0.4))
 
-    assert list(buffer.add("", usage=usage, output_tokens_delta=1)) == []
+    buffer.update_metadata(usage=usage, output_tokens_delta=1)
     chunk = next(buffer.add("text"))
 
     assert chunk.usage == usage


### PR DESCRIPTION
This PR prepares the `0.6.1` release and improves streaming observability across all supported providers while preserving the existing string-yielding API.

## Changes

- Added bounded streaming buffers via `buffer_chars`.
- Added structured `StreamChunk` metadata:
  - chunk index;
  - elapsed and delta time;
  - usage snapshots;
  - output token deltas.
- Added `on_chunk` and `on_done` callback support across adapters.
- Added provider-specific streaming usage tracking for OpenAI, Anthropic, and Google.
- Expanded streaming E2E coverage to all configured models in the registry.
- Added retry handling for complete streaming attempts, including callback state reset.
- Extended unit and integration test coverage.
- Updated documentation and bumped the package version to `0.6.1`.