### PR TITLE
feat(adapters): add cross-provider reasoning observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1023,6 +1023,30 @@ E2E tests require provider API keys to be present in environment variables:
 - `ANTHROPIC_API_KEY`
 - `GOOGLE_API_KEY`
 
+### Reasoning smoke script
+
+The standalone [reasoning_smoke.py](scripts/reasoning_smoke.py) script is intended for
+manual live checks and is not part of the pytest E2E suite or CI. It uses the
+default dog-and-potato prompt unless another prompt is supplied:
+
+```powershell
+python scripts/reasoning_smoke.py `
+  --provider openai `
+  --model gpt-5.6-sol `
+  --require-reasoning `
+  --dump-raw
+```
+
+Use `--prompt` to test another task. During the request, the reasoning summary
+is printed under `[summary]`, and the visible answer under a `-------------`
+separator and `[final answer]`, as they arrive. A successful run ends after
+the final answer; diagnostic JSON is printed only when expected reasoning is
+missing or callback finalization differs. The script also captures every decoded provider SSE event before
+adapter parsing. If no normalized reasoning event is found, it prints event
+names and payload keys; `--dump-raw` also prints the complete payloads. Raw
+output may contain model-generated reasoning, tool arguments, or other
+sensitive response data.
+
 ## License
 
 This project is licensed under the terms of the MIT License.  

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ This table is a positioning snapshot. Provider capabilities change independently
 ## Features
 
 - **Synchronous Streaming**: Iterate normalized text with `stream_chat()` across OpenAI, Anthropic, and Google. Optionally coalesce it into bounded chunks and observe per-chunk metadata without changing the yielded `str` contract.
+- **Reasoning Observability**: Opt in to provider-emitted reasoning summaries through `capture_reasoning=True`, `ReasoningEvent`, and the `on_reasoning` callback without mixing reasoning into visible text.
 - **Provider-Neutral Messages and Responses**: Use the same typed messages, `ChatResponse`, usage, pricing, parsed output, and tool-call fields regardless of the provider.
 - **Vision Input**: Send images alongside text via `ImagePart` — URL or raw bytes, all providers handled automatically.
 - **PDF Documents**: Send PDF URLs or bytes via `DocumentPart`; provider-specific file/document payloads are generated automatically.
@@ -152,7 +153,7 @@ print(response.content)
 By default, `buffer_chars=None` preserves provider text-delta behavior. Set a positive `buffer_chars` value when a consumer prefers bounded, coalesced text; `on_chunk` then receives a `StreamChunk` with the same text and observability metadata.
 
 ```python
-from llm_api_adapter import UniversalLLMAPIAdapter
+from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
 
 adapter = UniversalLLMAPIAdapter(
     organization="openai",
@@ -186,6 +187,48 @@ Buffering is pull-based and has no background worker or time-based flush. If the
 Streaming in v0.6.1 is synchronous and text-first. Async streaming, a universal provider-event type, partial tool arguments, and tool-call sequencing are deferred to later releases.
 
 Provider event references: [OpenAI Responses streaming](https://platform.openai.com/docs/api-reference/responses-streaming), [Anthropic streaming](https://platform.claude.com/docs/en/build-with-claude/streaming), and [Google `streamGenerateContent`](https://ai.google.dev/api/generate-content).
+
+### Reasoning observability
+
+Reasoning observability is opt-in and additive. Set `capture_reasoning=True` to retain provider-emitted reasoning summaries or readable thinking content in `ChatResponse.reasoning_events`.
+
+The stream still yields only visible text. Reasoning events are never sent to `on_delta` and never appear in the iterator. When supplied, `on_reasoning(event)` is called as each event is normalized; `on_done(response)` receives the complete `response.reasoning_events` list.
+
+```python
+import logging
+
+from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
+
+logger = logging.getLogger(__name__)
+observed_events = []
+
+
+def observe_reasoning(event):
+    observed_events.append(event)
+    # Application code decides what to log, redact, retain, or display.
+    logger.info("reasoning event kind=%s index=%s", event.kind, event.index)
+
+
+def on_done(response):
+    logger.info("captured %d reasoning events", len(response.reasoning_events))
+
+
+adapter = UniversalLLMAPIAdapter(
+    organization="openai",
+    model="gpt-5",
+    api_key="...",
+)
+
+for text in adapter.stream_chat(
+    messages=[{"role": "user", "content": "Explain SSE briefly."}],
+    capture_reasoning=True,
+    on_reasoning=observe_reasoning,
+    on_done=on_done,
+):
+    print(text, end="", flush=True)
+```
+
+`ReasoningEvent` contains `text`, `kind`, `index`, `elapsed_s`, and `delta_s`. Availability and content depend on the provider and model; an empty list is a valid result. The library does not automatically log, display, redact, or send reasoning to telemetry, and it does not promise access to a model's private chain of thought. Applications should apply their own redaction and retention policy.
 
 ## Handling Errors
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-api-adapter"
-version = "0.6.1"
+version = "0.6.2"
 description = "Lightweight, pluggable adapter for multiple LLM APIs (OpenAI, Anthropic, Google)"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/scripts/reasoning_smoke.py
+++ b/scripts/reasoning_smoke.py
@@ -1,0 +1,317 @@
+"""Run a stand-alone live reasoning-observability smoke test.
+
+This script is intentionally separate from pytest and CI. It prints reasoning
+and visible text as they arrive, and captures every decoded provider SSE event
+so a missing normalized reasoning event can be diagnosed against the provider
+payload.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Mapping
+from contextlib import contextmanager
+import json
+import os
+from pathlib import Path
+import sys
+import time
+from typing import Any, Iterator
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SOURCE_ROOT = PROJECT_ROOT / "src"
+if str(SOURCE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SOURCE_ROOT))
+
+try:
+    from dotenv import load_dotenv
+except ImportError:  # pragma: no cover - optional convenience for this script
+    load_dotenv = None
+
+from llm_api_adapter.errors import LLMAPIRateLimitError, LLMAPIServerError
+from llm_api_adapter.llm_registry.llm_registry import LLM_REGISTRY
+from llm_api_adapter.llms.anthropic.sync_client import ClaudeSyncClient
+from llm_api_adapter.llms.google.sync_client import GeminiSyncClient
+from llm_api_adapter.llms.openai.sync_client import OpenAISyncClient
+from llm_api_adapter.models.messages.chat_message import UserMessage
+from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
+
+
+DEFAULT_PROMPT = (
+    "Compare a dog and a potato. Identify three non-obvious properties they "
+    "share, state a comparison criterion, and briefly justify each conclusion. "
+    "Return exactly three numbered points."
+)
+
+API_KEY_ENV = {
+    "openai": "OPENAI_API_KEY",
+    "anthropic": "ANTHROPIC_API_KEY",
+    "google": "GOOGLE_API_KEY",
+}
+CLIENT_CLASSES = {
+    "openai": OpenAISyncClient,
+    "anthropic": ClaudeSyncClient,
+    "google": GeminiSyncClient,
+}
+TRANSIENT_ERRORS = (LLMAPIRateLimitError, LLMAPIServerError)
+
+
+class _LiveStreamPrinter:
+    """Print normalized reasoning and visible text as soon as they arrive."""
+
+    def __init__(self) -> None:
+        self._channel: str | None = None
+
+    def _select_channel(self, channel: str) -> None:
+        if self._channel != channel:
+            if self._channel is not None:
+                print()
+            if channel == "final answer":
+                print("-------------")
+            print(f"[{channel}] ", end="", flush=True)
+            self._channel = channel
+
+    def on_reasoning(self, event: Any) -> None:
+        if not event.text:
+            return
+        self._select_channel("summary")
+        print(event.text, end="", flush=True)
+
+    def on_delta(self, text: str) -> None:
+        if not text:
+            return
+        self._select_channel("final answer")
+        print(text, end="", flush=True)
+
+    def finish(self) -> None:
+        if self._channel is not None:
+            print()
+            self._channel = None
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run a live reasoning-observability smoke test for one model."
+    )
+    parser.add_argument("--provider", required=True, choices=sorted(API_KEY_ENV))
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--prompt", default=DEFAULT_PROMPT)
+    parser.add_argument("--max-tokens", type=int, default=16000)
+    parser.add_argument("--timeout", type=float, default=120)
+    parser.add_argument(
+        "--require-reasoning",
+        action="store_true",
+        help="Exit with code 2 if no normalized reasoning event is returned.",
+    )
+    parser.add_argument(
+        "--dump-raw",
+        action="store_true",
+        help="Print complete decoded provider events when no reasoning is captured.",
+    )
+    return parser.parse_args()
+
+
+def _event_metadata(event: Any) -> dict[str, Any]:
+    return {
+        "kind": event.kind,
+        "index": event.index,
+        "text_chars": len(event.text),
+        "elapsed_s": event.elapsed_s,
+        "delta_s": event.delta_s,
+    }
+
+
+def _raw_event_metadata(event: Any) -> dict[str, Any]:
+    event_name = event.get("event")
+    done = event.get("done", False)
+    data = event.get("data")
+    return {
+        "event": event_name,
+        "done": done,
+        "data_type": type(data).__name__,
+        "data_keys": (
+            sorted(str(key) for key in data)
+            if isinstance(data, Mapping)
+            else None
+        ),
+    }
+
+
+@contextmanager
+def _capture_provider_events(
+    provider: str,
+    raw_events: list[dict[str, Any]],
+) -> Iterator[None]:
+    client_class = CLIENT_CLASSES[provider]
+    original_stream = client_class.stream
+
+    def stream_with_capture(self, *args, **kwargs):
+        events = original_stream(self, *args, **kwargs)
+        for event in events:
+            raw_events.append(
+                {
+                    "event": event.event,
+                    "done": event.done,
+                    "data": event.data,
+                }
+            )
+            yield event
+
+    client_class.stream = stream_with_capture
+    try:
+        yield
+    finally:
+        client_class.stream = original_stream
+
+
+def _stream_with_retry(
+    adapter: UniversalLLMAPIAdapter,
+    request_kwargs: dict[str, Any],
+    completed_responses: list[Any],
+    observed_deltas: list[str],
+    observed_reasoning: list[Any],
+    raw_events: list[dict[str, Any]],
+    live_output: _LiveStreamPrinter,
+) -> list[str]:
+    delays = (2, 4, 8)
+    for attempt in range(len(delays) + 1):
+        try:
+            return list(adapter.stream_chat(**request_kwargs))
+        except TRANSIENT_ERRORS:
+            if attempt == len(delays):
+                raise
+            completed_responses.clear()
+            observed_deltas.clear()
+            observed_reasoning.clear()
+            raw_events.clear()
+            live_output.finish()
+            delay = delays[attempt]
+            print(f"Transient provider error; retrying in {delay}s...", file=sys.stderr)
+            time.sleep(delay)
+    return []
+
+
+def main() -> int:
+    args = _parse_args()
+    if load_dotenv is not None:
+        load_dotenv(PROJECT_ROOT / ".env")
+
+    api_key = os.getenv(API_KEY_ENV[args.provider])
+    if not api_key:
+        print(
+            f"Missing {API_KEY_ENV[args.provider]} for provider {args.provider}.",
+            file=sys.stderr,
+        )
+        return 2
+
+    provider_spec = LLM_REGISTRY.providers.get(args.provider)
+    model_spec = provider_spec.models.get(args.model) if provider_spec else None
+    expected_reasoning = bool(model_spec and model_spec.is_reasoning)
+
+    adapter = UniversalLLMAPIAdapter(
+        organization=args.provider,
+        model=args.model,
+        api_key=api_key,
+    )
+    completed_responses: list[Any] = []
+    observed_deltas: list[str] = []
+    observed_reasoning: list[Any] = []
+    raw_events: list[dict[str, Any]] = []
+    live_output = _LiveStreamPrinter()
+
+    def on_delta(text: str) -> None:
+        observed_deltas.append(text)
+        live_output.on_delta(text)
+
+    def on_reasoning(event: Any) -> None:
+        observed_reasoning.append(event)
+        live_output.on_reasoning(event)
+
+    def on_done(response: Any) -> None:
+        completed_responses.append(response)
+        live_output.finish()
+
+    request_kwargs: dict[str, Any] = {
+        "messages": [UserMessage(args.prompt)],
+        "max_tokens": args.max_tokens,
+        "timeout_s": args.timeout,
+        "capture_reasoning": True,
+        "on_delta": on_delta,
+        "on_reasoning": on_reasoning,
+        "on_done": on_done,
+    }
+    if expected_reasoning:
+        request_kwargs["reasoning_level"] = "high"
+
+    with _capture_provider_events(args.provider, raw_events):
+        text_chunks = _stream_with_retry(
+            adapter,
+            request_kwargs,
+            completed_responses,
+            observed_deltas,
+            observed_reasoning,
+            raw_events,
+            live_output,
+        )
+
+    live_output.finish()
+
+    streamed_text = "".join(text_chunks)
+    if not streamed_text.strip():
+        print("The provider returned no visible text.", file=sys.stderr)
+        return 1
+    if len(completed_responses) != 1:
+        print("The adapter did not finalize exactly one response.", file=sys.stderr)
+        return 1
+
+    response = completed_responses[0]
+    report = {
+        "provider": args.provider,
+        "model": args.model,
+        "registry_is_reasoning": expected_reasoning,
+        "visible_text_chars": len(streamed_text),
+        "reasoning_event_count": len(observed_reasoning),
+        "reasoning_events": [_event_metadata(event) for event in observed_reasoning],
+        "raw_event_count": len(raw_events),
+        "raw_events": [_raw_event_metadata(event) for event in raw_events],
+    }
+
+    response_reasoning_mismatch = response.reasoning_events != observed_reasoning
+    reasoning_expected = expected_reasoning or args.require_reasoning
+    diagnostic_needed = response_reasoning_mismatch or (
+        reasoning_expected and not observed_reasoning
+    )
+
+    if diagnostic_needed:
+        print("REASONING_SMOKE " + json.dumps(report, ensure_ascii=False, sort_keys=True))
+
+    if reasoning_expected and not observed_reasoning:
+        if args.dump_raw:
+            raw_report = {
+                "provider": args.provider,
+                "model": args.model,
+                "prompt": args.prompt,
+                "events": raw_events,
+            }
+            print(
+                "REASONING_SMOKE_RAW "
+                + json.dumps(raw_report, default=str, ensure_ascii=False, sort_keys=True)
+            )
+        else:
+            print(
+                "No normalized reasoning events captured. Re-run with --dump-raw "
+                "to print every decoded provider event."
+            )
+
+    if response_reasoning_mismatch:
+        print("Final response and callback reasoning events differ.", file=sys.stderr)
+        return 1
+    if args.require_reasoning and not observed_reasoning:
+        print("Reasoning was required but no reasoning event was returned.", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/llm_api_adapter/adapters/anthropic_adapter.py
+++ b/src/llm_api_adapter/adapters/anthropic_adapter.py
@@ -177,29 +177,6 @@ class AnthropicAdapter(LLMAdapterBase):
             **parser_kwargs,
         )
 
-    def _finalize_chat_response(
-        self,
-        chat_response: ChatResponse,
-        *,
-        effective_schema: Optional[dict],
-        response_model: Optional[Any],
-    ) -> ChatResponse:
-        chat_response.parsed_json = self._parse_json_response(
-            chat_response.content,
-            effective_schema,
-        )
-        chat_response.parsed_model = self._parse_response_model(
-            chat_response.parsed_json,
-            response_model,
-        )
-        if self.pricing:
-            chat_response.apply_pricing(
-                price_input_per_token=self.pricing.in_per_token,
-                price_output_per_token=self.pricing.out_per_token,
-                currency=self.pricing.currency,
-            )
-        return chat_response
-
     def stream_chat(
         self,
         messages: List[Message] | Messages,

--- a/src/llm_api_adapter/adapters/anthropic_adapter.py
+++ b/src/llm_api_adapter/adapters/anthropic_adapter.py
@@ -13,6 +13,7 @@ from ..adapters.base_adapter import (
     OnDone,
     OnReasoning,
     OnToolCall,
+    _StreamState,
 )
 from ..errors.llm_api_error import InvalidToolArgumentsError, LLMAPIError
 from ..errors.config_errors import LLMReasoningLevelError
@@ -30,16 +31,12 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass
-class _AnthropicStreamState:
+class _AnthropicStreamState(_StreamState):
     message_data: Dict[str, Any]
     content_blocks: Dict[int, Dict[str, Any]]
     input_json_fragments: Dict[int, List[str]]
     usage: Dict[str, Any]
     message_delta: Dict[str, Any]
-    chunk_buffer: StreamChunkBuffer
-    usage_tracker: StreamUsageTracker
-    reasoning_collector: Optional[StreamReasoningCollector]
-    reasoning_response: Optional[ChatResponse]
 
 
 @dataclass(repr=False)
@@ -351,13 +348,11 @@ class AnthropicAdapter(LLMAdapterBase):
             effective_schema=effective_schema,
             response_model=response_model,
         )
-        yield from self._emit_stream_chunks(
-            state.chunk_buffer.flush(),
+        yield from self._complete_stream(
+            chat_response,
+            state.chunk_buffer,
             on_chunk,
             on_delta,
-        )
-        self._invoke_stream_completion_callbacks(
-            chat_response,
             on_tool_call,
             on_done,
         )
@@ -432,16 +427,12 @@ class AnthropicAdapter(LLMAdapterBase):
             ),
             **parser_kwargs,
         )
-        if state.reasoning_collector is not None:
-            streamed_reasoning_events = state.reasoning_collector.snapshot()
-            if streamed_reasoning_events:
-                chat_response.reasoning_events = streamed_reasoning_events
-        self._prepare_stream_response(
+        return super()._finalize_stream_response(
             chat_response,
-            effective_schema,
-            response_model,
+            reasoning_collector=state.reasoning_collector,
+            effective_schema=effective_schema,
+            response_model=response_model,
         )
-        return chat_response
 
     def _handle_message_start(
         self,

--- a/src/llm_api_adapter/adapters/anthropic_adapter.py
+++ b/src/llm_api_adapter/adapters/anthropic_adapter.py
@@ -63,16 +63,21 @@ class AnthropicAdapter(LLMAdapterBase):
         response_model: Optional[Any] = None,
         capture_reasoning: bool = False,
     ) -> ChatResponse:
-        temperature = self._validate_parameter("temperature", temperature, 0, 2)
-        top_p = self._validate_parameter("top_p", top_p, 0, 1)
+        temperature, top_p = self._validate_sampling_parameters(
+            temperature,
+            top_p,
+        )
         try:
-            self._validate_tools(tools)
-            effective_schema = self._resolve_json_schema(json_schema, response_model, tools)
-            normalized_tool_choice = self._normalize_tool_choice(
-                tool_choice,
+            request_context = self._prepare_chat_request(
+                messages,
                 tools,
+                tool_choice,
+                json_schema,
+                response_model,
             )
-            normalized_messages = self._normalize_messages(messages)
+            effective_schema = request_context.effective_schema
+            normalized_tool_choice = request_context.normalized_tool_choice
+            normalized_messages = request_context.normalized_messages
             params = self._build_chat_params(
                 normalized_messages=normalized_messages,
                 max_tokens=max_tokens,
@@ -200,12 +205,20 @@ class AnthropicAdapter(LLMAdapterBase):
         capture_reasoning: bool = False,
         on_reasoning: Optional[OnReasoning] = None,
     ) -> Iterator[str]:
-        temperature = self._validate_parameter("temperature", temperature, 0, 2)
-        top_p = self._validate_parameter("top_p", top_p, 0, 1)
-        self._validate_tools(tools)
-        effective_schema = self._resolve_json_schema(json_schema, response_model, tools)
-        normalized_tool_choice = self._normalize_tool_choice(tool_choice, tools)
-        normalized_messages = self._normalize_messages(messages)
+        temperature, top_p = self._validate_sampling_parameters(
+            temperature,
+            top_p,
+        )
+        request_context = self._prepare_chat_request(
+            messages,
+            tools,
+            tool_choice,
+            json_schema,
+            response_model,
+        )
+        effective_schema = request_context.effective_schema
+        normalized_tool_choice = request_context.normalized_tool_choice
+        normalized_messages = request_context.normalized_messages
         params = self._build_stream_params(
             normalized_messages=normalized_messages,
             max_tokens=max_tokens,

--- a/src/llm_api_adapter/adapters/anthropic_adapter.py
+++ b/src/llm_api_adapter/adapters/anthropic_adapter.py
@@ -6,7 +6,14 @@ import logging
 from typing import Any, Dict, Iterator, List, Mapping, Optional
 import warnings
 
-from ..adapters.base_adapter import LLMAdapterBase, OnChunk, OnDelta, OnDone, OnToolCall
+from ..adapters.base_adapter import (
+    LLMAdapterBase,
+    OnChunk,
+    OnDelta,
+    OnDone,
+    OnReasoning,
+    OnToolCall,
+)
 from ..errors.llm_api_error import InvalidToolArgumentsError, LLMAPIError
 from ..errors.config_errors import LLMReasoningLevelError
 from ..llms.anthropic.sync_client import ClaudeSyncClient
@@ -37,6 +44,7 @@ class AnthropicAdapter(LLMAdapterBase):
         previous_response: Optional[ChatResponse] = None,
         json_schema: Optional[dict] = None,
         response_model: Optional[Any] = None,
+        capture_reasoning: bool = False,
     ) -> ChatResponse:
         temperature = self._validate_parameter("temperature", temperature, 0, 2)
         top_p = self._validate_parameter("top_p", top_p, 0, 1)
@@ -136,6 +144,8 @@ class AnthropicAdapter(LLMAdapterBase):
         on_done: Optional[OnDone] = None,
         buffer_chars: Optional[int] = None,
         on_chunk: Optional[OnChunk] = None,
+        capture_reasoning: bool = False,
+        on_reasoning: Optional[OnReasoning] = None,
     ) -> Iterator[str]:
         temperature = self._validate_parameter("temperature", temperature, 0, 2)
         top_p = self._validate_parameter("top_p", top_p, 0, 1)

--- a/src/llm_api_adapter/adapters/anthropic_adapter.py
+++ b/src/llm_api_adapter/adapters/anthropic_adapter.py
@@ -55,84 +55,137 @@ class AnthropicAdapter(LLMAdapterBase):
         try:
             self._validate_tools(tools)
             effective_schema = self._resolve_json_schema(json_schema, response_model, tools)
-            validated_tools = tools
             normalized_tool_choice = self._normalize_tool_choice(
                 tool_choice,
-                validated_tools,
+                tools,
             )
             normalized_messages = self._normalize_messages(messages)
-            system_prompt, transformed_messages = normalized_messages.to_anthropic()
-            params: Dict[str, Any] = {
-                "model": self.model,
-                "messages": transformed_messages,
-                "max_tokens": max_tokens,
-                "temperature": temperature,
-                "top_p": top_p,
-                "system": system_prompt,
-                "timeout_s": timeout_s,
-                "is_adaptive_thinking": self.is_adaptive_thinking,
-            }
-            if validated_tools:
-                params["tools"] = [
-                    self._to_anthropic_tool(tool)
-                    for tool in validated_tools
-                ]
-            if normalized_tool_choice is not None:
-                params["tool_choice"] = self._to_anthropic_tool_choice(
-                    normalized_tool_choice
-                )
-            if parallel_tool_calls is False:
-                params["disable_parallel_tool_use"] = True
-            elif parallel_tool_calls is True:
-                params["disable_parallel_tool_use"] = False
-            if effective_schema is not None:
-                params["output_config"] = {
-                    "format": {
-                        "type": "json_schema",
-                        "schema": self._enforce_strict_schema(effective_schema),
-                    }
-                }
-            if reasoning_level:
-                normalized_reasoning_level = self._normalize_reasoning_level(
-                    reasoning_level
-                )
-                if normalized_reasoning_level:
-                    if not self.is_adaptive_thinking:
-                        self.validate_reasoning_and_tokens(
-                            max_tokens=max_tokens,
-                            reasoning_level=reasoning_level,
-                            normalized_reasoning_level=normalized_reasoning_level,
-                        )
-                    params["budget_tokens"] = normalized_reasoning_level
-                if self.is_reasoning:
-                    effort = self._reasoning_level_to_effort(reasoning_level)
-                    if effort:
-                        params["effort"] = effort
-            if capture_reasoning:
-                params["capture_reasoning"] = True
-            params = {k: v for k, v in params.items() if v is not None}
+            params = self._build_chat_params(
+                normalized_messages=normalized_messages,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                top_p=top_p,
+                reasoning_level=reasoning_level,
+                timeout_s=timeout_s,
+                tools=tools,
+                normalized_tool_choice=normalized_tool_choice,
+                parallel_tool_calls=parallel_tool_calls,
+                effective_schema=effective_schema,
+                capture_reasoning=capture_reasoning,
+            )
             _ = previous_response
             client = ClaudeSyncClient(api_key=self.api_key)
             response = client.chat_completion(**params)
-            parser_kwargs = {"capture_reasoning": True} if capture_reasoning else {}
-            chat_response = ChatResponse.from_anthropic_response(
+            chat_response = self._parse_chat_response(
                 response,
-                **parser_kwargs,
+                capture_reasoning=capture_reasoning,
             )
-            chat_response.parsed_json = self._parse_json_response(chat_response.content, effective_schema)
-            chat_response.parsed_model = self._parse_response_model(chat_response.parsed_json, response_model)
-            if self.pricing:
-                chat_response.apply_pricing(
-                    price_input_per_token=self.pricing.in_per_token,
-                    price_output_per_token=self.pricing.out_per_token,
-                    currency=self.pricing.currency,
-                )
-            return chat_response
+            return self._finalize_chat_response(
+                chat_response,
+                effective_schema=effective_schema,
+                response_model=response_model,
+            )
         except LLMAPIError as e:
             self.handle_error(e)
         except Exception as e:
             error_message = getattr(e, "text", None) or str(e)
             self.handle_error(error=e, error_message=error_message)
+
+    def _build_chat_params(
+        self,
+        *,
+        normalized_messages: Messages,
+        max_tokens: int,
+        temperature: float,
+        top_p: float,
+        reasoning_level: Optional[str | int],
+        timeout_s: Optional[float],
+        tools: Optional[List[ToolSpec]],
+        normalized_tool_choice: Optional[str],
+        parallel_tool_calls: Optional[bool],
+        effective_schema: Optional[dict],
+        capture_reasoning: bool,
+    ) -> Dict[str, Any]:
+        system_prompt, transformed_messages = normalized_messages.to_anthropic()
+        params: Dict[str, Any] = {
+            "model": self.model,
+            "messages": transformed_messages,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "top_p": top_p,
+            "system": system_prompt,
+            "timeout_s": timeout_s,
+            "is_adaptive_thinking": self.is_adaptive_thinking,
+        }
+        if tools:
+            params["tools"] = [self._to_anthropic_tool(tool) for tool in tools]
+        if normalized_tool_choice is not None:
+            params["tool_choice"] = self._to_anthropic_tool_choice(
+                normalized_tool_choice
+            )
+        if parallel_tool_calls is False:
+            params["disable_parallel_tool_use"] = True
+        elif parallel_tool_calls is True:
+            params["disable_parallel_tool_use"] = False
+        if effective_schema is not None:
+            params["output_config"] = {
+                "format": {
+                    "type": "json_schema",
+                    "schema": self._enforce_strict_schema(effective_schema),
+                }
+            }
+        if reasoning_level:
+            normalized_reasoning_level = self._normalize_reasoning_level(reasoning_level)
+            if normalized_reasoning_level:
+                if not self.is_adaptive_thinking:
+                    self.validate_reasoning_and_tokens(
+                        max_tokens=max_tokens,
+                        reasoning_level=reasoning_level,
+                        normalized_reasoning_level=normalized_reasoning_level,
+                    )
+                params["budget_tokens"] = normalized_reasoning_level
+            if self.is_reasoning:
+                effort = self._reasoning_level_to_effort(reasoning_level)
+                if effort:
+                    params["effort"] = effort
+        if capture_reasoning:
+            params["capture_reasoning"] = True
+        return {key: value for key, value in params.items() if value is not None}
+
+    @staticmethod
+    def _parse_chat_response(
+        response: dict,
+        *,
+        capture_reasoning: bool,
+    ) -> ChatResponse:
+        parser_kwargs = {"capture_reasoning": True} if capture_reasoning else {}
+        return ChatResponse.from_anthropic_response(
+            response,
+            **parser_kwargs,
+        )
+
+    def _finalize_chat_response(
+        self,
+        chat_response: ChatResponse,
+        *,
+        effective_schema: Optional[dict],
+        response_model: Optional[Any],
+    ) -> ChatResponse:
+        chat_response.parsed_json = self._parse_json_response(
+            chat_response.content,
+            effective_schema,
+        )
+        chat_response.parsed_model = self._parse_response_model(
+            chat_response.parsed_json,
+            response_model,
+        )
+        if self.pricing:
+            chat_response.apply_pricing(
+                price_input_per_token=self.pricing.in_per_token,
+                price_output_per_token=self.pricing.out_per_token,
+                currency=self.pricing.currency,
+            )
+        return chat_response
 
     def stream_chat(
         self,

--- a/src/llm_api_adapter/adapters/anthropic_adapter.py
+++ b/src/llm_api_adapter/adapters/anthropic_adapter.py
@@ -29,6 +29,19 @@ from ..models.tools.tool_spec import ToolSpec
 logger = logging.getLogger(__name__)
 
 
+@dataclass
+class _AnthropicStreamState:
+    message_data: Dict[str, Any]
+    content_blocks: Dict[int, Dict[str, Any]]
+    input_json_fragments: Dict[int, List[str]]
+    usage: Dict[str, Any]
+    message_delta: Dict[str, Any]
+    chunk_buffer: StreamChunkBuffer
+    usage_tracker: StreamUsageTracker
+    reasoning_collector: Optional[StreamReasoningCollector]
+    reasoning_response: Optional[ChatResponse]
+
+
 @dataclass(repr=False)
 class AnthropicAdapter(LLMAdapterBase):
     company: str = "anthropic"
@@ -319,70 +332,37 @@ class AnthropicAdapter(LLMAdapterBase):
         capture_reasoning: bool,
         on_reasoning: Optional[OnReasoning],
     ) -> Iterator[str]:
-        message_data: Dict[str, Any] = {"model": self.model, "content": []}
-        content_blocks: Dict[int, Dict[str, Any]] = {}
-        input_json_fragments: Dict[int, List[str]] = {}
-        usage: Dict[str, Any] = {}
-        message_delta: Dict[str, Any] = {}
-        chunk_buffer = StreamChunkBuffer(buffer_chars)
-        usage_tracker = StreamUsageTracker()
-        reasoning_collector = (
-            StreamReasoningCollector() if capture_reasoning else None
+        state = _AnthropicStreamState(
+            message_data={"model": self.model, "content": []},
+            content_blocks={},
+            input_json_fragments={},
+            usage={},
+            message_delta={},
+            chunk_buffer=StreamChunkBuffer(buffer_chars),
+            usage_tracker=StreamUsageTracker(),
+            reasoning_collector=(
+                StreamReasoningCollector() if capture_reasoning else None
+            ),
+            reasoning_response=ChatResponse() if capture_reasoning else None,
         )
-        reasoning_response = ChatResponse() if capture_reasoning else None
 
         for event in self._iter_provider_stream_events(events):
-            payload = event.data if isinstance(event.data, Mapping) else {}
-            event_type = event.event or payload.get("type")
-            if event_type == "message_start":
-                message_data = self._handle_message_start(payload, usage, message_data)
-                usage_tracker.record(
-                    chunk_buffer,
-                    self._normalize_stream_usage(usage),
-                )
-            elif event_type == "content_block_start":
-                self._start_content_block(payload, content_blocks)
-            elif event_type == "content_block_delta":
-                yield from self._consume_content_block_delta(
-                    payload,
-                    content_blocks,
-                    input_json_fragments,
-                    chunk_buffer,
-                    on_chunk,
-                    on_delta,
-                    reasoning_collector,
-                    reasoning_response,
-                    on_reasoning,
-                )
-            elif event_type == "content_block_stop":
-                self._finalize_content_block(
-                    payload,
-                    content_blocks,
-                    input_json_fragments,
-                )
-            elif event_type == "message_delta":
-                self._handle_message_delta(payload, message_delta, usage)
-                usage_tracker.record(
-                    chunk_buffer,
-                    self._normalize_stream_usage(usage),
-                )
+            yield from self._consume_stream_event(
+                event,
+                state,
+                on_chunk=on_chunk,
+                on_delta=on_delta,
+                on_reasoning=on_reasoning,
+            )
 
-        parser_kwargs = {"capture_reasoning": True} if capture_reasoning else {}
-        chat_response = ChatResponse.from_anthropic_response(
-            self._build_stream_response(message_data, content_blocks, message_delta, usage),
-            **parser_kwargs,
-        )
-        if reasoning_collector is not None:
-            streamed_reasoning_events = reasoning_collector.snapshot()
-            if streamed_reasoning_events:
-                chat_response.reasoning_events = streamed_reasoning_events
-        self._prepare_stream_response(
-            chat_response,
-            effective_schema,
-            response_model,
+        chat_response = self._finalize_stream_response(
+            state,
+            capture_reasoning=capture_reasoning,
+            effective_schema=effective_schema,
+            response_model=response_model,
         )
         yield from self._emit_stream_chunks(
-            chunk_buffer.flush(),
+            state.chunk_buffer.flush(),
             on_chunk,
             on_delta,
         )
@@ -391,6 +371,87 @@ class AnthropicAdapter(LLMAdapterBase):
             on_tool_call,
             on_done,
         )
+
+    def _consume_stream_event(
+        self,
+        event: Any,
+        state: _AnthropicStreamState,
+        *,
+        on_chunk: Optional[OnChunk],
+        on_delta: Optional[OnDelta],
+        on_reasoning: Optional[OnReasoning],
+    ) -> Iterator[str]:
+        payload = event.data if isinstance(event.data, Mapping) else {}
+        event_type = event.event or payload.get("type")
+        if event_type == "message_start":
+            state.message_data = self._handle_message_start(
+                payload,
+                state.usage,
+                state.message_data,
+            )
+            state.usage_tracker.record(
+                state.chunk_buffer,
+                self._normalize_stream_usage(state.usage),
+            )
+        elif event_type == "content_block_start":
+            self._start_content_block(payload, state.content_blocks)
+        elif event_type == "content_block_delta":
+            yield from self._consume_content_block_delta(
+                payload,
+                state.content_blocks,
+                state.input_json_fragments,
+                state.chunk_buffer,
+                on_chunk,
+                on_delta,
+                state.reasoning_collector,
+                state.reasoning_response,
+                on_reasoning,
+            )
+        elif event_type == "content_block_stop":
+            self._finalize_content_block(
+                payload,
+                state.content_blocks,
+                state.input_json_fragments,
+            )
+        elif event_type == "message_delta":
+            self._handle_message_delta(
+                payload,
+                state.message_delta,
+                state.usage,
+            )
+            state.usage_tracker.record(
+                state.chunk_buffer,
+                self._normalize_stream_usage(state.usage),
+            )
+
+    def _finalize_stream_response(
+        self,
+        state: _AnthropicStreamState,
+        *,
+        capture_reasoning: bool,
+        effective_schema: Optional[dict],
+        response_model: Optional[Any],
+    ) -> ChatResponse:
+        parser_kwargs = {"capture_reasoning": True} if capture_reasoning else {}
+        chat_response = ChatResponse.from_anthropic_response(
+            self._build_stream_response(
+                state.message_data,
+                state.content_blocks,
+                state.message_delta,
+                state.usage,
+            ),
+            **parser_kwargs,
+        )
+        if state.reasoning_collector is not None:
+            streamed_reasoning_events = state.reasoning_collector.snapshot()
+            if streamed_reasoning_events:
+                chat_response.reasoning_events = streamed_reasoning_events
+        self._prepare_stream_response(
+            chat_response,
+            effective_schema,
+            response_model,
+        )
+        return chat_response
 
     def _handle_message_start(
         self,

--- a/src/llm_api_adapter/adapters/anthropic_adapter.py
+++ b/src/llm_api_adapter/adapters/anthropic_adapter.py
@@ -17,7 +17,11 @@ from ..adapters.base_adapter import (
 from ..errors.llm_api_error import InvalidToolArgumentsError, LLMAPIError
 from ..errors.config_errors import LLMReasoningLevelError
 from ..llms.anthropic.sync_client import ClaudeSyncClient
-from ..llms.streaming import StreamChunkBuffer, StreamUsageTracker
+from ..llms.streaming import (
+    StreamChunkBuffer,
+    StreamReasoningCollector,
+    StreamUsageTracker,
+)
 from ..models.messages.chat_message import Message, Messages
 from ..models.responses.chat_response import ChatResponse, Usage
 from ..models.tools.tool_spec import ToolSpec
@@ -104,11 +108,17 @@ class AnthropicAdapter(LLMAdapterBase):
                     effort = self._reasoning_level_to_effort(reasoning_level)
                     if effort:
                         params["effort"] = effort
+            if capture_reasoning:
+                params["capture_reasoning"] = True
             params = {k: v for k, v in params.items() if v is not None}
             _ = previous_response
             client = ClaudeSyncClient(api_key=self.api_key)
             response = client.chat_completion(**params)
-            chat_response = ChatResponse.from_anthropic_response(response)
+            parser_kwargs = {"capture_reasoning": True} if capture_reasoning else {}
+            chat_response = ChatResponse.from_anthropic_response(
+                response,
+                **parser_kwargs,
+            )
             chat_response.parsed_json = self._parse_json_response(chat_response.content, effective_schema)
             chat_response.parsed_model = self._parse_response_model(chat_response.parsed_json, response_model)
             if self.pricing:
@@ -164,6 +174,7 @@ class AnthropicAdapter(LLMAdapterBase):
             normalized_tool_choice=normalized_tool_choice,
             parallel_tool_calls=parallel_tool_calls,
             effective_schema=effective_schema,
+            capture_reasoning=capture_reasoning,
         )
         _ = previous_response
         client = ClaudeSyncClient(api_key=self.api_key)
@@ -177,6 +188,8 @@ class AnthropicAdapter(LLMAdapterBase):
             on_done,
             buffer_chars,
             on_chunk,
+            capture_reasoning,
+            on_reasoning,
         )
 
     def _build_stream_params(
@@ -192,6 +205,7 @@ class AnthropicAdapter(LLMAdapterBase):
         normalized_tool_choice: Optional[str],
         parallel_tool_calls: Optional[bool],
         effective_schema: Optional[dict],
+        capture_reasoning: bool,
     ) -> Dict[str, Any]:
         system_prompt, transformed_messages = normalized_messages.to_anthropic()
         params: Dict[str, Any] = {
@@ -231,10 +245,12 @@ class AnthropicAdapter(LLMAdapterBase):
                         normalized_reasoning_level=normalized_reasoning_level,
                     )
                 params["budget_tokens"] = normalized_reasoning_level
-            if self.is_reasoning:
-                effort = self._reasoning_level_to_effort(reasoning_level)
-                if effort:
-                    params["effort"] = effort
+                if self.is_reasoning:
+                    effort = self._reasoning_level_to_effort(reasoning_level)
+                    if effort:
+                        params["effort"] = effort
+        if capture_reasoning:
+            params["capture_reasoning"] = True
         return {key: value for key, value in params.items() if value is not None}
 
     def _consume_stream(
@@ -247,6 +263,8 @@ class AnthropicAdapter(LLMAdapterBase):
         on_done: Optional[OnDone],
         buffer_chars: Optional[int],
         on_chunk: Optional[OnChunk],
+        capture_reasoning: bool,
+        on_reasoning: Optional[OnReasoning],
     ) -> Iterator[str]:
         message_data: Dict[str, Any] = {"model": self.model, "content": []}
         content_blocks: Dict[int, Dict[str, Any]] = {}
@@ -255,6 +273,10 @@ class AnthropicAdapter(LLMAdapterBase):
         message_delta: Dict[str, Any] = {}
         chunk_buffer = StreamChunkBuffer(buffer_chars)
         usage_tracker = StreamUsageTracker()
+        reasoning_collector = (
+            StreamReasoningCollector() if capture_reasoning else None
+        )
+        reasoning_response = ChatResponse() if capture_reasoning else None
 
         for event in self._iter_provider_stream_events(events):
             payload = event.data if isinstance(event.data, Mapping) else {}
@@ -275,6 +297,9 @@ class AnthropicAdapter(LLMAdapterBase):
                     chunk_buffer,
                     on_chunk,
                     on_delta,
+                    reasoning_collector,
+                    reasoning_response,
+                    on_reasoning,
                 )
             elif event_type == "content_block_stop":
                 self._finalize_content_block(
@@ -289,9 +314,15 @@ class AnthropicAdapter(LLMAdapterBase):
                     self._normalize_stream_usage(usage),
                 )
 
+        parser_kwargs = {"capture_reasoning": True} if capture_reasoning else {}
         chat_response = ChatResponse.from_anthropic_response(
-            self._build_stream_response(message_data, content_blocks, message_delta, usage)
+            self._build_stream_response(message_data, content_blocks, message_delta, usage),
+            **parser_kwargs,
         )
+        if reasoning_collector is not None:
+            streamed_reasoning_events = reasoning_collector.snapshot()
+            if streamed_reasoning_events:
+                chat_response.reasoning_events = streamed_reasoning_events
         self._prepare_stream_response(
             chat_response,
             effective_schema,
@@ -334,6 +365,8 @@ class AnthropicAdapter(LLMAdapterBase):
         content_blocks[index] = dict(block)
         if block.get("type") == "text":
             content_blocks[index]["text"] = str(block.get("text") or "")
+        elif block.get("type") == "thinking":
+            content_blocks[index]["thinking"] = str(block.get("thinking") or "")
         elif block.get("type") == "tool_use":
             current_input = block.get("input")
             content_blocks[index]["input"] = (
@@ -348,6 +381,9 @@ class AnthropicAdapter(LLMAdapterBase):
         chunk_buffer: StreamChunkBuffer,
         on_chunk: Optional[OnChunk],
         on_delta: Optional[OnDelta],
+        reasoning_collector: Optional[StreamReasoningCollector],
+        reasoning_response: Optional[ChatResponse],
+        on_reasoning: Optional[OnReasoning],
     ) -> Iterator[str]:
         index = payload.get("index")
         delta = payload.get("delta")
@@ -365,6 +401,19 @@ class AnthropicAdapter(LLMAdapterBase):
                     on_chunk,
                     on_delta,
                 )
+        elif delta.get("type") == "thinking_delta":
+            thinking_text = delta.get("thinking")
+            if isinstance(thinking_text, str) and thinking_text:
+                block["thinking"] = f"{block.get('thinking', '')}{thinking_text}"
+                if reasoning_collector is not None and reasoning_response is not None:
+                    self._record_reasoning_event(
+                        reasoning_response,
+                        reasoning_collector,
+                        thinking_text,
+                        capture_reasoning=True,
+                        kind="summary",
+                        on_reasoning=on_reasoning,
+                    )
         elif delta.get("type") == "input_json_delta":
             partial_json = delta.get("partial_json")
             if isinstance(partial_json, str):

--- a/src/llm_api_adapter/adapters/base_adapter.py
+++ b/src/llm_api_adapter/adapters/base_adapter.py
@@ -23,7 +23,11 @@ from ..models.responses.reasoning_event import (
     ReasoningEventKind,
 )
 from ..models.responses.stream_chunk import StreamChunk
-from ..llms.streaming import StreamReasoningCollector
+from ..llms.streaming import (
+    StreamChunkBuffer,
+    StreamReasoningCollector,
+    StreamUsageTracker,
+)
 from ..models.tools import ToolCall, ToolSpec
 
 logger = logging.getLogger(__name__)
@@ -50,6 +54,14 @@ OnChunk = Callable[[StreamChunk], None]
 OnToolCall = Callable[[ToolCall], None]
 OnDone = Callable[[ChatResponse], None]
 OnReasoning = Callable[[ReasoningEvent], None]
+
+
+@dataclass
+class _StreamState:
+    chunk_buffer: StreamChunkBuffer
+    usage_tracker: StreamUsageTracker
+    reasoning_collector: Optional[StreamReasoningCollector]
+    reasoning_response: Optional[ChatResponse]
 
 
 @dataclass
@@ -556,16 +568,37 @@ class LLMAdapterBase(ABC):
     def _finalize_stream_response(
         self,
         chat_response: ChatResponse,
+        *,
+        reasoning_collector: Optional[StreamReasoningCollector] = None,
         effective_schema: Optional[dict],
         response_model: Optional[Any],
-        on_tool_call: Optional[OnToolCall],
-        on_done: Optional[OnDone],
-    ) -> None:
-        """Apply normal response post-processing, then invoke stream callbacks."""
+    ) -> ChatResponse:
+        """Apply common reasoning, structured-output and pricing finalization."""
+        if reasoning_collector is not None:
+            streamed_reasoning_events = reasoning_collector.snapshot()
+            if streamed_reasoning_events:
+                chat_response.reasoning_events = streamed_reasoning_events
         self._prepare_stream_response(
             chat_response,
             effective_schema,
             response_model,
+        )
+        return chat_response
+
+    def _complete_stream(
+        self,
+        chat_response: ChatResponse,
+        chunk_buffer: StreamChunkBuffer,
+        on_chunk: Optional[OnChunk],
+        on_delta: Optional[OnDelta],
+        on_tool_call: Optional[OnToolCall],
+        on_done: Optional[OnDone],
+    ) -> Iterator[str]:
+        """Flush visible text and invoke the common stream callbacks."""
+        yield from self._emit_stream_chunks(
+            chunk_buffer.flush(),
+            on_chunk,
+            on_delta,
         )
         self._invoke_stream_completion_callbacks(
             chat_response,

--- a/src/llm_api_adapter/adapters/base_adapter.py
+++ b/src/llm_api_adapter/adapters/base_adapter.py
@@ -400,6 +400,30 @@ class LLMAdapterBase(ABC):
             error_message = getattr(error, "text", None) or str(error)
             self.handle_error(error=error, error_message=error_message)
 
+    def _finalize_chat_response(
+        self,
+        chat_response: ChatResponse,
+        *,
+        effective_schema: Optional[dict],
+        response_model: Optional[Any],
+    ) -> ChatResponse:
+        """Apply common structured-output parsing and pricing to a response."""
+        chat_response.parsed_json = self._parse_json_response(
+            chat_response.content,
+            effective_schema,
+        )
+        chat_response.parsed_model = self._parse_response_model(
+            chat_response.parsed_json,
+            response_model,
+        )
+        if self.pricing:
+            chat_response.apply_pricing(
+                price_input_per_token=self.pricing.in_per_token,
+                price_output_per_token=self.pricing.out_per_token,
+                currency=self.pricing.currency,
+            )
+        return chat_response
+
     def _prepare_stream_response(
         self,
         chat_response: ChatResponse,

--- a/src/llm_api_adapter/adapters/base_adapter.py
+++ b/src/llm_api_adapter/adapters/base_adapter.py
@@ -37,6 +37,14 @@ REASONING_LEVELS_DEFAULT = {
 
 TOOL_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
 
+
+@dataclass(frozen=True)
+class _ChatRequestContext:
+    normalized_messages: Messages
+    effective_schema: Optional[dict]
+    normalized_tool_choice: Optional[str]
+
+
 OnDelta = Callable[[str], None]
 OnChunk = Callable[[StreamChunk], None]
 OnToolCall = Callable[[ToolCall], None]
@@ -163,6 +171,43 @@ class LLMAdapterBase(ABC):
             logger.error(error_message)
             raise ValueError(error_message)
         return value
+
+    def _validate_sampling_parameters(
+        self,
+        temperature: float,
+        top_p: float,
+    ) -> tuple[float, float]:
+        """Validate the sampling parameters shared by all providers."""
+        return (
+            self._validate_parameter("temperature", temperature, 0, 2),
+            self._validate_parameter("top_p", top_p, 0, 1),
+        )
+
+    def _prepare_chat_request(
+        self,
+        messages: Any,
+        tools: Optional[List[ToolSpec]],
+        tool_choice: Any,
+        json_schema: Optional[dict],
+        response_model: Optional[Any],
+    ) -> _ChatRequestContext:
+        """Validate and normalize provider-neutral chat inputs."""
+        self._validate_tools(tools)
+        effective_schema = self._resolve_json_schema(
+            json_schema,
+            response_model,
+            tools,
+        )
+        normalized_tool_choice = self._normalize_tool_choice(
+            tool_choice,
+            tools,
+        )
+        normalized_messages = self._normalize_messages(messages)
+        return _ChatRequestContext(
+            normalized_messages=normalized_messages,
+            effective_schema=effective_schema,
+            normalized_tool_choice=normalized_tool_choice,
+        )
 
     def _normalize_messages(self, messages: Any) -> Messages:
         if isinstance(messages, Messages):

--- a/src/llm_api_adapter/adapters/base_adapter.py
+++ b/src/llm_api_adapter/adapters/base_adapter.py
@@ -18,7 +18,12 @@ from ..errors.llm_api_error import (
 from ..llm_registry.llm_registry import Pricing, LLM_REGISTRY
 from ..models.messages.chat_message import Messages
 from ..models.responses.chat_response import ChatResponse
+from ..models.responses.reasoning_event import (
+    ReasoningEvent,
+    ReasoningEventKind,
+)
 from ..models.responses.stream_chunk import StreamChunk
+from ..llms.streaming import StreamReasoningCollector
 from ..models.tools import ToolCall, ToolSpec
 
 logger = logging.getLogger(__name__)
@@ -36,6 +41,7 @@ OnDelta = Callable[[str], None]
 OnChunk = Callable[[StreamChunk], None]
 OnToolCall = Callable[[ToolCall], None]
 OnDone = Callable[[ChatResponse], None]
+OnReasoning = Callable[[ReasoningEvent], None]
 
 
 @dataclass
@@ -78,9 +84,28 @@ class LLMAdapterBase(ABC):
             self.is_adaptive_thinking = getattr(model_spec, "is_adaptive_thinking", False)
 
     @abstractmethod
-    def chat(self, **kwargs) -> ChatResponse:
+    def chat(
+        self,
+        messages: Any,
+        max_tokens: Optional[int] = None,
+        temperature: float = 1.0,
+        top_p: float = 1.0,
+        reasoning_level: Optional[str | int] = None,
+        timeout_s: Optional[float] = None,
+        tools: Optional[List[ToolSpec]] = None,
+        tool_choice: Any = None,
+        parallel_tool_calls: Optional[bool] = None,
+        previous_response: Optional[ChatResponse] = None,
+        json_schema: Optional[dict] = None,
+        response_model: Optional[Any] = None,
+        *,
+        capture_reasoning: bool = False,
+    ) -> ChatResponse:
         """
         Generates a response based on the provided conversation.
+
+        ``capture_reasoning`` is an opt-in request flag implemented by
+        provider adapters; the default preserves the existing request.
         """
         raise NotImplementedError
 
@@ -104,12 +129,18 @@ class LLMAdapterBase(ABC):
         on_done: Optional[OnDone] = None,
         buffer_chars: Optional[int] = None,
         on_chunk: Optional[OnChunk] = None,
+        *,
+        capture_reasoning: bool = False,
+        on_reasoning: Optional[OnReasoning] = None,
     ) -> Iterator[str]:
         """Stream normalized text deltas synchronously.
 
         ``buffer_chars`` optionally coalesces visible text into bounded
         chunks.  ``on_chunk`` receives each emitted :class:`StreamChunk`
         before the corresponding ``on_delta`` callback and yielded text.
+        ``on_reasoning`` receives provider-normalized reasoning events only
+        when ``capture_reasoning`` is enabled; reasoning is never yielded as
+        visible text.
         """
         raise NotImplementedError
 
@@ -409,6 +440,35 @@ class LLMAdapterBase(ABC):
                 on_tool_call(tool_call)
         if on_done is not None:
             on_done(chat_response)
+
+    def _record_reasoning_event(
+        self,
+        chat_response: ChatResponse,
+        collector: StreamReasoningCollector,
+        text: str,
+        *,
+        capture_reasoning: bool,
+        kind: ReasoningEventKind = "summary",
+        on_reasoning: Optional[OnReasoning] = None,
+    ) -> Optional[ReasoningEvent]:
+        """Append an opt-in reasoning event and then notify its callback.
+
+        The response is updated before ``on_reasoning`` runs, so a later
+        ``on_done`` callback observes the same sequence.  This helper is
+        intentionally separate from visible-text emission and therefore does
+        not call ``on_delta`` or yield anything.
+        """
+        if not capture_reasoning:
+            return None
+
+        event = collector.add(text, kind=kind)
+        if event is None:
+            return None
+
+        chat_response.reasoning_events.append(event)
+        if on_reasoning is not None:
+            on_reasoning(event)
+        return event
 
     def _emit_stream_chunks(
         self,

--- a/src/llm_api_adapter/adapters/google_adapter.py
+++ b/src/llm_api_adapter/adapters/google_adapter.py
@@ -15,7 +15,11 @@ from ..adapters.base_adapter import (
 )
 from ..errors.llm_api_error import LLMAPIError
 from ..llms.google.sync_client import GeminiSyncClient
-from ..llms.streaming import StreamChunkBuffer, StreamUsageTracker
+from ..llms.streaming import (
+    StreamChunkBuffer,
+    StreamReasoningCollector,
+    StreamUsageTracker,
+)
 from ..models.messages.chat_message import Message, Messages
 from ..models.responses.chat_response import ChatResponse, Usage
 from ..models.tools import ToolSpec
@@ -75,15 +79,12 @@ class GoogleAdapter(LLMAdapterBase):
             if effective_schema is not None:
                 generation_config["responseMimeType"] = "application/json"
                 generation_config["responseSchema"] = self._to_google_schema(effective_schema)
-            if reasoning_level:
-                normalized_reasoning_level = self._normalize_reasoning_level(
-                    reasoning_level
-                )
-                if normalized_reasoning_level is not None:
-                    generation_config["thinkingConfig"] = {
-                        "thinkingBudget": normalized_reasoning_level,
-                        "includeThoughts": False,
-                    }
+            thinking_config = self._build_thinking_config(
+                reasoning_level=reasoning_level,
+                capture_reasoning=capture_reasoning,
+            )
+            if thinking_config is not None:
+                generation_config["thinkingConfig"] = thinking_config
             payload: Dict[str, Any] = {
                 "contents": transformed_messages,
                 "generationConfig": generation_config,
@@ -111,7 +112,11 @@ class GoogleAdapter(LLMAdapterBase):
                 timeout_s=timeout_s,
                 **payload,
             )
-            chat_response = ChatResponse.from_google_response(response_json)
+            parser_kwargs = {"capture_reasoning": True} if capture_reasoning else {}
+            chat_response = ChatResponse.from_google_response(
+                response_json,
+                **parser_kwargs,
+            )
             chat_response.parsed_json = self._parse_json_response(chat_response.content, effective_schema)
             chat_response.parsed_model = self._parse_response_model(chat_response.parsed_json, response_model)
             if self.pricing:
@@ -166,6 +171,7 @@ class GoogleAdapter(LLMAdapterBase):
             tools=tools,
             normalized_tool_choice=normalized_tool_choice,
             effective_schema=effective_schema,
+            capture_reasoning=capture_reasoning,
         )
         _ = parallel_tool_calls
         client = GeminiSyncClient(self.api_key)
@@ -179,6 +185,8 @@ class GoogleAdapter(LLMAdapterBase):
             on_done,
             buffer_chars,
             on_chunk,
+            capture_reasoning,
+            on_reasoning,
         )
 
     def _build_stream_payload(
@@ -192,6 +200,7 @@ class GoogleAdapter(LLMAdapterBase):
         tools: Optional[List[ToolSpec]],
         normalized_tool_choice: Optional[str],
         effective_schema: Optional[dict],
+        capture_reasoning: bool,
     ) -> Dict[str, Any]:
         system_prompt, transformed_messages = normalized_messages.to_google()
         generation_config: Dict[str, Any] = {
@@ -202,13 +211,12 @@ class GoogleAdapter(LLMAdapterBase):
         if effective_schema is not None:
             generation_config["responseMimeType"] = "application/json"
             generation_config["responseSchema"] = self._to_google_schema(effective_schema)
-        if reasoning_level:
-            normalized_reasoning_level = self._normalize_reasoning_level(reasoning_level)
-            if normalized_reasoning_level is not None:
-                generation_config["thinkingConfig"] = {
-                    "thinkingBudget": normalized_reasoning_level,
-                    "includeThoughts": False,
-                }
+        thinking_config = self._build_thinking_config(
+            reasoning_level=reasoning_level,
+            capture_reasoning=capture_reasoning,
+        )
+        if thinking_config is not None:
+            generation_config["thinkingConfig"] = thinking_config
         payload: Dict[str, Any] = {
             "contents": transformed_messages,
             "generationConfig": generation_config,
@@ -236,6 +244,8 @@ class GoogleAdapter(LLMAdapterBase):
         on_done: Optional[OnDone],
         buffer_chars: Optional[int],
         on_chunk: Optional[OnChunk],
+        capture_reasoning: bool,
+        on_reasoning: Optional[OnReasoning],
     ) -> Iterator[str]:
         text_parts: List[str] = []
         function_parts: List[Dict[str, Any]] = []
@@ -244,6 +254,10 @@ class GoogleAdapter(LLMAdapterBase):
         response_metadata: Dict[str, Any] = {}
         chunk_buffer = StreamChunkBuffer(buffer_chars)
         usage_tracker = StreamUsageTracker()
+        reasoning_collector = (
+            StreamReasoningCollector() if capture_reasoning else None
+        )
+        reasoning_response = ChatResponse() if capture_reasoning else None
 
         for event in self._iter_provider_stream_events(events):
             chunk = event.data if isinstance(event.data, Mapping) else {}
@@ -273,10 +287,24 @@ class GoogleAdapter(LLMAdapterBase):
                 if not isinstance(part, Mapping):
                     continue
                 text = part.get("text")
-                if (
+                if part.get("thought"):
+                    if (
+                        reasoning_collector is not None
+                        and reasoning_response is not None
+                        and isinstance(text, str)
+                        and text
+                    ):
+                        self._record_reasoning_event(
+                            reasoning_response,
+                            reasoning_collector,
+                            text,
+                            capture_reasoning=True,
+                            kind="summary",
+                            on_reasoning=on_reasoning,
+                        )
+                elif (
                     isinstance(text, str)
                     and text
-                    and not part.get("thought", False)
                 ):
                     text_parts.append(text)
                     yield from self._emit_stream_chunks(
@@ -300,7 +328,15 @@ class GoogleAdapter(LLMAdapterBase):
         }
         if usage_metadata:
             final_response["usageMetadata"] = usage_metadata
-        chat_response = ChatResponse.from_google_response(final_response)
+        parser_kwargs = {"capture_reasoning": True} if capture_reasoning else {}
+        chat_response = ChatResponse.from_google_response(
+            final_response,
+            **parser_kwargs,
+        )
+        if reasoning_collector is not None:
+            streamed_reasoning_events = reasoning_collector.snapshot()
+            if streamed_reasoning_events:
+                chat_response.reasoning_events = streamed_reasoning_events
         self._prepare_stream_response(
             chat_response,
             effective_schema,
@@ -316,6 +352,24 @@ class GoogleAdapter(LLMAdapterBase):
             on_tool_call,
             on_done,
         )
+
+    def _build_thinking_config(
+        self,
+        *,
+        reasoning_level: Optional[str | int],
+        capture_reasoning: bool,
+    ) -> Optional[Dict[str, Any]]:
+        thinking_config: Dict[str, Any] = {}
+        if reasoning_level:
+            normalized_reasoning_level = self._normalize_reasoning_level(
+                reasoning_level
+            )
+            if normalized_reasoning_level is not None:
+                thinking_config["thinkingBudget"] = normalized_reasoning_level
+                thinking_config["includeThoughts"] = False
+        if capture_reasoning:
+            thinking_config["includeThoughts"] = True
+        return thinking_config or None
 
     @staticmethod
     def _normalize_stream_usage(raw_usage: Mapping[str, Any]) -> Optional[Usage]:

--- a/src/llm_api_adapter/adapters/google_adapter.py
+++ b/src/llm_api_adapter/adapters/google_adapter.py
@@ -5,7 +5,14 @@ import logging
 from typing import Any, Dict, Iterator, List, Mapping, Optional
 import warnings
 
-from ..adapters.base_adapter import LLMAdapterBase, OnChunk, OnDelta, OnDone, OnToolCall
+from ..adapters.base_adapter import (
+    LLMAdapterBase,
+    OnChunk,
+    OnDelta,
+    OnDone,
+    OnReasoning,
+    OnToolCall,
+)
 from ..errors.llm_api_error import LLMAPIError
 from ..llms.google.sync_client import GeminiSyncClient
 from ..llms.streaming import StreamChunkBuffer, StreamUsageTracker
@@ -35,6 +42,7 @@ class GoogleAdapter(LLMAdapterBase):
         previous_response: Optional[ChatResponse] = None,
         json_schema: Optional[dict] = None,
         response_model: Optional[Any] = None,
+        capture_reasoning: bool = False,
     ) -> ChatResponse:
         temperature = self._validate_parameter(
             name="temperature",
@@ -139,6 +147,8 @@ class GoogleAdapter(LLMAdapterBase):
         on_done: Optional[OnDone] = None,
         buffer_chars: Optional[int] = None,
         on_chunk: Optional[OnChunk] = None,
+        capture_reasoning: bool = False,
+        on_reasoning: Optional[OnReasoning] = None,
     ) -> Iterator[str]:
         temperature = self._validate_parameter("temperature", temperature, 0, 2)
         top_p = self._validate_parameter("top_p", top_p, 0, 1)

--- a/src/llm_api_adapter/adapters/google_adapter.py
+++ b/src/llm_api_adapter/adapters/google_adapter.py
@@ -61,26 +61,21 @@ class GoogleAdapter(LLMAdapterBase):
         response_model: Optional[Any] = None,
         capture_reasoning: bool = False,
     ) -> ChatResponse:
-        temperature = self._validate_parameter(
-            name="temperature",
-            value=temperature,
-            min_value=0,
-            max_value=2,
-        )
-        top_p = self._validate_parameter(
-            name="top_p",
-            value=top_p,
-            min_value=0,
-            max_value=1,
+        temperature, top_p = self._validate_sampling_parameters(
+            temperature,
+            top_p,
         )
         try:
-            self._validate_tools(tools)
-            effective_schema = self._resolve_json_schema(json_schema, response_model, tools)
-            normalized_tool_choice = self._normalize_tool_choice(
-                tool_choice,
+            request_context = self._prepare_chat_request(
+                messages,
                 tools,
+                tool_choice,
+                json_schema,
+                response_model,
             )
-            normalized_messages = self._normalize_messages(messages)
+            effective_schema = request_context.effective_schema
+            normalized_tool_choice = request_context.normalized_tool_choice
+            normalized_messages = request_context.normalized_messages
             params = self._build_chat_params(
                 normalized_messages=normalized_messages,
                 max_tokens=max_tokens,
@@ -185,12 +180,20 @@ class GoogleAdapter(LLMAdapterBase):
         capture_reasoning: bool = False,
         on_reasoning: Optional[OnReasoning] = None,
     ) -> Iterator[str]:
-        temperature = self._validate_parameter("temperature", temperature, 0, 2)
-        top_p = self._validate_parameter("top_p", top_p, 0, 1)
-        self._validate_tools(tools)
-        effective_schema = self._resolve_json_schema(json_schema, response_model, tools)
-        normalized_tool_choice = self._normalize_tool_choice(tool_choice, tools)
-        normalized_messages = self._normalize_messages(messages)
+        temperature, top_p = self._validate_sampling_parameters(
+            temperature,
+            top_p,
+        )
+        request_context = self._prepare_chat_request(
+            messages,
+            tools,
+            tool_choice,
+            json_schema,
+            response_model,
+        )
+        effective_schema = request_context.effective_schema
+        normalized_tool_choice = request_context.normalized_tool_choice
+        normalized_messages = request_context.normalized_messages
         _ = previous_response
         payload = self._build_stream_payload(
             normalized_messages=normalized_messages,

--- a/src/llm_api_adapter/adapters/google_adapter.py
+++ b/src/llm_api_adapter/adapters/google_adapter.py
@@ -12,6 +12,7 @@ from ..adapters.base_adapter import (
     OnDone,
     OnReasoning,
     OnToolCall,
+    _StreamState,
 )
 from ..errors.llm_api_error import LLMAPIError
 from ..llms.google.sync_client import GeminiSyncClient
@@ -28,16 +29,12 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass
-class _GoogleStreamState:
-    chunk_buffer: StreamChunkBuffer
-    usage_tracker: StreamUsageTracker
+class _GoogleStreamState(_StreamState):
     text_parts: List[str] = field(default_factory=list)
     function_parts: List[Dict[str, Any]] = field(default_factory=list)
     finish_reason: Optional[str] = None
     usage_metadata: Dict[str, Any] = field(default_factory=dict)
     response_metadata: Dict[str, Any] = field(default_factory=dict)
-    reasoning_collector: Optional[StreamReasoningCollector] = None
-    reasoning_response: Optional[ChatResponse] = None
 
 
 @dataclass(repr=False)
@@ -324,13 +321,11 @@ class GoogleAdapter(LLMAdapterBase):
             effective_schema=effective_schema,
             response_model=response_model,
         )
-        yield from self._emit_stream_chunks(
-            state.chunk_buffer.flush(),
+        yield from self._complete_stream(
+            chat_response,
+            state.chunk_buffer,
             on_chunk,
             on_delta,
-        )
-        self._invoke_stream_completion_callbacks(
-            chat_response,
             on_tool_call,
             on_done,
         )
@@ -435,16 +430,12 @@ class GoogleAdapter(LLMAdapterBase):
             final_response,
             **parser_kwargs,
         )
-        if state.reasoning_collector is not None:
-            streamed_reasoning_events = state.reasoning_collector.snapshot()
-            if streamed_reasoning_events:
-                chat_response.reasoning_events = streamed_reasoning_events
-        self._prepare_stream_response(
+        return super()._finalize_stream_response(
             chat_response,
-            effective_schema,
-            response_model,
+            reasoning_collector=state.reasoning_collector,
+            effective_schema=effective_schema,
+            response_model=response_model,
         )
-        return chat_response
 
     @staticmethod
     def _build_stream_response(state: _GoogleStreamState) -> Dict[str, Any]:

--- a/src/llm_api_adapter/adapters/google_adapter.py
+++ b/src/llm_api_adapter/adapters/google_adapter.py
@@ -63,74 +63,114 @@ class GoogleAdapter(LLMAdapterBase):
         try:
             self._validate_tools(tools)
             effective_schema = self._resolve_json_schema(json_schema, response_model, tools)
-            validated_tools = tools
             normalized_tool_choice = self._normalize_tool_choice(
                 tool_choice,
-                validated_tools,
+                tools,
             )
             normalized_messages = self._normalize_messages(messages)
-            _ = previous_response
-            system_prompt, transformed_messages = normalized_messages.to_google()
-            generation_config: Dict[str, Any] = {
-                "maxOutputTokens": max_tokens,
-                "temperature": temperature,
-                "topP": top_p,
-            }
-            if effective_schema is not None:
-                generation_config["responseMimeType"] = "application/json"
-                generation_config["responseSchema"] = self._to_google_schema(effective_schema)
-            thinking_config = self._build_thinking_config(
+            params = self._build_chat_params(
+                normalized_messages=normalized_messages,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                top_p=top_p,
                 reasoning_level=reasoning_level,
+                timeout_s=timeout_s,
+                tools=tools,
+                normalized_tool_choice=normalized_tool_choice,
+                effective_schema=effective_schema,
                 capture_reasoning=capture_reasoning,
             )
-            if thinking_config is not None:
-                generation_config["thinkingConfig"] = thinking_config
-            payload: Dict[str, Any] = {
-                "contents": transformed_messages,
-                "generationConfig": generation_config,
-            }
-            if system_prompt:
-                payload["system_instruction"] = {
-                    "parts": [{"text": system_prompt}]
-                }
-            if validated_tools:
-                payload["tools"] = [
-                    {
-                        "functionDeclarations": [
-                            self._to_google_function_declaration(tool)
-                            for tool in validated_tools
-                        ]
-                    }
-                ]
-            tool_config = self._to_google_tool_config(normalized_tool_choice)
-            if tool_config is not None:
-                payload["toolConfig"] = tool_config
+            _ = previous_response
             _ = parallel_tool_calls
             client = GeminiSyncClient(self.api_key)
-            response_json = client.chat_completion(
-                model=self.model,
-                timeout_s=timeout_s,
-                **payload,
+            response = client.chat_completion(**params)
+            chat_response = self._parse_chat_response(
+                response,
+                capture_reasoning=capture_reasoning,
             )
-            parser_kwargs = {"capture_reasoning": True} if capture_reasoning else {}
-            chat_response = ChatResponse.from_google_response(
-                response_json,
-                **parser_kwargs,
+            return self._finalize_chat_response(
+                chat_response,
+                effective_schema=effective_schema,
+                response_model=response_model,
             )
-            chat_response.parsed_json = self._parse_json_response(chat_response.content, effective_schema)
-            chat_response.parsed_model = self._parse_response_model(chat_response.parsed_json, response_model)
-            if self.pricing:
-                chat_response.apply_pricing(
-                    price_input_per_token=self.pricing.in_per_token,
-                    price_output_per_token=self.pricing.out_per_token,
-                    currency=self.pricing.currency,
-                )
-            return chat_response
         except LLMAPIError as e:
             self.handle_error(e)
         except Exception as e:
             error_message = getattr(e, "text", None) or str(e)
             self.handle_error(error=e, error_message=error_message)
+
+    def _build_chat_params(
+        self,
+        *,
+        normalized_messages: Messages,
+        max_tokens: Optional[int],
+        temperature: float,
+        top_p: float,
+        reasoning_level: Optional[str | int],
+        timeout_s: Optional[float],
+        tools: Optional[List[ToolSpec]],
+        normalized_tool_choice: Optional[str],
+        effective_schema: Optional[dict],
+        capture_reasoning: bool,
+    ) -> Dict[str, Any]:
+        system_prompt, transformed_messages = normalized_messages.to_google()
+        params: Dict[str, Any] = {
+            "model": self.model,
+            "timeout_s": timeout_s,
+            "contents": transformed_messages,
+            "generationConfig": self._build_generation_config(
+                max_tokens=max_tokens,
+                temperature=temperature,
+                top_p=top_p,
+                reasoning_level=reasoning_level,
+                effective_schema=effective_schema,
+                capture_reasoning=capture_reasoning,
+            ),
+        }
+        if system_prompt:
+            params["system_instruction"] = {"parts": [{"text": system_prompt}]}
+        if tools:
+            params["tools"] = [{
+                "functionDeclarations": [
+                    self._to_google_function_declaration(tool) for tool in tools
+                ]
+            }]
+        tool_config = self._to_google_tool_config(normalized_tool_choice)
+        if tool_config is not None:
+            params["toolConfig"] = tool_config
+        return {key: value for key, value in params.items() if value is not None}
+
+    @staticmethod
+    def _parse_chat_response(
+        response: dict,
+        *,
+        capture_reasoning: bool,
+    ) -> ChatResponse:
+        parser_kwargs = {"capture_reasoning": True} if capture_reasoning else {}
+        return ChatResponse.from_google_response(response, **parser_kwargs)
+
+    def _finalize_chat_response(
+        self,
+        chat_response: ChatResponse,
+        *,
+        effective_schema: Optional[dict],
+        response_model: Optional[Any],
+    ) -> ChatResponse:
+        chat_response.parsed_json = self._parse_json_response(
+            chat_response.content,
+            effective_schema,
+        )
+        chat_response.parsed_model = self._parse_response_model(
+            chat_response.parsed_json,
+            response_model,
+        )
+        if self.pricing:
+            chat_response.apply_pricing(
+                price_input_per_token=self.pricing.in_per_token,
+                price_output_per_token=self.pricing.out_per_token,
+                currency=self.pricing.currency,
+            )
+        return chat_response
 
     def stream_chat(
         self,
@@ -203,20 +243,14 @@ class GoogleAdapter(LLMAdapterBase):
         capture_reasoning: bool,
     ) -> Dict[str, Any]:
         system_prompt, transformed_messages = normalized_messages.to_google()
-        generation_config: Dict[str, Any] = {
-            "maxOutputTokens": max_tokens,
-            "temperature": temperature,
-            "topP": top_p,
-        }
-        if effective_schema is not None:
-            generation_config["responseMimeType"] = "application/json"
-            generation_config["responseSchema"] = self._to_google_schema(effective_schema)
-        thinking_config = self._build_thinking_config(
+        generation_config = self._build_generation_config(
+            max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
             reasoning_level=reasoning_level,
+            effective_schema=effective_schema,
             capture_reasoning=capture_reasoning,
         )
-        if thinking_config is not None:
-            generation_config["thinkingConfig"] = thinking_config
         payload: Dict[str, Any] = {
             "contents": transformed_messages,
             "generationConfig": generation_config,
@@ -233,6 +267,32 @@ class GoogleAdapter(LLMAdapterBase):
         if tool_config is not None:
             payload["toolConfig"] = tool_config
         return payload
+
+    def _build_generation_config(
+        self,
+        *,
+        max_tokens: Optional[int],
+        temperature: float,
+        top_p: float,
+        reasoning_level: Optional[str | int],
+        effective_schema: Optional[dict],
+        capture_reasoning: bool,
+    ) -> Dict[str, Any]:
+        generation_config: Dict[str, Any] = {
+            "maxOutputTokens": max_tokens,
+            "temperature": temperature,
+            "topP": top_p,
+        }
+        if effective_schema is not None:
+            generation_config["responseMimeType"] = "application/json"
+            generation_config["responseSchema"] = self._to_google_schema(effective_schema)
+        thinking_config = self._build_thinking_config(
+            reasoning_level=reasoning_level,
+            capture_reasoning=capture_reasoning,
+        )
+        if thinking_config is not None:
+            generation_config["thinkingConfig"] = thinking_config
+        return generation_config
 
     def _consume_stream(
         self,

--- a/src/llm_api_adapter/adapters/google_adapter.py
+++ b/src/llm_api_adapter/adapters/google_adapter.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import logging
 from typing import Any, Dict, Iterator, List, Mapping, Optional
 import warnings
@@ -25,6 +25,19 @@ from ..models.responses.chat_response import ChatResponse, Usage
 from ..models.tools import ToolSpec
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _GoogleStreamState:
+    chunk_buffer: StreamChunkBuffer
+    usage_tracker: StreamUsageTracker
+    text_parts: List[str] = field(default_factory=list)
+    function_parts: List[Dict[str, Any]] = field(default_factory=list)
+    finish_reason: Optional[str] = None
+    usage_metadata: Dict[str, Any] = field(default_factory=dict)
+    response_metadata: Dict[str, Any] = field(default_factory=dict)
+    reasoning_collector: Optional[StreamReasoningCollector] = None
+    reasoning_response: Optional[ChatResponse] = None
 
 
 @dataclass(repr=False)
@@ -284,103 +297,32 @@ class GoogleAdapter(LLMAdapterBase):
         capture_reasoning: bool,
         on_reasoning: Optional[OnReasoning],
     ) -> Iterator[str]:
-        text_parts: List[str] = []
-        function_parts: List[Dict[str, Any]] = []
-        finish_reason: Optional[str] = None
-        usage_metadata: Dict[str, Any] = {}
-        response_metadata: Dict[str, Any] = {}
-        chunk_buffer = StreamChunkBuffer(buffer_chars)
-        usage_tracker = StreamUsageTracker()
-        reasoning_collector = (
-            StreamReasoningCollector() if capture_reasoning else None
+        state = _GoogleStreamState(
+            chunk_buffer=StreamChunkBuffer(buffer_chars),
+            usage_tracker=StreamUsageTracker(),
+            reasoning_collector=(
+                StreamReasoningCollector() if capture_reasoning else None
+            ),
+            reasoning_response=ChatResponse() if capture_reasoning else None,
         )
-        reasoning_response = ChatResponse() if capture_reasoning else None
 
         for event in self._iter_provider_stream_events(events):
-            chunk = event.data if isinstance(event.data, Mapping) else {}
-            for field in ("modelVersion", "responseId", "promptFeedback"):
-                if field in chunk:
-                    response_metadata[field] = chunk[field]
-            chunk_usage = chunk.get("usageMetadata")
-            if isinstance(chunk_usage, Mapping):
-                usage_metadata.update(chunk_usage)
-                usage_tracker.record(
-                    chunk_buffer,
-                    self._normalize_stream_usage(usage_metadata),
-                )
-            candidates = chunk.get("candidates")
-            if not isinstance(candidates, list) or not candidates:
-                continue
-            candidate = candidates[0]
-            if not isinstance(candidate, Mapping):
-                continue
-            if candidate.get("finishReason") is not None:
-                finish_reason = str(candidate["finishReason"])
-            content = candidate.get("content")
-            parts = content.get("parts") if isinstance(content, Mapping) else []
-            if not isinstance(parts, list):
-                continue
-            for part in parts:
-                if not isinstance(part, Mapping):
-                    continue
-                text = part.get("text")
-                if part.get("thought"):
-                    if (
-                        reasoning_collector is not None
-                        and reasoning_response is not None
-                        and isinstance(text, str)
-                        and text
-                    ):
-                        self._record_reasoning_event(
-                            reasoning_response,
-                            reasoning_collector,
-                            text,
-                            capture_reasoning=True,
-                            kind="summary",
-                            on_reasoning=on_reasoning,
-                        )
-                elif (
-                    isinstance(text, str)
-                    and text
-                ):
-                    text_parts.append(text)
-                    yield from self._emit_stream_chunks(
-                        chunk_buffer.add(text),
-                        on_chunk,
-                        on_delta,
-                    )
-                if isinstance(part.get("functionCall"), Mapping):
-                    function_parts.append(dict(part))
+            yield from self._consume_stream_event(
+                event,
+                state,
+                on_chunk=on_chunk,
+                on_delta=on_delta,
+                on_reasoning=on_reasoning,
+            )
 
-        final_parts: List[Dict[str, Any]] = []
-        if text_parts:
-            final_parts.append({"text": "".join(text_parts)})
-        final_parts.extend(function_parts)
-        final_candidate: Dict[str, Any] = {"content": {"parts": final_parts}}
-        if finish_reason is not None:
-            final_candidate["finishReason"] = finish_reason
-        final_response: Dict[str, Any] = {
-            **response_metadata,
-            "candidates": [final_candidate],
-        }
-        if usage_metadata:
-            final_response["usageMetadata"] = usage_metadata
-        parser_kwargs = {"capture_reasoning": True} if capture_reasoning else {}
-        chat_response = ChatResponse.from_google_response(
-            final_response,
-            **parser_kwargs,
-        )
-        if reasoning_collector is not None:
-            streamed_reasoning_events = reasoning_collector.snapshot()
-            if streamed_reasoning_events:
-                chat_response.reasoning_events = streamed_reasoning_events
-        self._prepare_stream_response(
-            chat_response,
-            effective_schema,
-            response_model,
+        chat_response = self._finalize_stream_response(
+            state,
+            capture_reasoning=capture_reasoning,
+            effective_schema=effective_schema,
+            response_model=response_model,
         )
         yield from self._emit_stream_chunks(
-            chunk_buffer.flush(),
+            state.chunk_buffer.flush(),
             on_chunk,
             on_delta,
         )
@@ -389,6 +331,134 @@ class GoogleAdapter(LLMAdapterBase):
             on_tool_call,
             on_done,
         )
+
+    def _consume_stream_event(
+        self,
+        event: Any,
+        state: _GoogleStreamState,
+        *,
+        on_chunk: Optional[OnChunk],
+        on_delta: Optional[OnDelta],
+        on_reasoning: Optional[OnReasoning],
+    ) -> Iterator[str]:
+        chunk = event.data if isinstance(event.data, Mapping) else {}
+        self._update_stream_state_from_chunk(chunk, state)
+
+        candidates = chunk.get("candidates")
+        if not isinstance(candidates, list) or not candidates:
+            return
+        candidate = candidates[0]
+        if not isinstance(candidate, Mapping):
+            return
+        if candidate.get("finishReason") is not None:
+            state.finish_reason = str(candidate["finishReason"])
+        content = candidate.get("content")
+        parts = content.get("parts") if isinstance(content, Mapping) else []
+        if not isinstance(parts, list):
+            return
+        for part in parts:
+            yield from self._consume_stream_part(
+                part,
+                state,
+                on_chunk=on_chunk,
+                on_delta=on_delta,
+                on_reasoning=on_reasoning,
+            )
+
+    def _update_stream_state_from_chunk(
+        self,
+        chunk: Mapping[str, Any],
+        state: _GoogleStreamState,
+    ) -> None:
+        for field in ("modelVersion", "responseId", "promptFeedback"):
+            if field in chunk:
+                state.response_metadata[field] = chunk[field]
+        chunk_usage = chunk.get("usageMetadata")
+        if isinstance(chunk_usage, Mapping):
+            state.usage_metadata.update(chunk_usage)
+            state.usage_tracker.record(
+                state.chunk_buffer,
+                self._normalize_stream_usage(state.usage_metadata),
+            )
+
+    def _consume_stream_part(
+        self,
+        part: Any,
+        state: _GoogleStreamState,
+        *,
+        on_chunk: Optional[OnChunk],
+        on_delta: Optional[OnDelta],
+        on_reasoning: Optional[OnReasoning],
+    ) -> Iterator[str]:
+        if not isinstance(part, Mapping):
+            return
+        text = part.get("text")
+        if part.get("thought"):
+            if (
+                state.reasoning_collector is not None
+                and state.reasoning_response is not None
+                and isinstance(text, str)
+                and text
+            ):
+                self._record_reasoning_event(
+                    state.reasoning_response,
+                    state.reasoning_collector,
+                    text,
+                    capture_reasoning=True,
+                    kind="summary",
+                    on_reasoning=on_reasoning,
+                )
+        elif isinstance(text, str) and text:
+            state.text_parts.append(text)
+            yield from self._emit_stream_chunks(
+                state.chunk_buffer.add(text),
+                on_chunk,
+                on_delta,
+            )
+        if isinstance(part.get("functionCall"), Mapping):
+            state.function_parts.append(dict(part))
+
+    def _finalize_stream_response(
+        self,
+        state: _GoogleStreamState,
+        *,
+        capture_reasoning: bool,
+        effective_schema: Optional[dict],
+        response_model: Optional[Any],
+    ) -> ChatResponse:
+        final_response = self._build_stream_response(state)
+        parser_kwargs = {"capture_reasoning": True} if capture_reasoning else {}
+        chat_response = ChatResponse.from_google_response(
+            final_response,
+            **parser_kwargs,
+        )
+        if state.reasoning_collector is not None:
+            streamed_reasoning_events = state.reasoning_collector.snapshot()
+            if streamed_reasoning_events:
+                chat_response.reasoning_events = streamed_reasoning_events
+        self._prepare_stream_response(
+            chat_response,
+            effective_schema,
+            response_model,
+        )
+        return chat_response
+
+    @staticmethod
+    def _build_stream_response(state: _GoogleStreamState) -> Dict[str, Any]:
+        final_parts: List[Dict[str, Any]] = []
+        if state.text_parts:
+            final_parts.append({"text": "".join(state.text_parts)})
+        final_parts.extend(state.function_parts)
+        final_candidate: Dict[str, Any] = {"content": {"parts": final_parts}}
+        if state.finish_reason is not None:
+            final_candidate["finishReason"] = state.finish_reason
+        final_response: Dict[str, Any] = {
+            **state.response_metadata,
+            "candidates": [final_candidate],
+        }
+        if state.usage_metadata:
+            final_response["usageMetadata"] = state.usage_metadata
+        return final_response
 
     def _build_thinking_config(
         self,

--- a/src/llm_api_adapter/adapters/google_adapter.py
+++ b/src/llm_api_adapter/adapters/google_adapter.py
@@ -149,29 +149,6 @@ class GoogleAdapter(LLMAdapterBase):
         parser_kwargs = {"capture_reasoning": True} if capture_reasoning else {}
         return ChatResponse.from_google_response(response, **parser_kwargs)
 
-    def _finalize_chat_response(
-        self,
-        chat_response: ChatResponse,
-        *,
-        effective_schema: Optional[dict],
-        response_model: Optional[Any],
-    ) -> ChatResponse:
-        chat_response.parsed_json = self._parse_json_response(
-            chat_response.content,
-            effective_schema,
-        )
-        chat_response.parsed_model = self._parse_response_model(
-            chat_response.parsed_json,
-            response_model,
-        )
-        if self.pricing:
-            chat_response.apply_pricing(
-                price_input_per_token=self.pricing.in_per_token,
-                price_output_per_token=self.pricing.out_per_token,
-                currency=self.pricing.currency,
-            )
-        return chat_response
-
     def stream_chat(
         self,
         messages: List[Message] | Messages,

--- a/src/llm_api_adapter/adapters/openai_adapter.py
+++ b/src/llm_api_adapter/adapters/openai_adapter.py
@@ -13,6 +13,7 @@ from ..adapters.base_adapter import (
     OnDone,
     OnReasoning,
     OnToolCall,
+    _StreamState,
 )
 from ..errors.llm_api_error import LLMAPIError
 from ..llms.streaming import (
@@ -29,15 +30,11 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass
-class _ResponsesStreamState:
-    chunk_buffer: StreamChunkBuffer
-    usage_tracker: StreamUsageTracker
+class _ResponsesStreamState(_StreamState):
     final_response: Optional[dict] = None
     response_metadata: Dict[str, Any] = field(default_factory=dict)
     text_parts: List[str] = field(default_factory=list)
     function_calls: Dict[str, Dict[str, Any]] = field(default_factory=dict)
-    reasoning_collector: Optional[StreamReasoningCollector] = None
-    reasoning_response: Optional[ChatResponse] = None
 
 
 @dataclass(repr=False)
@@ -416,13 +413,11 @@ class OpenAIAdapter(LLMAdapterBase):
             effective_schema=effective_schema,
             response_model=response_model,
         )
-        yield from self._emit_stream_chunks(
-            state.chunk_buffer.flush(),
+        yield from self._complete_stream(
+            chat_response,
+            state.chunk_buffer,
             on_chunk,
             on_delta,
-        )
-        self._invoke_stream_completion_callbacks(
-            chat_response,
             on_tool_call,
             on_done,
         )
@@ -565,16 +560,12 @@ class OpenAIAdapter(LLMAdapterBase):
             final_response,
             **parser_kwargs,
         )
-        if state.reasoning_collector is not None:
-            streamed_reasoning_events = state.reasoning_collector.snapshot()
-            if streamed_reasoning_events:
-                chat_response.reasoning_events = streamed_reasoning_events
-        self._prepare_stream_response(
+        return super()._finalize_stream_response(
             chat_response,
-            effective_schema,
-            response_model,
+            reasoning_collector=state.reasoning_collector,
+            effective_schema=effective_schema,
+            response_model=response_model,
         )
-        return chat_response
 
     def _build_responses_stream_response(
         self,
@@ -649,18 +640,16 @@ class OpenAIAdapter(LLMAdapterBase):
             tool_calls,
             finish_reason,
         )
-        self._prepare_stream_response(
+        chat_response = super()._finalize_stream_response(
             chat_response,
-            effective_schema,
-            response_model,
+            effective_schema=effective_schema,
+            response_model=response_model,
         )
-        yield from self._emit_stream_chunks(
-            chunk_buffer.flush(),
+        yield from self._complete_stream(
+            chat_response,
+            chunk_buffer,
             on_chunk,
             on_delta,
-        )
-        self._invoke_stream_completion_callbacks(
-            chat_response,
             on_tool_call,
             on_done,
         )

--- a/src/llm_api_adapter/adapters/openai_adapter.py
+++ b/src/llm_api_adapter/adapters/openai_adapter.py
@@ -61,25 +61,23 @@ class OpenAIAdapter(LLMAdapterBase):
         *,
         capture_reasoning: bool = False,
     ) -> ChatResponse:
-        temperature = self._validate_parameter(
-            name="temperature",
-            value=temperature,
-            min_value=0,
-            max_value=2,
+        temperature, top_p = self._validate_sampling_parameters(
+            temperature,
+            top_p,
         )
-        top_p = self._validate_parameter(
-            name="top_p",
-            value=top_p,
-            min_value=0,
-            max_value=1,
+        request_context = self._prepare_chat_request(
+            messages,
+            tools,
+            tool_choice,
+            json_schema,
+            response_model,
         )
-        self._validate_tools(tools)
-        effective_schema = self._resolve_json_schema(json_schema, response_model, tools)
-        normalized_tool_choice = self._normalize_tool_choice(tool_choice, tools)
+        effective_schema = request_context.effective_schema
+        normalized_tool_choice = request_context.normalized_tool_choice
 
         try:
             client = OpenAISyncClient(api_key=self.api_key)
-            normalized_messages = self._normalize_messages(messages)
+            normalized_messages = request_context.normalized_messages
             use_responses_api = client._should_use_responses_api(self.model)
             params = self._build_chat_params(
                 normalized_messages=normalized_messages,
@@ -263,13 +261,21 @@ class OpenAIAdapter(LLMAdapterBase):
         capture_reasoning: bool = False,
         on_reasoning: Optional[OnReasoning] = None,
     ) -> Iterator[str]:
-        temperature = self._validate_parameter("temperature", temperature, 0, 2)
-        top_p = self._validate_parameter("top_p", top_p, 0, 1)
-        self._validate_tools(tools)
-        effective_schema = self._resolve_json_schema(json_schema, response_model, tools)
-        normalized_tool_choice = self._normalize_tool_choice(tool_choice, tools)
+        temperature, top_p = self._validate_sampling_parameters(
+            temperature,
+            top_p,
+        )
+        request_context = self._prepare_chat_request(
+            messages,
+            tools,
+            tool_choice,
+            json_schema,
+            response_model,
+        )
+        effective_schema = request_context.effective_schema
+        normalized_tool_choice = request_context.normalized_tool_choice
         client = OpenAISyncClient(api_key=self.api_key)
-        normalized_messages = self._normalize_messages(messages)
+        normalized_messages = request_context.normalized_messages
         use_responses_api = client._should_use_responses_api(self.model)
         params = self._build_stream_params(
             normalized_messages=normalized_messages,

--- a/src/llm_api_adapter/adapters/openai_adapter.py
+++ b/src/llm_api_adapter/adapters/openai_adapter.py
@@ -6,7 +6,14 @@ import logging
 from typing import Any, Dict, Iterator, List, Mapping, Optional
 import warnings
 
-from ..adapters.base_adapter import LLMAdapterBase, OnChunk, OnDelta, OnDone, OnToolCall
+from ..adapters.base_adapter import (
+    LLMAdapterBase,
+    OnChunk,
+    OnDelta,
+    OnDone,
+    OnReasoning,
+    OnToolCall,
+)
 from ..errors.llm_api_error import LLMAPIError
 from ..llms.streaming import StreamChunkBuffer, StreamUsageTracker
 from ..llms.openai.sync_client import OpenAISyncClient
@@ -35,6 +42,8 @@ class OpenAIAdapter(LLMAdapterBase):
         previous_response: Optional[ChatResponse] = None,
         json_schema: Optional[dict] = None,
         response_model: Optional[Any] = None,
+        *,
+        capture_reasoning: bool = False,
     ) -> ChatResponse:
         temperature = self._validate_parameter(
             name="temperature",
@@ -162,6 +171,9 @@ class OpenAIAdapter(LLMAdapterBase):
         on_done: Optional[OnDone] = None,
         buffer_chars: Optional[int] = None,
         on_chunk: Optional[OnChunk] = None,
+        *,
+        capture_reasoning: bool = False,
+        on_reasoning: Optional[OnReasoning] = None,
     ) -> Iterator[str]:
         temperature = self._validate_parameter("temperature", temperature, 0, 2)
         top_p = self._validate_parameter("top_p", top_p, 0, 1)

--- a/src/llm_api_adapter/adapters/openai_adapter.py
+++ b/src/llm_api_adapter/adapters/openai_adapter.py
@@ -240,30 +240,6 @@ class OpenAIAdapter(LLMAdapterBase):
             )
         return ChatResponse.from_openai_response(response)
 
-    def _finalize_chat_response(
-        self,
-        chat_response: ChatResponse,
-        *,
-        effective_schema: Optional[dict],
-        response_model: Optional[Any],
-    ) -> ChatResponse:
-        chat_response.parsed_json = self._parse_json_response(
-            chat_response.content,
-            effective_schema,
-        )
-        chat_response.parsed_model = self._parse_response_model(
-            chat_response.parsed_json,
-            response_model,
-        )
-
-        if self.pricing:
-            chat_response.apply_pricing(
-                price_input_per_token=self.pricing.in_per_token,
-                price_output_per_token=self.pricing.out_per_token,
-                currency=self.pricing.currency,
-            )
-        return chat_response
-
     def stream_chat(
         self,
         messages: List[Message] | Messages,

--- a/src/llm_api_adapter/adapters/openai_adapter.py
+++ b/src/llm_api_adapter/adapters/openai_adapter.py
@@ -69,100 +69,188 @@ class OpenAIAdapter(LLMAdapterBase):
             client = OpenAISyncClient(api_key=self.api_key)
             normalized_messages = self._normalize_messages(messages)
             use_responses_api = client._should_use_responses_api(self.model)
-            normalized_reasoning_level = self._normalize_reasoning_level(
-                reasoning_level
+            params = self._build_chat_params(
+                normalized_messages=normalized_messages,
+                use_responses_api=use_responses_api,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                top_p=top_p,
+                reasoning_level=reasoning_level,
+                tools=tools,
+                normalized_tool_choice=normalized_tool_choice,
+                parallel_tool_calls=parallel_tool_calls,
+                previous_response=previous_response,
+                effective_schema=effective_schema,
+                capture_reasoning=capture_reasoning,
             )
-
-            previous_response_id: Optional[str] = None
-            if previous_response is not None:
-                previous_response_id = previous_response.response_id
-
-            if use_responses_api:
-                transformed_messages = normalized_messages.to_openai_responses_input()
-                instructions = normalized_messages.to_openai_responses_instructions()
-                openai_tools = self._map_tools_to_openai_responses(tools)
-                openai_tool_choice = self._map_tool_choice_to_openai_responses(
-                    normalized_tool_choice
-                )
-            else:
-                transformed_messages = normalized_messages.to_openai()
-                instructions = None
-                openai_tools = self._map_tools_to_openai(tools)
-                openai_tool_choice = self._map_tool_choice_to_openai(
-                    normalized_tool_choice
-                )
-
-            params: Dict[str, Any] = {
-                "model": self.model,
-                "max_tokens": max_tokens,
-                "temperature": temperature,
-                "top_p": top_p,
-                "reasoning_effort": normalized_reasoning_level,
-                "tools": openai_tools,
-                "tool_choice": openai_tool_choice,
-            }
-
-            if use_responses_api:
-                params["input"] = transformed_messages
-                if capture_reasoning:
-                    params["capture_reasoning"] = True
-                if instructions is not None:
-                    params["instructions"] = instructions
-                if previous_response_id is not None:
-                    params["previous_response_id"] = previous_response_id
-                if effective_schema is not None:
-                    params["text"] = {
-                        "format": {
-                            "type": "json_schema",
-                            "name": "response",
-                            "strict": True,
-                            "schema": self._enforce_strict_schema(effective_schema),
-                        }
-                    }
-            else:
-                params["messages"] = transformed_messages
-                params["parallel_tool_calls"] = parallel_tool_calls
-                if effective_schema is not None:
-                    params["response_format"] = {
-                        "type": "json_schema",
-                        "json_schema": {
-                            "name": "response",
-                            "strict": True,
-                            "schema": self._enforce_strict_schema(effective_schema),
-                        },
-                    }
-
-            params = {k: v for k, v in params.items() if v is not None}
             response = client.complete(timeout=timeout_s, **params)
-
-            if use_responses_api:
-                parser_kwargs = (
-                    {"capture_reasoning": True} if capture_reasoning else {}
-                )
-                chat_response = ChatResponse.from_openai_responses_response(
-                    response,
-                    **parser_kwargs,
-                )
-            else:
-                chat_response = ChatResponse.from_openai_response(response)
-
-            chat_response.parsed_json = self._parse_json_response(chat_response.content, effective_schema)
-            chat_response.parsed_model = self._parse_response_model(chat_response.parsed_json, response_model)
-
-            if self.pricing:
-                chat_response.apply_pricing(
-                    price_input_per_token=self.pricing.in_per_token,
-                    price_output_per_token=self.pricing.out_per_token,
-                    currency=self.pricing.currency,
-                )
-
-            return chat_response
+            chat_response = self._parse_chat_response(
+                response,
+                use_responses_api=use_responses_api,
+                capture_reasoning=capture_reasoning,
+            )
+            return self._finalize_chat_response(
+                chat_response,
+                effective_schema=effective_schema,
+                response_model=response_model,
+            )
 
         except LLMAPIError as e:
             self.handle_error(e)
         except Exception as e:
             error_message = getattr(e, "text", None) or str(e)
             self.handle_error(error=e, error_message=error_message)
+
+    def _build_chat_params(
+        self,
+        *,
+        normalized_messages: Messages,
+        use_responses_api: bool,
+        max_tokens: Optional[int],
+        temperature: float,
+        top_p: float,
+        reasoning_level: Optional[str | int],
+        tools: Optional[List[ToolSpec]],
+        normalized_tool_choice: Optional[str],
+        parallel_tool_calls: Optional[bool],
+        previous_response: Optional[ChatResponse],
+        effective_schema: Optional[dict],
+        capture_reasoning: bool,
+    ) -> Dict[str, Any]:
+        normalized_reasoning_level = self._normalize_reasoning_level(reasoning_level)
+        params: Dict[str, Any] = {
+            "model": self.model,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "top_p": top_p,
+            "reasoning_effort": normalized_reasoning_level,
+        }
+
+        if use_responses_api:
+            params.update(
+                self._build_responses_chat_params(
+                    normalized_messages=normalized_messages,
+                    tools=tools,
+                    normalized_tool_choice=normalized_tool_choice,
+                    previous_response=previous_response,
+                    effective_schema=effective_schema,
+                    capture_reasoning=capture_reasoning,
+                )
+            )
+        else:
+            params.update(
+                self._build_chat_completions_params(
+                    normalized_messages=normalized_messages,
+                    tools=tools,
+                    normalized_tool_choice=normalized_tool_choice,
+                    parallel_tool_calls=parallel_tool_calls,
+                    effective_schema=effective_schema,
+                )
+            )
+
+        return {key: value for key, value in params.items() if value is not None}
+
+    def _build_responses_chat_params(
+        self,
+        *,
+        normalized_messages: Messages,
+        tools: Optional[List[ToolSpec]],
+        normalized_tool_choice: Optional[str],
+        previous_response: Optional[ChatResponse],
+        effective_schema: Optional[dict],
+        capture_reasoning: bool,
+    ) -> Dict[str, Any]:
+        params: Dict[str, Any] = {
+            "input": normalized_messages.to_openai_responses_input(),
+            "tools": self._map_tools_to_openai_responses(tools),
+            "tool_choice": self._map_tool_choice_to_openai_responses(
+                normalized_tool_choice
+            ),
+        }
+        if capture_reasoning:
+            params["capture_reasoning"] = True
+        instructions = normalized_messages.to_openai_responses_instructions()
+        if instructions is not None:
+            params["instructions"] = instructions
+        if previous_response is not None and previous_response.response_id is not None:
+            params["previous_response_id"] = previous_response.response_id
+        if effective_schema is not None:
+            params["text"] = {
+                "format": {
+                    "type": "json_schema",
+                    "name": "response",
+                    "strict": True,
+                    "schema": self._enforce_strict_schema(effective_schema),
+                }
+            }
+        return params
+
+    def _build_chat_completions_params(
+        self,
+        *,
+        normalized_messages: Messages,
+        tools: Optional[List[ToolSpec]],
+        normalized_tool_choice: Optional[str],
+        parallel_tool_calls: Optional[bool],
+        effective_schema: Optional[dict],
+    ) -> Dict[str, Any]:
+        params: Dict[str, Any] = {
+            "messages": normalized_messages.to_openai(),
+            "tools": self._map_tools_to_openai(tools),
+            "tool_choice": self._map_tool_choice_to_openai(
+                normalized_tool_choice
+            ),
+            "parallel_tool_calls": parallel_tool_calls,
+        }
+        if effective_schema is not None:
+            params["response_format"] = {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "response",
+                    "strict": True,
+                    "schema": self._enforce_strict_schema(effective_schema),
+                },
+            }
+        return params
+
+    @staticmethod
+    def _parse_chat_response(
+        response: dict,
+        *,
+        use_responses_api: bool,
+        capture_reasoning: bool,
+    ) -> ChatResponse:
+        if use_responses_api:
+            parser_kwargs = {"capture_reasoning": True} if capture_reasoning else {}
+            return ChatResponse.from_openai_responses_response(
+                response,
+                **parser_kwargs,
+            )
+        return ChatResponse.from_openai_response(response)
+
+    def _finalize_chat_response(
+        self,
+        chat_response: ChatResponse,
+        *,
+        effective_schema: Optional[dict],
+        response_model: Optional[Any],
+    ) -> ChatResponse:
+        chat_response.parsed_json = self._parse_json_response(
+            chat_response.content,
+            effective_schema,
+        )
+        chat_response.parsed_model = self._parse_response_model(
+            chat_response.parsed_json,
+            response_model,
+        )
+
+        if self.pricing:
+            chat_response.apply_pricing(
+                price_input_per_token=self.pricing.in_per_token,
+                price_output_per_token=self.pricing.out_per_token,
+                currency=self.pricing.currency,
+            )
+        return chat_response
 
     def stream_chat(
         self,

--- a/src/llm_api_adapter/adapters/openai_adapter.py
+++ b/src/llm_api_adapter/adapters/openai_adapter.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import json
 import logging
 from typing import Any, Dict, Iterator, List, Mapping, Optional
@@ -26,6 +26,18 @@ from ..models.responses.chat_response import ChatResponse, Usage
 from ..models.tools import ToolSpec
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _ResponsesStreamState:
+    chunk_buffer: StreamChunkBuffer
+    usage_tracker: StreamUsageTracker
+    final_response: Optional[dict] = None
+    response_metadata: Dict[str, Any] = field(default_factory=dict)
+    text_parts: List[str] = field(default_factory=list)
+    function_calls: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    reasoning_collector: Optional[StreamReasoningCollector] = None
+    reasoning_response: Optional[ChatResponse] = None
 
 
 @dataclass(repr=False)
@@ -399,115 +411,31 @@ class OpenAIAdapter(LLMAdapterBase):
         capture_reasoning: bool,
         on_reasoning: Optional[OnReasoning],
     ) -> Iterator[str]:
-        final_response: Optional[dict] = None
-        response_metadata: Dict[str, Any] = {}
-        text_parts: List[str] = []
-        function_calls: Dict[str, Dict[str, Any]] = {}
-        chunk_buffer = StreamChunkBuffer(buffer_chars)
-        usage_tracker = StreamUsageTracker()
-        reasoning_collector = (
-            StreamReasoningCollector() if capture_reasoning else None
+        state = _ResponsesStreamState(
+            chunk_buffer=StreamChunkBuffer(buffer_chars),
+            usage_tracker=StreamUsageTracker(),
+            reasoning_collector=(
+                StreamReasoningCollector() if capture_reasoning else None
+            ),
+            reasoning_response=ChatResponse() if capture_reasoning else None,
         )
-        reasoning_response = ChatResponse() if capture_reasoning else None
         for event in self._iter_provider_stream_events(events):
-            payload = event.data if isinstance(event.data, Mapping) else {}
-            event_type = event.event or payload.get("type")
-            response_data = payload.get("response")
-            if isinstance(response_data, Mapping):
-                response_metadata.update(response_data)
-            usage_tracker.record(
-                chunk_buffer,
-                self._normalize_stream_usage(
-                    self._response_event_usage(payload, response_data),
-                    input_field="input_tokens",
-                    output_field="output_tokens",
-                ),
+            yield from self._consume_responses_stream_event(
+                event,
+                state,
+                on_chunk=on_chunk,
+                on_delta=on_delta,
+                on_reasoning=on_reasoning,
             )
-            if event_type in (
-                "response.reasoning_summary_text.delta",
-                "response.reasoning_text.delta",
-            ):
-                delta = payload.get("delta")
-                if (
-                    reasoning_collector is not None
-                    and reasoning_response is not None
-                    and isinstance(delta, str)
-                    and delta
-                ):
-                    self._record_reasoning_event(
-                        reasoning_response,
-                        reasoning_collector,
-                        delta,
-                        capture_reasoning=True,
-                        kind=(
-                            "summary"
-                            if event_type == "response.reasoning_summary_text.delta"
-                            else "content"
-                        ),
-                        on_reasoning=on_reasoning,
-                    )
-            elif event_type == "response.output_text.delta":
-                delta = payload.get("delta")
-                if isinstance(delta, str) and delta:
-                    text_parts.append(delta)
-                    yield from self._emit_stream_chunks(
-                        chunk_buffer.add(delta),
-                        on_chunk,
-                        on_delta,
-                    )
-            elif event_type in (
-                "response.function_call_arguments.delta",
-                "response.function_call_arguments.done",
-            ):
-                call_key = str(
-                    payload.get("call_id")
-                    or payload.get("item_id")
-                    or payload.get("output_index")
-                    or len(function_calls)
-                )
-                call = function_calls.setdefault(
-                    call_key,
-                    {"type": "function_call", "arguments": ""},
-                )
-                call["call_id"] = payload.get("call_id") or call.get("call_id")
-                call["id"] = payload.get("item_id") or call.get("id")
-                call["name"] = payload.get("name") or call.get("name")
-                if event_type.endswith(".delta") and isinstance(payload.get("delta"), str):
-                    call["arguments"] = f"{call.get('arguments', '')}{payload['delta']}"
-                elif "arguments" in payload:
-                    call["arguments"] = payload["arguments"]
-            elif event_type == "response.completed" and isinstance(response_data, Mapping):
-                final_response = dict(response_data)
-        if final_response is None:
-            output: List[Dict[str, Any]] = []
-            if text_parts:
-                output.append({
-                    "type": "message",
-                    "content": [{"type": "output_text", "text": "".join(text_parts)}],
-                })
-            output.extend(function_calls.values())
-            final_response = {
-                **response_metadata,
-                "model": response_metadata.get("model", self.model),
-                "output": output,
-                "status": response_metadata.get("status", "completed"),
-            }
-        parser_kwargs = {"capture_reasoning": True} if capture_reasoning else {}
-        chat_response = ChatResponse.from_openai_responses_response(
-            final_response,
-            **parser_kwargs,
-        )
-        if reasoning_collector is not None:
-            streamed_reasoning_events = reasoning_collector.snapshot()
-            if streamed_reasoning_events:
-                chat_response.reasoning_events = streamed_reasoning_events
-        self._prepare_stream_response(
-            chat_response,
-            effective_schema,
-            response_model,
+
+        chat_response = self._finalize_responses_stream(
+            state,
+            capture_reasoning=capture_reasoning,
+            effective_schema=effective_schema,
+            response_model=response_model,
         )
         yield from self._emit_stream_chunks(
-            chunk_buffer.flush(),
+            state.chunk_buffer.flush(),
             on_chunk,
             on_delta,
         )
@@ -516,6 +444,177 @@ class OpenAIAdapter(LLMAdapterBase):
             on_tool_call,
             on_done,
         )
+
+    def _consume_responses_stream_event(
+        self,
+        event: Any,
+        state: _ResponsesStreamState,
+        *,
+        on_chunk: Optional[OnChunk],
+        on_delta: Optional[OnDelta],
+        on_reasoning: Optional[OnReasoning],
+    ) -> Iterator[str]:
+        payload = event.data if isinstance(event.data, Mapping) else {}
+        event_type = event.event or payload.get("type")
+        response_data = payload.get("response")
+        if isinstance(response_data, Mapping):
+            state.response_metadata.update(response_data)
+        state.usage_tracker.record(
+            state.chunk_buffer,
+            self._normalize_stream_usage(
+                self._response_event_usage(payload, response_data),
+                input_field="input_tokens",
+                output_field="output_tokens",
+            ),
+        )
+
+        if event_type in (
+            "response.reasoning_summary_text.delta",
+            "response.reasoning_text.delta",
+        ):
+            self._handle_responses_reasoning_delta(
+                payload,
+                event_type,
+                state,
+                on_reasoning,
+            )
+        elif event_type == "response.output_text.delta":
+            yield from self._handle_responses_output_text_delta(
+                payload,
+                state,
+                on_chunk,
+                on_delta,
+            )
+        elif event_type in (
+            "response.function_call_arguments.delta",
+            "response.function_call_arguments.done",
+        ):
+            self._handle_responses_function_call_event(
+                payload,
+                event_type,
+                state,
+            )
+        elif event_type == "response.completed" and isinstance(response_data, Mapping):
+            state.final_response = dict(response_data)
+
+    def _handle_responses_reasoning_delta(
+        self,
+        payload: Mapping[str, Any],
+        event_type: str,
+        state: _ResponsesStreamState,
+        on_reasoning: Optional[OnReasoning],
+    ) -> None:
+        delta = payload.get("delta")
+        if (
+            state.reasoning_collector is None
+            or state.reasoning_response is None
+            or not isinstance(delta, str)
+            or not delta
+        ):
+            return
+        self._record_reasoning_event(
+            state.reasoning_response,
+            state.reasoning_collector,
+            delta,
+            capture_reasoning=True,
+            kind=(
+                "summary"
+                if event_type == "response.reasoning_summary_text.delta"
+                else "content"
+            ),
+            on_reasoning=on_reasoning,
+        )
+
+    def _handle_responses_output_text_delta(
+        self,
+        payload: Mapping[str, Any],
+        state: _ResponsesStreamState,
+        on_chunk: Optional[OnChunk],
+        on_delta: Optional[OnDelta],
+    ) -> Iterator[str]:
+        delta = payload.get("delta")
+        if not isinstance(delta, str) or not delta:
+            return
+        state.text_parts.append(delta)
+        yield from self._emit_stream_chunks(
+            state.chunk_buffer.add(delta),
+            on_chunk,
+            on_delta,
+        )
+
+    @staticmethod
+    def _handle_responses_function_call_event(
+        payload: Mapping[str, Any],
+        event_type: str,
+        state: _ResponsesStreamState,
+    ) -> None:
+        call_key = str(
+            payload.get("call_id")
+            or payload.get("item_id")
+            or payload.get("output_index")
+            or len(state.function_calls)
+        )
+        call = state.function_calls.setdefault(
+            call_key,
+            {"type": "function_call", "arguments": ""},
+        )
+        call["call_id"] = payload.get("call_id") or call.get("call_id")
+        call["id"] = payload.get("item_id") or call.get("id")
+        call["name"] = payload.get("name") or call.get("name")
+        if event_type.endswith(".delta") and isinstance(payload.get("delta"), str):
+            call["arguments"] = f"{call.get('arguments', '')}{payload['delta']}"
+        elif "arguments" in payload:
+            call["arguments"] = payload["arguments"]
+
+    def _finalize_responses_stream(
+        self,
+        state: _ResponsesStreamState,
+        *,
+        capture_reasoning: bool,
+        effective_schema: Optional[dict],
+        response_model: Optional[Any],
+    ) -> ChatResponse:
+        if state.final_response is None:
+            final_response = self._build_responses_stream_response(state)
+        else:
+            final_response = state.final_response
+        parser_kwargs = {"capture_reasoning": True} if capture_reasoning else {}
+        chat_response = ChatResponse.from_openai_responses_response(
+            final_response,
+            **parser_kwargs,
+        )
+        if state.reasoning_collector is not None:
+            streamed_reasoning_events = state.reasoning_collector.snapshot()
+            if streamed_reasoning_events:
+                chat_response.reasoning_events = streamed_reasoning_events
+        self._prepare_stream_response(
+            chat_response,
+            effective_schema,
+            response_model,
+        )
+        return chat_response
+
+    def _build_responses_stream_response(
+        self,
+        state: _ResponsesStreamState,
+    ) -> Dict[str, Any]:
+        output: List[Dict[str, Any]] = []
+        if state.text_parts:
+            output.append(
+                {
+                    "type": "message",
+                    "content": [
+                        {"type": "output_text", "text": "".join(state.text_parts)}
+                    ],
+                }
+            )
+        output.extend(state.function_calls.values())
+        return {
+            **state.response_metadata,
+            "model": state.response_metadata.get("model", self.model),
+            "output": output,
+            "status": state.response_metadata.get("status", "completed"),
+        }
 
     def _consume_chat_completions_stream(
         self,

--- a/src/llm_api_adapter/adapters/openai_adapter.py
+++ b/src/llm_api_adapter/adapters/openai_adapter.py
@@ -15,7 +15,11 @@ from ..adapters.base_adapter import (
     OnToolCall,
 )
 from ..errors.llm_api_error import LLMAPIError
-from ..llms.streaming import StreamChunkBuffer, StreamUsageTracker
+from ..llms.streaming import (
+    StreamChunkBuffer,
+    StreamReasoningCollector,
+    StreamUsageTracker,
+)
 from ..llms.openai.sync_client import OpenAISyncClient
 from ..models.messages.chat_message import Message, Messages
 from ..models.responses.chat_response import ChatResponse, Usage
@@ -100,6 +104,8 @@ class OpenAIAdapter(LLMAdapterBase):
 
             if use_responses_api:
                 params["input"] = transformed_messages
+                if capture_reasoning:
+                    params["capture_reasoning"] = True
                 if instructions is not None:
                     params["instructions"] = instructions
                 if previous_response_id is not None:
@@ -130,7 +136,13 @@ class OpenAIAdapter(LLMAdapterBase):
             response = client.complete(timeout=timeout_s, **params)
 
             if use_responses_api:
-                chat_response = ChatResponse.from_openai_responses_response(response)
+                parser_kwargs = (
+                    {"capture_reasoning": True} if capture_reasoning else {}
+                )
+                chat_response = ChatResponse.from_openai_responses_response(
+                    response,
+                    **parser_kwargs,
+                )
             else:
                 chat_response = ChatResponse.from_openai_response(response)
 
@@ -195,6 +207,7 @@ class OpenAIAdapter(LLMAdapterBase):
             parallel_tool_calls=parallel_tool_calls,
             previous_response=previous_response,
             effective_schema=effective_schema,
+            capture_reasoning=capture_reasoning,
         )
         events = client.stream(timeout=timeout_s, **params)
         if use_responses_api:
@@ -207,6 +220,8 @@ class OpenAIAdapter(LLMAdapterBase):
                 on_done,
                 buffer_chars,
                 on_chunk,
+                capture_reasoning,
+                on_reasoning,
             )
             return
         yield from self._consume_chat_completions_stream(
@@ -234,6 +249,7 @@ class OpenAIAdapter(LLMAdapterBase):
         parallel_tool_calls: Optional[bool],
         previous_response: Optional[ChatResponse],
         effective_schema: Optional[dict],
+        capture_reasoning: bool,
     ) -> Dict[str, Any]:
         params: Dict[str, Any] = {
             "model": self.model,
@@ -262,6 +278,8 @@ class OpenAIAdapter(LLMAdapterBase):
                         "schema": self._enforce_strict_schema(effective_schema),
                     }
                 }
+            if capture_reasoning:
+                params["capture_reasoning"] = True
         else:
             params["messages"] = normalized_messages.to_openai()
             params["tools"] = self._map_tools_to_openai(tools)
@@ -290,6 +308,8 @@ class OpenAIAdapter(LLMAdapterBase):
         on_done: Optional[OnDone],
         buffer_chars: Optional[int],
         on_chunk: Optional[OnChunk],
+        capture_reasoning: bool,
+        on_reasoning: Optional[OnReasoning],
     ) -> Iterator[str]:
         final_response: Optional[dict] = None
         response_metadata: Dict[str, Any] = {}
@@ -297,6 +317,10 @@ class OpenAIAdapter(LLMAdapterBase):
         function_calls: Dict[str, Dict[str, Any]] = {}
         chunk_buffer = StreamChunkBuffer(buffer_chars)
         usage_tracker = StreamUsageTracker()
+        reasoning_collector = (
+            StreamReasoningCollector() if capture_reasoning else None
+        )
+        reasoning_response = ChatResponse() if capture_reasoning else None
         for event in self._iter_provider_stream_events(events):
             payload = event.data if isinstance(event.data, Mapping) else {}
             event_type = event.event or payload.get("type")
@@ -311,7 +335,30 @@ class OpenAIAdapter(LLMAdapterBase):
                     output_field="output_tokens",
                 ),
             )
-            if event_type == "response.output_text.delta":
+            if event_type in (
+                "response.reasoning_summary_text.delta",
+                "response.reasoning_text.delta",
+            ):
+                delta = payload.get("delta")
+                if (
+                    reasoning_collector is not None
+                    and reasoning_response is not None
+                    and isinstance(delta, str)
+                    and delta
+                ):
+                    self._record_reasoning_event(
+                        reasoning_response,
+                        reasoning_collector,
+                        delta,
+                        capture_reasoning=True,
+                        kind=(
+                            "summary"
+                            if event_type == "response.reasoning_summary_text.delta"
+                            else "content"
+                        ),
+                        on_reasoning=on_reasoning,
+                    )
+            elif event_type == "response.output_text.delta":
                 delta = payload.get("delta")
                 if isinstance(delta, str) and delta:
                     text_parts.append(delta)
@@ -357,7 +404,15 @@ class OpenAIAdapter(LLMAdapterBase):
                 "output": output,
                 "status": response_metadata.get("status", "completed"),
             }
-        chat_response = ChatResponse.from_openai_responses_response(final_response)
+        parser_kwargs = {"capture_reasoning": True} if capture_reasoning else {}
+        chat_response = ChatResponse.from_openai_responses_response(
+            final_response,
+            **parser_kwargs,
+        )
+        if reasoning_collector is not None:
+            streamed_reasoning_events = reasoning_collector.snapshot()
+            if streamed_reasoning_events:
+                chat_response.reasoning_events = streamed_reasoning_events
         self._prepare_stream_response(
             chat_response,
             effective_schema,

--- a/src/llm_api_adapter/llms/anthropic/sync_client.py
+++ b/src/llm_api_adapter/llms/anthropic/sync_client.py
@@ -52,6 +52,7 @@ class ClaudeSyncClient:
         budget_tokens = kwargs.pop("budget_tokens", None)
         effort = kwargs.pop("effort", None)
         is_adaptive_thinking = kwargs.pop("is_adaptive_thinking", False)
+        capture_reasoning = kwargs.pop("capture_reasoning", False)
         if is_adaptive_thinking:
             kwargs.pop("top_p", None)
             if effort:
@@ -65,6 +66,10 @@ class ClaudeSyncClient:
                 kwargs.pop("top_p", None)
             if budget_tokens:
                 kwargs["thinking"] = {"type": "enabled", "budget_tokens": budget_tokens}
+        if capture_reasoning:
+            thinking = kwargs.get("thinking")
+            if isinstance(thinking, dict):
+                kwargs["thinking"] = {**thinking, "display": "summarized"}
         return {"model": model, **kwargs}
 
     def _send_request(self, url: str, payload: dict, timeout_s: float | None = None):

--- a/src/llm_api_adapter/llms/google/sync_client.py
+++ b/src/llm_api_adapter/llms/google/sync_client.py
@@ -58,7 +58,12 @@ class GeminiSyncClient:
             thinking_config = gen_cfg["thinkingConfig"]
             thinking_budget = thinking_config.get("thinkingBudget")
             min_budget = MIN_THINKING_BUDGET.get(model)
-            if min_budget is None or thinking_budget < min_budget:
+            if (
+                min_budget is not None
+                and isinstance(thinking_budget, int)
+                and not isinstance(thinking_budget, bool)
+                and thinking_budget < min_budget
+            ):
                 thinking_config["thinkingBudget"] = min_budget
         return {"model": model, **kwargs}
 

--- a/src/llm_api_adapter/llms/openai/sync_client.py
+++ b/src/llm_api_adapter/llms/openai/sync_client.py
@@ -91,10 +91,16 @@ class OpenAISyncClient:
         if "max_tokens" in payload:
             payload["max_output_tokens"] = payload.pop("max_tokens")
         reasoning_effort = payload.pop("reasoning_effort", None)
+        capture_reasoning = payload.pop("capture_reasoning", False)
+        reasoning: dict = {}
         if reasoning_effort is not None:
             if model in ("gpt-5", "gpt-5-nano", "gpt-5-mini") and reasoning_effort == "none":
                 reasoning_effort = "minimal"
-            payload["reasoning"] = {"effort": reasoning_effort}
+            reasoning["effort"] = reasoning_effort
+        if capture_reasoning:
+            reasoning["summary"] = "auto"
+        if reasoning:
+            payload["reasoning"] = reasoning
         if model.startswith("gpt-5-nano"):
             temperature = payload.pop("temperature", None)
             if temperature not in (None, 1.0):

--- a/src/llm_api_adapter/llms/streaming.py
+++ b/src/llm_api_adapter/llms/streaming.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 import json
 import logging
 import time
-from typing import Any, Callable, Iterator, Mapping, Optional
+from typing import Any, Callable, Iterator, List, Mapping, Optional
 
 import requests
 
@@ -23,6 +23,7 @@ from ..errors.llm_api_error import (
     LLMAPITimeoutError,
 )
 from ..models.responses.chat_response import Usage
+from ..models.responses.reasoning_event import ReasoningEvent, ReasoningEventKind
 from ..models.responses.stream_chunk import StreamChunk
 
 logger = logging.getLogger(__name__)
@@ -155,6 +156,46 @@ class StreamChunkBuffer:
         self._last_emitted_at = emitted_at
         self._output_tokens_delta = None
         return chunk
+
+
+class StreamReasoningCollector:
+    """Collect normalized reasoning fragments with deterministic timing."""
+
+    def __init__(self, *, clock: Clock = time.perf_counter) -> None:
+        self._clock = clock
+        self._started_at = clock()
+        self._last_emitted_at = self._started_at
+        self._next_index = 0
+        self._events: List[ReasoningEvent] = []
+
+    def add(
+        self,
+        text: str,
+        *,
+        kind: ReasoningEventKind = "summary",
+    ) -> Optional[ReasoningEvent]:
+        """Record a non-empty reasoning fragment and return its event."""
+        if not isinstance(text, str):
+            raise TypeError("text must be a string")
+        if not text:
+            return None
+
+        emitted_at = self._clock()
+        event = ReasoningEvent(
+            text=text,
+            kind=kind,
+            index=self._next_index,
+            elapsed_s=emitted_at - self._started_at,
+            delta_s=emitted_at - self._last_emitted_at,
+        )
+        self._events.append(event)
+        self._next_index += 1
+        self._last_emitted_at = emitted_at
+        return event
+
+    def snapshot(self) -> List[ReasoningEvent]:
+        """Return a shallow copy of the collected immutable events."""
+        return list(self._events)
 
 
 class StreamUsageTracker:

--- a/src/llm_api_adapter/models/__init__.py
+++ b/src/llm_api_adapter/models/__init__.py
@@ -1,3 +1,9 @@
-from .responses import ChatResponse, StreamChunk, Usage
+from .responses import ChatResponse, ReasoningEvent, ReasoningEventKind, StreamChunk, Usage
 
-__all__ = ["ChatResponse", "StreamChunk", "Usage"]
+__all__ = [
+    "ChatResponse",
+    "ReasoningEvent",
+    "ReasoningEventKind",
+    "StreamChunk",
+    "Usage",
+]

--- a/src/llm_api_adapter/models/responses/__init__.py
+++ b/src/llm_api_adapter/models/responses/__init__.py
@@ -1,4 +1,11 @@
 from .chat_response import ChatResponse, Usage
+from .reasoning_event import ReasoningEvent, ReasoningEventKind
 from .stream_chunk import StreamChunk
 
-__all__ = ["ChatResponse", "StreamChunk", "Usage"]
+__all__ = [
+    "ChatResponse",
+    "ReasoningEvent",
+    "ReasoningEventKind",
+    "StreamChunk",
+    "Usage",
+]

--- a/src/llm_api_adapter/models/responses/chat_response.py
+++ b/src/llm_api_adapter/models/responses/chat_response.py
@@ -359,7 +359,12 @@ class ChatResponse:
         )
 
     @classmethod
-    def from_google_response(cls, api_response: dict) -> "ChatResponse":
+    def from_google_response(
+        cls,
+        api_response: dict,
+        *,
+        capture_reasoning: bool = False,
+    ) -> "ChatResponse":
         u = api_response.get("usageMetadata", {}) or {}
         thoughts_tokens = u.get("thoughtsTokenCount", 0)
         usage = Usage(
@@ -379,10 +384,24 @@ class ChatResponse:
             )
         parsed_tool_calls: Optional[List[ToolCall]] = None
         text_content: Optional[str] = None
+        reasoning_events: List[ReasoningEvent] = []
         for part in parts:
             if not isinstance(part, dict):
                 continue
-            if text_content is None and "text" in part:
+            if part.get("thought"):
+                if capture_reasoning:
+                    thought_text = part.get("text")
+                    if isinstance(thought_text, str) and thought_text:
+                        reasoning_events.append(
+                            ReasoningEvent(
+                                text=thought_text,
+                                kind="summary",
+                                index=len(reasoning_events),
+                                elapsed_s=0.0,
+                                delta_s=0.0,
+                            )
+                        )
+            elif text_content is None and "text" in part:
                 text_content = part.get("text")
             fc = part.get("functionCall") or part.get("function_call")
             if isinstance(fc, dict) and fc:
@@ -420,6 +439,7 @@ class ChatResponse:
             content=text_content,
             tool_calls=parsed_tool_calls,
             finish_reason=finish_reason_str,
+            reasoning_events=reasoning_events,
         )
 
     def apply_pricing(

--- a/src/llm_api_adapter/models/responses/chat_response.py
+++ b/src/llm_api_adapter/models/responses/chat_response.py
@@ -23,6 +23,13 @@ class _ParsedResponsesOutput:
 
 
 @dataclass
+class _ParsedAnthropicContent:
+    text: Optional[str] = None
+    tool_calls: Optional[List[ToolCall]] = None
+    reasoning_events: List[ReasoningEvent] = field(default_factory=list)
+
+
+@dataclass
 class ChatResponse:
     model: Optional[str] = None
     response_id: Optional[str] = None
@@ -275,50 +282,80 @@ class ChatResponse:
             output_tokens=u.get("output_tokens", 0),
             total_tokens=u.get("input_tokens", 0) + u.get("output_tokens", 0),
         )
-        blocks = api_response.get("content", []) or []
-        parsed_tool_calls: Optional[List[ToolCall]] = None
-        text_content: Optional[str] = None
-        reasoning_events: List[ReasoningEvent] = []
-        for block in blocks:
-            block_type = block.get("type")
-            if block_type == "text" and text_content is None:
-                text_content = block.get("text")
-            elif block_type == "thinking" and capture_reasoning:
-                thinking_text = block.get("thinking")
-                if isinstance(thinking_text, str) and thinking_text:
-                    reasoning_events.append(
-                        ReasoningEvent(
-                            text=thinking_text,
-                            kind="summary",
-                            index=len(reasoning_events),
-                            elapsed_s=0.0,
-                            delta_s=0.0,
-                        )
-                    )
-            elif block_type == "tool_use":
-                if parsed_tool_calls is None:
-                    parsed_tool_calls = []
-                name = block.get("name")
-                arguments = block.get("input")
-                if not isinstance(arguments, dict):
-                    raise InvalidToolArgumentsError(
-                        detail=f"Anthropic tool input must be dict for tool={name!r}"
-                    )
-                parsed_tool_calls.append(
-                    ToolCall(
-                        name=name,
-                        arguments=arguments,
-                        call_id=block.get("id"),
-                    )
-                )
+        parsed_content = cls._parse_anthropic_content_blocks(
+            api_response.get("content", []) or [],
+            capture_reasoning=capture_reasoning,
+        )
         return cls(
             model=api_response.get("model"),
             response_id=api_response.get("id"),
             usage=usage,
-            content=text_content,
-            tool_calls=parsed_tool_calls,
+            content=parsed_content.text,
+            tool_calls=parsed_content.tool_calls,
             finish_reason=api_response.get("stop_reason"),
-            reasoning_events=reasoning_events,
+            reasoning_events=parsed_content.reasoning_events,
+        )
+
+    @classmethod
+    def _parse_anthropic_content_blocks(
+        cls,
+        blocks: Any,
+        *,
+        capture_reasoning: bool,
+    ) -> _ParsedAnthropicContent:
+        parsed_content = _ParsedAnthropicContent()
+        for block in blocks:
+            block_type = block.get("type")
+            if block_type == "text" and parsed_content.text is None:
+                parsed_content.text = cls._parse_anthropic_text_block(block)
+            elif block_type == "thinking" and capture_reasoning:
+                reasoning_event = cls._parse_anthropic_thinking_block(
+                    block,
+                    index=len(parsed_content.reasoning_events),
+                )
+                if reasoning_event is not None:
+                    parsed_content.reasoning_events.append(reasoning_event)
+            elif block_type == "tool_use":
+                if parsed_content.tool_calls is None:
+                    parsed_content.tool_calls = []
+                parsed_content.tool_calls.append(
+                    cls._parse_anthropic_tool_use_block(block)
+                )
+        return parsed_content
+
+    @staticmethod
+    def _parse_anthropic_text_block(block: dict) -> Optional[str]:
+        return block.get("text")
+
+    @staticmethod
+    def _parse_anthropic_thinking_block(
+        block: dict,
+        *,
+        index: int,
+    ) -> Optional[ReasoningEvent]:
+        thinking_text = block.get("thinking")
+        if not isinstance(thinking_text, str) or not thinking_text:
+            return None
+        return ReasoningEvent(
+            text=thinking_text,
+            kind="summary",
+            index=index,
+            elapsed_s=0.0,
+            delta_s=0.0,
+        )
+
+    @staticmethod
+    def _parse_anthropic_tool_use_block(block: dict) -> ToolCall:
+        name = block.get("name")
+        arguments = block.get("input")
+        if not isinstance(arguments, dict):
+            raise InvalidToolArgumentsError(
+                detail=f"Anthropic tool input must be dict for tool={name!r}"
+            )
+        return ToolCall(
+            name=name,
+            arguments=arguments,
+            call_id=block.get("id"),
         )
 
     @classmethod

--- a/src/llm_api_adapter/models/responses/chat_response.py
+++ b/src/llm_api_adapter/models/responses/chat_response.py
@@ -108,7 +108,12 @@ class ChatResponse:
         )
 
     @classmethod
-    def from_openai_responses_response(cls, api_response: dict) -> "ChatResponse":
+    def from_openai_responses_response(
+        cls,
+        api_response: dict,
+        *,
+        capture_reasoning: bool = False,
+    ) -> "ChatResponse":
         u = api_response.get("usage", {}) or {}
         usage = Usage(
             input_tokens=u.get("input_tokens", 0),
@@ -116,6 +121,7 @@ class ChatResponse:
             total_tokens=u.get("total_tokens", 0),
         )
         parsed_tool_calls: Optional[List[ToolCall]] = None
+        reasoning_events: List[ReasoningEvent] = []
         text_parts: List[str] = []
         output_items = api_response.get("output") or []
         if not isinstance(output_items, list):
@@ -136,6 +142,44 @@ class ChatResponse:
                         text_value = content_item.get("text")
                         if isinstance(text_value, str) and text_value.strip():
                             text_parts.append(text_value)
+            elif item_type == "reasoning" and capture_reasoning:
+                summary_items = item.get("summary") or []
+                if isinstance(summary_items, list):
+                    for summary_item in summary_items:
+                        if not isinstance(summary_item, dict):
+                            continue
+                        if summary_item.get("type") != "summary_text":
+                            continue
+                        text_value = summary_item.get("text")
+                        if isinstance(text_value, str) and text_value:
+                            reasoning_events.append(
+                                ReasoningEvent(
+                                    text=text_value,
+                                    kind="summary",
+                                    index=len(reasoning_events),
+                                    elapsed_s=0.0,
+                                    delta_s=0.0,
+                                )
+                            )
+
+                content_items = item.get("content") or []
+                if isinstance(content_items, list):
+                    for content_item in content_items:
+                        if not isinstance(content_item, dict):
+                            continue
+                        if content_item.get("type") != "reasoning_text":
+                            continue
+                        text_value = content_item.get("text")
+                        if isinstance(text_value, str) and text_value:
+                            reasoning_events.append(
+                                ReasoningEvent(
+                                    text=text_value,
+                                    kind="content",
+                                    index=len(reasoning_events),
+                                    elapsed_s=0.0,
+                                    delta_s=0.0,
+                                )
+                            )
             elif item_type in ("function_call", "tool_call"):
                 if parsed_tool_calls is None:
                     parsed_tool_calls = []
@@ -160,7 +204,11 @@ class ChatResponse:
                     )
                 )
         text = "\n".join(text_parts) if text_parts else None
-        if not parsed_tool_calls and (not text or not text.strip()):
+        if (
+            not parsed_tool_calls
+            and not reasoning_events
+            and (not text or not text.strip())
+        ):
             warnings.warn(
                 "OpenAI Responses API returned empty content and no tool calls.",
                 UserWarning,
@@ -173,6 +221,7 @@ class ChatResponse:
             content=text,
             tool_calls=parsed_tool_calls,
             finish_reason=api_response.get("status"),
+            reasoning_events=reasoning_events,
         )
 
     @classmethod

--- a/src/llm_api_adapter/models/responses/chat_response.py
+++ b/src/llm_api_adapter/models/responses/chat_response.py
@@ -30,6 +30,14 @@ class _ParsedAnthropicContent:
 
 
 @dataclass
+class _ParsedGoogleContent:
+    text: Optional[str] = None
+    tool_calls: Optional[List[ToolCall]] = None
+    finish_reason: Optional[str] = None
+    reasoning_events: List[ReasoningEvent] = field(default_factory=list)
+
+
+@dataclass
 class ChatResponse:
     model: Optional[str] = None
     response_id: Optional[str] = None
@@ -365,81 +373,117 @@ class ChatResponse:
         *,
         capture_reasoning: bool = False,
     ) -> "ChatResponse":
-        u = api_response.get("usageMetadata", {}) or {}
-        thoughts_tokens = u.get("thoughtsTokenCount", 0)
-        usage = Usage(
-            input_tokens=u.get("promptTokenCount", 0),
-            output_tokens=u.get("candidatesTokenCount", 0) + thoughts_tokens,
-            total_tokens=u.get("totalTokenCount", 0),
-        )
+        usage = cls._parse_google_usage(api_response)
         first_candidate = (api_response.get("candidates") or [None])[0] or {}
-        finish_reason = first_candidate.get("finishReason")
-        finish_reason_str = str(finish_reason) if finish_reason is not None else None
-        content_obj = first_candidate.get("content") or {}
+        parsed_content = cls._parse_google_content(
+            first_candidate,
+            capture_reasoning=capture_reasoning,
+        )
+        return cls(
+            model=api_response.get("modelVersion"),
+            usage=usage,
+            content=parsed_content.text,
+            tool_calls=parsed_content.tool_calls,
+            finish_reason=parsed_content.finish_reason,
+            reasoning_events=parsed_content.reasoning_events,
+        )
+
+    @staticmethod
+    def _parse_google_usage(api_response: dict) -> Usage:
+        usage_data = api_response.get("usageMetadata", {}) or {}
+        thoughts_tokens = usage_data.get("thoughtsTokenCount", 0)
+        return Usage(
+            input_tokens=usage_data.get("promptTokenCount", 0),
+            output_tokens=usage_data.get("candidatesTokenCount", 0) + thoughts_tokens,
+            total_tokens=usage_data.get("totalTokenCount", 0),
+        )
+
+    @classmethod
+    def _parse_google_content(
+        cls,
+        candidate: dict,
+        *,
+        capture_reasoning: bool,
+    ) -> _ParsedGoogleContent:
+        finish_reason = candidate.get("finishReason")
+        parsed_content = _ParsedGoogleContent(
+            finish_reason=(
+                str(finish_reason) if finish_reason is not None else None
+            )
+        )
+        content_obj = candidate.get("content") or {}
         parts = content_obj.get("parts") or []
         if not isinstance(parts, list):
             raise LLMAPIError(
                 "Google API returned malformed response",
                 detail="content.parts is not a list",
             )
-        parsed_tool_calls: Optional[List[ToolCall]] = None
-        text_content: Optional[str] = None
-        reasoning_events: List[ReasoningEvent] = []
         for part in parts:
-            if not isinstance(part, dict):
-                continue
-            if part.get("thought"):
-                if capture_reasoning:
-                    thought_text = part.get("text")
-                    if isinstance(thought_text, str) and thought_text:
-                        reasoning_events.append(
-                            ReasoningEvent(
-                                text=thought_text,
-                                kind="summary",
-                                index=len(reasoning_events),
-                                elapsed_s=0.0,
-                                delta_s=0.0,
-                            )
+            cls._parse_google_part(
+                part,
+                parsed_content,
+                capture_reasoning=capture_reasoning,
+            )
+        return parsed_content
+
+    @classmethod
+    def _parse_google_part(
+        cls,
+        part: Any,
+        parsed_content: _ParsedGoogleContent,
+        *,
+        capture_reasoning: bool,
+    ) -> None:
+        if not isinstance(part, dict):
+            return
+        if part.get("thought"):
+            if capture_reasoning:
+                thought_text = part.get("text")
+                if isinstance(thought_text, str) and thought_text:
+                    parsed_content.reasoning_events.append(
+                        ReasoningEvent(
+                            text=thought_text,
+                            kind="summary",
+                            index=len(parsed_content.reasoning_events),
+                            elapsed_s=0.0,
+                            delta_s=0.0,
                         )
-            elif text_content is None and "text" in part:
-                text_content = part.get("text")
-            fc = part.get("functionCall") or part.get("function_call")
-            if isinstance(fc, dict) and fc:
-                if parsed_tool_calls is None:
-                    parsed_tool_calls = []
-                name = fc.get("name")
-                if not isinstance(name, str) or not name:
-                    raise InvalidToolArgumentsError(
-                        detail="Google functionCall.name must be non-empty str"
                     )
-                args = fc.get("args") if "args" in fc else fc.get("arguments", {})
-                if args is None:
-                    args = {}
-                if not isinstance(args, dict):
-                    raise InvalidToolArgumentsError(
-                        detail=f"Google functionCall args must be dict for tool={name!r}"
-                    )
-                thought_signature = part.get("thoughtSignature")
-                provider_data = None
-                if thought_signature is not None:
-                    provider_data = {
-                        "thoughtSignature": thought_signature,
-                    }
-                parsed_tool_calls.append(
-                    ToolCall(
-                        name=name,
-                        arguments=args,
-                        call_id=name,
-                        provider_data=provider_data,
-                    )
-                )
-        return cls(
-            model=api_response.get("modelVersion"),
-            usage=usage,
-            content=text_content,
-            tool_calls=parsed_tool_calls,
-            finish_reason=finish_reason_str,
-            reasoning_events=reasoning_events,
+        elif parsed_content.text is None and "text" in part:
+            parsed_content.text = part.get("text")
+        fc = part.get("functionCall") or part.get("function_call")
+        if isinstance(fc, dict) and fc:
+            if parsed_content.tool_calls is None:
+                parsed_content.tool_calls = []
+            parsed_content.tool_calls.append(cls._parse_google_tool_call(part, fc))
+
+    @staticmethod
+    def _parse_google_tool_call(part: dict, function_call: dict) -> ToolCall:
+        name = function_call.get("name")
+        if not isinstance(name, str) or not name:
+            raise InvalidToolArgumentsError(
+                detail="Google functionCall.name must be non-empty str"
+            )
+        args = (
+            function_call.get("args")
+            if "args" in function_call
+            else function_call.get("arguments", {})
+        )
+        if args is None:
+            args = {}
+        if not isinstance(args, dict):
+            raise InvalidToolArgumentsError(
+                detail=f"Google functionCall args must be dict for tool={name!r}"
+            )
+        thought_signature = part.get("thoughtSignature")
+        provider_data = None
+        if thought_signature is not None:
+            provider_data = {"thoughtSignature": thought_signature}
+        return ToolCall(
+            name=name,
+            arguments=args,
+            call_id=name,
+            provider_data=provider_data,
         )
 
     def apply_pricing(

--- a/src/llm_api_adapter/models/responses/chat_response.py
+++ b/src/llm_api_adapter/models/responses/chat_response.py
@@ -16,6 +16,13 @@ class Usage:
 
 
 @dataclass
+class _ParsedResponsesOutput:
+    text_parts: List[str] = field(default_factory=list)
+    tool_calls: Optional[List[ToolCall]] = None
+    reasoning_events: List[ReasoningEvent] = field(default_factory=list)
+
+
+@dataclass
 class ChatResponse:
     model: Optional[str] = None
     response_id: Optional[str] = None
@@ -120,93 +127,14 @@ class ChatResponse:
             output_tokens=u.get("output_tokens", 0),
             total_tokens=u.get("total_tokens", 0),
         )
-        parsed_tool_calls: Optional[List[ToolCall]] = None
-        reasoning_events: List[ReasoningEvent] = []
-        text_parts: List[str] = []
-        output_items = api_response.get("output") or []
-        if not isinstance(output_items, list):
-            output_items = []
-        for item in output_items:
-            if not isinstance(item, dict):
-                continue
-            item_type = item.get("type")
-            if item_type == "message":
-                content_items = item.get("content") or []
-                if not isinstance(content_items, list):
-                    continue
-                for content_item in content_items:
-                    if not isinstance(content_item, dict):
-                        continue
-                    content_type = content_item.get("type")
-                    if content_type in ("output_text", "text"):
-                        text_value = content_item.get("text")
-                        if isinstance(text_value, str) and text_value.strip():
-                            text_parts.append(text_value)
-            elif item_type == "reasoning" and capture_reasoning:
-                summary_items = item.get("summary") or []
-                if isinstance(summary_items, list):
-                    for summary_item in summary_items:
-                        if not isinstance(summary_item, dict):
-                            continue
-                        if summary_item.get("type") != "summary_text":
-                            continue
-                        text_value = summary_item.get("text")
-                        if isinstance(text_value, str) and text_value:
-                            reasoning_events.append(
-                                ReasoningEvent(
-                                    text=text_value,
-                                    kind="summary",
-                                    index=len(reasoning_events),
-                                    elapsed_s=0.0,
-                                    delta_s=0.0,
-                                )
-                            )
-
-                content_items = item.get("content") or []
-                if isinstance(content_items, list):
-                    for content_item in content_items:
-                        if not isinstance(content_item, dict):
-                            continue
-                        if content_item.get("type") != "reasoning_text":
-                            continue
-                        text_value = content_item.get("text")
-                        if isinstance(text_value, str) and text_value:
-                            reasoning_events.append(
-                                ReasoningEvent(
-                                    text=text_value,
-                                    kind="content",
-                                    index=len(reasoning_events),
-                                    elapsed_s=0.0,
-                                    delta_s=0.0,
-                                )
-                            )
-            elif item_type in ("function_call", "tool_call"):
-                if parsed_tool_calls is None:
-                    parsed_tool_calls = []
-                name = item.get("name")
-                raw_args = item.get("arguments", "{}")
-                try:
-                    if isinstance(raw_args, str):
-                        arguments = json.loads(raw_args) if raw_args.strip() else {}
-                    elif isinstance(raw_args, dict):
-                        arguments = raw_args
-                    else:
-                        arguments = {}
-                except Exception as e:
-                    raise InvalidToolArgumentsError(
-                        detail=f"OpenAI responses tool arguments JSON parse failed for tool={name!r}: {e}"
-                    )
-                parsed_tool_calls.append(
-                    ToolCall(
-                        name=name,
-                        arguments=arguments,
-                        call_id=item.get("call_id") or item.get("id"),
-                    )
-                )
-        text = "\n".join(text_parts) if text_parts else None
+        parsed_output = cls._parse_responses_output_items(
+            api_response.get("output") or [],
+            capture_reasoning=capture_reasoning,
+        )
+        text = "\n".join(parsed_output.text_parts) if parsed_output.text_parts else None
         if (
-            not parsed_tool_calls
-            and not reasoning_events
+            not parsed_output.tool_calls
+            and not parsed_output.reasoning_events
             and (not text or not text.strip())
         ):
             warnings.warn(
@@ -219,9 +147,119 @@ class ChatResponse:
             timestamp=api_response.get("created_at"),
             usage=usage,
             content=text,
-            tool_calls=parsed_tool_calls,
+            tool_calls=parsed_output.tool_calls,
             finish_reason=api_response.get("status"),
-            reasoning_events=reasoning_events,
+            reasoning_events=parsed_output.reasoning_events,
+        )
+
+    @classmethod
+    def _parse_responses_output_items(
+        cls,
+        output_items: Any,
+        *,
+        capture_reasoning: bool,
+    ) -> _ParsedResponsesOutput:
+        parsed_output = _ParsedResponsesOutput()
+        if not isinstance(output_items, list):
+            return parsed_output
+
+        for item in output_items:
+            if not isinstance(item, dict):
+                continue
+            item_type = item.get("type")
+            if item_type == "message":
+                cls._append_responses_message_text(item, parsed_output.text_parts)
+            elif item_type == "reasoning" and capture_reasoning:
+                cls._append_responses_reasoning_events(
+                    item,
+                    parsed_output.reasoning_events,
+                )
+            elif item_type in ("function_call", "tool_call"):
+                if parsed_output.tool_calls is None:
+                    parsed_output.tool_calls = []
+                parsed_output.tool_calls.append(cls._parse_responses_tool_call(item))
+        return parsed_output
+
+    @staticmethod
+    def _append_responses_message_text(
+        item: dict,
+        text_parts: List[str],
+    ) -> None:
+        content_items = item.get("content") or []
+        if not isinstance(content_items, list):
+            return
+        for content_item in content_items:
+            if not isinstance(content_item, dict):
+                continue
+            content_type = content_item.get("type")
+            if content_type not in ("output_text", "text"):
+                continue
+            text_value = content_item.get("text")
+            if isinstance(text_value, str) and text_value.strip():
+                text_parts.append(text_value)
+
+    @staticmethod
+    def _append_responses_reasoning_events(
+        item: dict,
+        reasoning_events: List[ReasoningEvent],
+    ) -> None:
+        summary_items = item.get("summary") or []
+        if isinstance(summary_items, list):
+            for summary_item in summary_items:
+                if not isinstance(summary_item, dict):
+                    continue
+                if summary_item.get("type") != "summary_text":
+                    continue
+                text_value = summary_item.get("text")
+                if isinstance(text_value, str) and text_value:
+                    reasoning_events.append(
+                        ReasoningEvent(
+                            text=text_value,
+                            kind="summary",
+                            index=len(reasoning_events),
+                            elapsed_s=0.0,
+                            delta_s=0.0,
+                        )
+                    )
+
+        content_items = item.get("content") or []
+        if isinstance(content_items, list):
+            for content_item in content_items:
+                if not isinstance(content_item, dict):
+                    continue
+                if content_item.get("type") != "reasoning_text":
+                    continue
+                text_value = content_item.get("text")
+                if isinstance(text_value, str) and text_value:
+                    reasoning_events.append(
+                        ReasoningEvent(
+                            text=text_value,
+                            kind="content",
+                            index=len(reasoning_events),
+                            elapsed_s=0.0,
+                            delta_s=0.0,
+                        )
+                    )
+
+    @staticmethod
+    def _parse_responses_tool_call(item: dict) -> ToolCall:
+        name = item.get("name")
+        raw_args = item.get("arguments", "{}")
+        try:
+            if isinstance(raw_args, str):
+                arguments = json.loads(raw_args) if raw_args.strip() else {}
+            elif isinstance(raw_args, dict):
+                arguments = raw_args
+            else:
+                arguments = {}
+        except Exception as e:
+            raise InvalidToolArgumentsError(
+                detail=f"OpenAI responses tool arguments JSON parse failed for tool={name!r}: {e}"
+            )
+        return ToolCall(
+            name=name,
+            arguments=arguments,
+            call_id=item.get("call_id") or item.get("id"),
         )
 
     @classmethod

--- a/src/llm_api_adapter/models/responses/chat_response.py
+++ b/src/llm_api_adapter/models/responses/chat_response.py
@@ -1,10 +1,11 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import json
 from typing import Any, List, Optional
 import warnings
 
 from ...errors.llm_api_error import InvalidToolArgumentsError, LLMAPIError
 from ...models.tools import ToolCall
+from .reasoning_event import ReasoningEvent
 
 
 @dataclass
@@ -29,6 +30,7 @@ class ChatResponse:
     finish_reason: Optional[str] = None
     parsed_json: Optional[dict] = None
     parsed_model: Optional[Any] = None
+    reasoning_events: List[ReasoningEvent] = field(default_factory=list)
 
     @classmethod
     def from_openai_response(cls, api_response: dict) -> "ChatResponse":

--- a/src/llm_api_adapter/models/responses/chat_response.py
+++ b/src/llm_api_adapter/models/responses/chat_response.py
@@ -263,7 +263,12 @@ class ChatResponse:
         )
 
     @classmethod
-    def from_anthropic_response(cls, api_response: dict) -> "ChatResponse":
+    def from_anthropic_response(
+        cls,
+        api_response: dict,
+        *,
+        capture_reasoning: bool = False,
+    ) -> "ChatResponse":
         u = api_response.get("usage", {}) or {}
         usage = Usage(
             input_tokens=u.get("input_tokens", 0),
@@ -273,10 +278,23 @@ class ChatResponse:
         blocks = api_response.get("content", []) or []
         parsed_tool_calls: Optional[List[ToolCall]] = None
         text_content: Optional[str] = None
+        reasoning_events: List[ReasoningEvent] = []
         for block in blocks:
             block_type = block.get("type")
             if block_type == "text" and text_content is None:
                 text_content = block.get("text")
+            elif block_type == "thinking" and capture_reasoning:
+                thinking_text = block.get("thinking")
+                if isinstance(thinking_text, str) and thinking_text:
+                    reasoning_events.append(
+                        ReasoningEvent(
+                            text=thinking_text,
+                            kind="summary",
+                            index=len(reasoning_events),
+                            elapsed_s=0.0,
+                            delta_s=0.0,
+                        )
+                    )
             elif block_type == "tool_use":
                 if parsed_tool_calls is None:
                     parsed_tool_calls = []
@@ -300,6 +318,7 @@ class ChatResponse:
             content=text_content,
             tool_calls=parsed_tool_calls,
             finish_reason=api_response.get("stop_reason"),
+            reasoning_events=reasoning_events,
         )
 
     @classmethod

--- a/src/llm_api_adapter/models/responses/reasoning_event.py
+++ b/src/llm_api_adapter/models/responses/reasoning_event.py
@@ -1,0 +1,33 @@
+"""Immutable provider-neutral reasoning observability events."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+ReasoningEventKind = Literal["summary", "content"]
+
+
+@dataclass(frozen=True)
+class ReasoningEvent:
+    """A normalized provider-emitted reasoning fragment.
+
+    The event is deliberately immutable so callbacks and final responses can
+    safely share the same value without exposing collector state.
+    """
+
+    text: str
+    kind: ReasoningEventKind
+    index: int
+    elapsed_s: float
+    delta_s: float
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.text, str):
+            raise TypeError("text must be a string")
+        if self.kind not in ("summary", "content"):
+            raise ValueError("kind must be 'summary' or 'content'")
+
+
+__all__ = ["ReasoningEvent", "ReasoningEventKind"]

--- a/tests/unit/adapters/test_anthropic_adapter.py
+++ b/tests/unit/adapters/test_anthropic_adapter.py
@@ -7,6 +7,7 @@ from src.llm_api_adapter.errors.llm_api_error import LLMAPIError
 from src.llm_api_adapter.adapters.anthropic_adapter import ClaudeSyncClient
 from src.llm_api_adapter.models.messages.chat_message import Prompt, UserMessage
 from src.llm_api_adapter.models.responses.chat_response import ChatResponse, Usage
+from src.llm_api_adapter.models.responses.reasoning_event import ReasoningEvent
 from src.llm_api_adapter.models.tools import ToolSpec
 from src.llm_api_adapter.llms.streaming import SSEEvent
 
@@ -113,6 +114,35 @@ def test_chat_sets_thinking_when_reasoning_level_provided(adapter):
         kwargs = mock_chat.call_args.kwargs
         assert "budget_tokens" in kwargs
         assert kwargs["budget_tokens"] == 4096
+
+
+@pytest.mark.unit
+def test_chat_capture_reasoning_is_opt_in(adapter):
+    fake_response = {
+        "model": "claude-sonnet-4-5",
+        "content": [
+            {"type": "thinking", "thinking": "Plan", "signature": "secret"},
+            {"type": "text", "text": "Answer"},
+        ],
+    }
+    with patch.object(
+        ClaudeSyncClient,
+        "chat_completion",
+        return_value=fake_response,
+    ) as mock_chat:
+        result = adapter.chat(
+            [UserMessage("hi")],
+            max_tokens=2048,
+            reasoning_level=1024,
+            capture_reasoning=True,
+        )
+
+    assert mock_chat.call_args.kwargs["capture_reasoning"] is True
+    assert result.reasoning_events == [
+        ReasoningEvent("Plan", "summary", 0, 0.0, 0.0),
+    ]
+    assert result.content == "Answer"
+
 
 @pytest.mark.unit
 def test_validate_reasoning_and_tokens_raises_llm_reasoning_level_error(adapter):
@@ -241,6 +271,78 @@ def test_stream_chat_normalizes_text_and_completed_tool_use(adapter):
     assert done[0].finish_reason == "tool_use"
     assert tool_calls[0].name == "get_weather"
     assert tool_calls[0].arguments == {"city": "Tel Aviv"}
+
+
+@pytest.mark.unit
+def test_stream_chat_separates_thinking_from_visible_text(adapter):
+    events = iter([
+        SSEEvent(
+            event="message_start",
+            data={"type": "message_start", "message": {
+                "model": "claude-sonnet-4-5", "content": [],
+            }},
+        ),
+        SSEEvent(
+            event="content_block_start",
+            data={"type": "content_block_start", "index": 0, "content_block": {
+                "type": "thinking", "thinking": "",
+            }},
+        ),
+        SSEEvent(
+            event="content_block_delta",
+            data={"type": "content_block_delta", "index": 0, "delta": {
+                "type": "thinking_delta", "thinking": "Plan",
+            }},
+        ),
+        SSEEvent(
+            event="content_block_delta",
+            data={"type": "content_block_delta", "index": 0, "delta": {
+                "type": "signature_delta", "signature": "secret",
+            }},
+        ),
+        SSEEvent(
+            event="content_block_stop",
+            data={"type": "content_block_stop", "index": 0},
+        ),
+        SSEEvent(
+            event="content_block_start",
+            data={"type": "content_block_start", "index": 1, "content_block": {
+                "type": "text", "text": "",
+            }},
+        ),
+        SSEEvent(
+            event="content_block_delta",
+            data={"type": "content_block_delta", "index": 1, "delta": {
+                "type": "text_delta", "text": "Answer",
+            }},
+        ),
+        SSEEvent(
+            event="content_block_stop",
+            data={"type": "content_block_stop", "index": 1},
+        ),
+        SSEEvent(event="message_stop", data={"type": "message_stop"}),
+    ])
+    reasoning = []
+    visible_deltas = []
+    done = []
+
+    with patch.object(ClaudeSyncClient, "stream", return_value=events) as mock_stream:
+        output = list(adapter.stream_chat(
+            [UserMessage("hi")],
+            max_tokens=2048,
+            reasoning_level=1024,
+            capture_reasoning=True,
+            on_delta=visible_deltas.append,
+            on_reasoning=reasoning.append,
+            on_done=done.append,
+        ))
+
+    expected = [ReasoningEvent("Plan", "summary", 0, 0.0, 0.0)]
+    assert output == ["Answer"]
+    assert visible_deltas == ["Answer"]
+    assert reasoning == expected
+    assert done[0].reasoning_events == expected
+    assert mock_stream.call_args.kwargs["capture_reasoning"] is True
 
 
 @pytest.mark.unit

--- a/tests/unit/adapters/test_anthropic_adapter.py
+++ b/tests/unit/adapters/test_anthropic_adapter.py
@@ -337,11 +337,15 @@ def test_stream_chat_separates_thinking_from_visible_text(adapter):
             on_done=done.append,
         ))
 
-    expected = [ReasoningEvent("Plan", "summary", 0, 0.0, 0.0)]
     assert output == ["Answer"]
     assert visible_deltas == ["Answer"]
-    assert reasoning == expected
-    assert done[0].reasoning_events == expected
+    assert len(reasoning) == 1
+    assert reasoning[0].text == "Plan"
+    assert reasoning[0].kind == "summary"
+    assert reasoning[0].index == 0
+    assert reasoning[0].elapsed_s >= 0.0
+    assert reasoning[0].delta_s >= 0.0
+    assert done[0].reasoning_events == reasoning
     assert mock_stream.call_args.kwargs["capture_reasoning"] is True
 
 

--- a/tests/unit/adapters/test_base_adapter.py
+++ b/tests/unit/adapters/test_base_adapter.py
@@ -202,6 +202,24 @@ def test_normalize_messages_accepts_list_and_messages(adapter):
 
 
 @pytest.mark.unit
+def test_prepare_chat_request_normalizes_provider_neutral_context(adapter):
+    tool = make_tool()
+
+    context = adapter._prepare_chat_request(
+        [UserMessage("hi")],
+        [tool],
+        "auto",
+        None,
+        None,
+    )
+
+    assert isinstance(context.normalized_messages, Messages)
+    assert context.normalized_messages.items[0] == UserMessage("hi")
+    assert context.effective_schema is None
+    assert context.normalized_tool_choice == "auto"
+
+
+@pytest.mark.unit
 def test_generate_chat_answer_emits_deprecation_warning(adapter):
     with pytest.warns(DeprecationWarning):
         adapter.generate_chat_answer(messages=[UserMessage("hi")])

--- a/tests/unit/adapters/test_base_adapter.py
+++ b/tests/unit/adapters/test_base_adapter.py
@@ -20,8 +20,11 @@ from src.llm_api_adapter.models.messages.chat_message import (
 )
 from src.llm_api_adapter.models.responses.chat_response import ChatResponse
 from src.llm_api_adapter.models.responses.reasoning_event import ReasoningEvent
-from src.llm_api_adapter.llms.streaming import StreamReasoningCollector
-from src.llm_api_adapter.models.tools import ToolSpec
+from src.llm_api_adapter.llms.streaming import (
+    StreamChunkBuffer,
+    StreamReasoningCollector,
+)
+from src.llm_api_adapter.models.tools import ToolCall, ToolSpec
 
 
 class DummyClient:
@@ -295,6 +298,58 @@ def test_record_reasoning_event_updates_response_before_callback(adapter):
     adapter._invoke_stream_completion_callbacks(response, None, completed.append)
     assert completed == [response]
     assert completed[0].reasoning_events == [expected]
+
+
+@pytest.mark.unit
+def test_complete_stream_flushes_chunks_before_completion_callbacks(adapter):
+    response = ChatResponse(
+        content="Hello",
+        tool_calls=[ToolCall(name="weather", arguments={"city": "Tel Aviv"})],
+    )
+    chunk_buffer = StreamChunkBuffer(buffer_chars=10)
+    list(chunk_buffer.add("Hello"))
+    events = []
+
+    output = list(
+        adapter._complete_stream(
+            response,
+            chunk_buffer,
+            on_chunk=lambda chunk: events.append(("chunk", chunk.text)),
+            on_delta=lambda text: events.append(("delta", text)),
+            on_tool_call=lambda call: events.append(("tool", call.name)),
+            on_done=lambda completed: events.append(("done", completed.content)),
+        )
+    )
+
+    assert output == ["Hello"]
+    assert events == [
+        ("chunk", "Hello"),
+        ("delta", "Hello"),
+        ("tool", "weather"),
+        ("done", "Hello"),
+    ]
+
+
+@pytest.mark.unit
+def test_finalize_stream_response_attaches_reasoning_and_structured_output(adapter):
+    class StreamAnswer(BaseModel):
+        answer: str
+
+    response = ChatResponse(content='{"answer": "Hello"}')
+    collector = StreamReasoningCollector(clock=iter([0.0, 0.25]).__next__)
+    event = collector.add("Plan")
+
+    finalized = adapter._finalize_stream_response(
+        response,
+        reasoning_collector=collector,
+        effective_schema={"type": "object"},
+        response_model=StreamAnswer,
+    )
+
+    assert finalized is response
+    assert finalized.reasoning_events == [event]
+    assert finalized.parsed_json == {"answer": "Hello"}
+    assert finalized.parsed_model == StreamAnswer(answer="Hello")
 
 
 @pytest.mark.unit

--- a/tests/unit/adapters/test_base_adapter.py
+++ b/tests/unit/adapters/test_base_adapter.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from inspect import signature
 from unittest.mock import patch
 
 import pytest
@@ -18,6 +19,8 @@ from src.llm_api_adapter.models.messages.chat_message import (
     UserMessage,
 )
 from src.llm_api_adapter.models.responses.chat_response import ChatResponse
+from src.llm_api_adapter.models.responses.reasoning_event import ReasoningEvent
+from src.llm_api_adapter.llms.streaming import StreamReasoningCollector
 from src.llm_api_adapter.models.tools import ToolSpec
 
 
@@ -220,7 +223,7 @@ def test_handle_error_reraises_and_logs(adapter, caplog):
 @pytest.mark.unit
 def test_base_abstract_chat_method_raises_not_implemented(adapter):
     with pytest.raises(NotImplementedError):
-        LLMAdapterBase.chat(adapter)
+        LLMAdapterBase.chat(adapter, messages=[UserMessage("hello")])
 
 
 @pytest.mark.unit
@@ -231,6 +234,88 @@ def test_base_stream_chat_contract_raises_not_implemented(adapter):
             messages=[UserMessage("hello")],
             on_delta=lambda delta: None,
         )
+
+
+@pytest.mark.unit
+def test_reasoning_contract_is_exposed_by_all_provider_adapters():
+    from src.llm_api_adapter.adapters.anthropic_adapter import AnthropicAdapter
+    from src.llm_api_adapter.adapters.google_adapter import GoogleAdapter
+    from src.llm_api_adapter.adapters.openai_adapter import OpenAIAdapter
+
+    for adapter_class in (OpenAIAdapter, AnthropicAdapter, GoogleAdapter):
+        chat_params = signature(adapter_class.chat).parameters
+        stream_params = signature(adapter_class.stream_chat).parameters
+        assert chat_params["capture_reasoning"].default is False
+        assert stream_params["capture_reasoning"].default is False
+        assert stream_params["on_reasoning"].default is None
+
+
+@pytest.mark.unit
+def test_record_reasoning_event_updates_response_before_callback(adapter):
+    response = ChatResponse()
+    collector = StreamReasoningCollector(clock=iter([0.0, 0.25]).__next__)
+    observed = []
+
+    def on_reasoning(event):
+        observed.append((event, list(response.reasoning_events)))
+
+    event = adapter._record_reasoning_event(
+        response,
+        collector,
+        "visible summary",
+        capture_reasoning=True,
+        on_reasoning=on_reasoning,
+    )
+
+    expected = ReasoningEvent("visible summary", "summary", 0, 0.25, 0.25)
+    assert event == expected
+    assert response.reasoning_events == [expected]
+    assert collector.snapshot() == [expected]
+    assert observed == [(expected, [expected])]
+
+    completed = []
+    adapter._invoke_stream_completion_callbacks(response, None, completed.append)
+    assert completed == [response]
+    assert completed[0].reasoning_events == [expected]
+
+
+@pytest.mark.unit
+def test_record_reasoning_event_is_opt_in_and_does_not_call_callback(adapter):
+    response = ChatResponse()
+    collector = StreamReasoningCollector(clock=iter([0.0, 0.25]).__next__)
+    callbacks = []
+
+    assert adapter._record_reasoning_event(
+        response,
+        collector,
+        "not captured",
+        capture_reasoning=False,
+        on_reasoning=callbacks.append,
+    ) is None
+
+    assert response.reasoning_events == []
+    assert collector.snapshot() == []
+    assert callbacks == []
+
+
+@pytest.mark.unit
+def test_reasoning_callback_exception_preserves_existing_callback_semantics(adapter):
+    response = ChatResponse()
+    collector = StreamReasoningCollector(clock=iter([0.0, 0.25]).__next__)
+
+    with pytest.raises(RuntimeError, match="callback failed"):
+        adapter._record_reasoning_event(
+            response,
+            collector,
+            "captured before failure",
+            capture_reasoning=True,
+            on_reasoning=lambda event: (_ for _ in ()).throw(
+                RuntimeError("callback failed")
+            ),
+        )
+
+    assert len(response.reasoning_events) == 1
+    assert response.reasoning_events[0].text == "captured before failure"
 
 
 @pytest.mark.unit

--- a/tests/unit/adapters/test_google_adapter.py
+++ b/tests/unit/adapters/test_google_adapter.py
@@ -9,6 +9,7 @@ from src.llm_api_adapter.models.messages.chat_message import Prompt, UserMessage
 from src.llm_api_adapter.models.responses.chat_response import ChatResponse, Usage
 from src.llm_api_adapter.models.tools import ToolSpec
 from src.llm_api_adapter.llms.streaming import SSEEvent
+from src.llm_api_adapter.models.responses.reasoning_event import ReasoningEvent
 
 @pytest.fixture
 def adapter():
@@ -121,6 +122,40 @@ def test_chat_adds_thinking_config_when_reasoning_level_set(adapter):
     assert "thinkingConfig" in gen_cfg
     assert isinstance(gen_cfg["thinkingConfig"], dict)
     assert gen_cfg["thinkingConfig"]["includeThoughts"] is False
+
+
+@pytest.mark.unit
+def test_chat_captures_google_thought_summaries_when_opted_in(adapter):
+    fake_response = {
+        "modelVersion": "gemini-2.5-pro",
+        "candidates": [{
+            "content": {
+                "parts": [
+                    {"text": "Plan", "thought": True},
+                    {"text": "Answer"},
+                ]
+            }
+        }],
+    }
+
+    with patch.object(
+        GeminiSyncClient,
+        "chat_completion",
+        return_value=fake_response,
+    ) as mock_client:
+        response = adapter.chat(
+            [UserMessage("hi")],
+            capture_reasoning=True,
+        )
+
+    thinking_config = mock_client.call_args.kwargs["generationConfig"][
+        "thinkingConfig"
+    ]
+    assert thinking_config == {"includeThoughts": True}
+    assert response.content == "Answer"
+    assert response.reasoning_events == [
+        ReasoningEvent("Plan", "summary", 0, 0.0, 0.0),
+    ]
 
 @pytest.mark.unit
 def test_normalize_reasoning_level_bool_raises(adapter):
@@ -250,6 +285,47 @@ def test_stream_chat_normalizes_chunks_excludes_thoughts_and_finalizes(adapter):
     assert done[0].usage.total_tokens == 5
     assert tool_calls[0].name == "get_weather"
     assert tool_calls[0].arguments == {"city": "Tel Aviv"}
+
+
+@pytest.mark.unit
+def test_stream_chat_captures_google_thought_summaries_separately(adapter):
+    events = iter([
+        SSEEvent(data={
+            "candidates": [{
+                "content": {"parts": [{"text": "Plan", "thought": True}]}
+            }],
+        }, event=None),
+        SSEEvent(data={
+            "candidates": [{
+                "content": {"parts": [{"text": "Answer"}]}
+            }],
+        }, event=None),
+        SSEEvent(data={
+            "candidates": [{
+                "content": {"parts": [{"text": "Details", "thought": True}]},
+                "finishReason": "STOP",
+            }],
+        }, event=None),
+    ])
+    reasoning = []
+    done = []
+
+    with patch.object(GeminiSyncClient, "stream", return_value=events) as mock_stream:
+        output = list(adapter.stream_chat(
+            [UserMessage("hi")],
+            capture_reasoning=True,
+            on_reasoning=reasoning.append,
+            on_done=done.append,
+        ))
+
+    assert output == ["Answer"]
+    assert [event.text for event in reasoning] == ["Plan", "Details"]
+    assert done[0].content == "Answer"
+    assert done[0].reasoning_events == reasoning
+    thinking_config = mock_stream.call_args.kwargs["generationConfig"][
+        "thinkingConfig"
+    ]
+    assert thinking_config == {"includeThoughts": True}
 
 
 @pytest.mark.unit

--- a/tests/unit/adapters/test_openai_adapter.py
+++ b/tests/unit/adapters/test_openai_adapter.py
@@ -188,6 +188,52 @@ def test_chat_responses_api_builds_expected_params(adapter):
 
 
 @pytest.mark.unit
+def test_chat_responses_api_capture_reasoning_is_opt_in_and_normalized(adapter):
+    fake_response = {
+        "id": "resp_123",
+        "model": "gpt-5",
+        "status": "completed",
+        "output": [
+            {
+                "type": "reasoning",
+                "summary": [{"type": "summary_text", "text": "Plan"}],
+            },
+            {
+                "type": "message",
+                "content": [{"type": "output_text", "text": "Answer"}],
+            },
+        ],
+    }
+
+    with patch.object(OpenAISyncClient, "complete", return_value=fake_response) as mock_complete:
+        result = adapter.chat(
+            [UserMessage("hi")],
+            capture_reasoning=True,
+        )
+
+    assert mock_complete.call_args.kwargs["capture_reasoning"] is True
+    assert [event.text for event in result.reasoning_events] == ["Plan"]
+    assert result.reasoning_events[0].kind == "summary"
+
+
+@pytest.mark.unit
+def test_chat_legacy_capture_reasoning_does_not_add_responses_field(legacy_adapter):
+    fake_response = {
+        "model": "gpt-4o",
+        "choices": [{"message": {"content": "Answer"}}],
+    }
+
+    with patch.object(OpenAISyncClient, "complete", return_value=fake_response) as mock_complete:
+        result = legacy_adapter.chat(
+            [UserMessage("hi")],
+            capture_reasoning=True,
+        )
+
+    assert "capture_reasoning" not in mock_complete.call_args.kwargs
+    assert result.reasoning_events == []
+
+
+@pytest.mark.unit
 def test_chat_legacy_api_builds_expected_params(legacy_adapter):
     fake_response = {"id": "chatcmpl_123"}
     fake_chat_response = ChatResponse()
@@ -721,6 +767,73 @@ def test_stream_chat_responses_uses_completed_response(adapter):
     assert done[0].response_id == "resp_123"
     assert done[0].usage.total_tokens == 3
     assert tool_calls[0].arguments == {"city": "Tel Aviv"}
+
+
+@pytest.mark.unit
+def test_stream_chat_responses_separates_reasoning_events_from_visible_text(adapter):
+    events = iter([
+        SSEEvent(
+            event="response.reasoning_summary_text.delta",
+            data={
+                "type": "response.reasoning_summary_text.delta",
+                "delta": "Plan",
+            },
+        ),
+        SSEEvent(
+            event="response.reasoning_text.delta",
+            data={
+                "type": "response.reasoning_text.delta",
+                "delta": "Details",
+            },
+        ),
+        SSEEvent(
+            event="response.output_text.delta",
+            data={"type": "response.output_text.delta", "delta": "Answer"},
+        ),
+        SSEEvent(
+            event="response.completed",
+            data={
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_123",
+                    "model": "gpt-5",
+                    "status": "completed",
+                    "output": [
+                        {
+                            "type": "reasoning",
+                            "summary": [{"type": "summary_text", "text": "Plan"}],
+                            "content": [{"type": "reasoning_text", "text": "Details"}],
+                        },
+                        {
+                            "type": "message",
+                            "content": [{"type": "output_text", "text": "Answer"}],
+                        },
+                    ],
+                },
+            },
+        ),
+    ])
+    reasoning = []
+    deltas = []
+    done = []
+
+    with patch.object(OpenAISyncClient, "stream", return_value=events) as mock_stream:
+        output = list(adapter.stream_chat(
+            [UserMessage("hi")],
+            capture_reasoning=True,
+            on_reasoning=reasoning.append,
+            on_delta=deltas.append,
+            on_done=done.append,
+        ))
+
+    assert output == ["Answer"]
+    assert deltas == ["Answer"]
+    assert [(event.text, event.kind, event.index) for event in reasoning] == [
+        ("Plan", "summary", 0),
+        ("Details", "content", 1),
+    ]
+    assert done[0].reasoning_events == reasoning
+    assert mock_stream.call_args.kwargs["capture_reasoning"] is True
 
 
 @pytest.mark.unit

--- a/tests/unit/adapters/test_reasoning_contract.py
+++ b/tests/unit/adapters/test_reasoning_contract.py
@@ -1,0 +1,258 @@
+from unittest.mock import patch
+
+import pytest
+
+from src.llm_api_adapter.adapters.anthropic_adapter import (
+    AnthropicAdapter,
+    ClaudeSyncClient,
+)
+from src.llm_api_adapter.adapters.google_adapter import (
+    GeminiSyncClient,
+    GoogleAdapter,
+)
+from src.llm_api_adapter.adapters.openai_adapter import (
+    OpenAIAdapter,
+    OpenAISyncClient,
+)
+from src.llm_api_adapter.llms.streaming import SSEEvent
+from src.llm_api_adapter.models.messages.chat_message import UserMessage
+
+
+def _openai_events(*, include_reasoning=True):
+    events = []
+    if include_reasoning:
+        events.extend([
+            SSEEvent(
+                event="response.reasoning_summary_text.delta",
+                data={
+                    "type": "response.reasoning_summary_text.delta",
+                    "delta": "Plan",
+                },
+            ),
+            SSEEvent(
+                event="response.reasoning_text.delta",
+                data={
+                    "type": "response.reasoning_text.delta",
+                    "delta": "Details",
+                },
+            ),
+        ])
+    events.extend([
+        SSEEvent(
+            event="response.output_text.delta",
+            data={"type": "response.output_text.delta", "delta": "Answer"},
+        ),
+        SSEEvent(
+            event="response.completed",
+            data={
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_123",
+                    "model": "gpt-5",
+                    "output": [{
+                        "type": "message",
+                        "content": [{"type": "output_text", "text": "Answer"}],
+                    }],
+                },
+            },
+        ),
+    ])
+    return iter(events)
+
+
+def _anthropic_events(*, include_reasoning=True):
+    events = [
+        SSEEvent(
+            event="message_start",
+            data={
+                "type": "message_start",
+                "message": {"model": "claude-sonnet-4-5", "content": []},
+            },
+        ),
+    ]
+    if include_reasoning:
+        events.extend([
+            SSEEvent(
+                event="content_block_start",
+                data={
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": {"type": "thinking", "thinking": ""},
+                },
+            ),
+            SSEEvent(
+                event="content_block_delta",
+                data={
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "thinking_delta", "thinking": "Plan"},
+                },
+            ),
+            SSEEvent(
+                event="content_block_stop",
+                data={"type": "content_block_stop", "index": 0},
+            ),
+        ])
+    text_index = 1 if include_reasoning else 0
+    events.extend([
+        SSEEvent(
+            event="content_block_start",
+            data={
+                "type": "content_block_start",
+                "index": text_index,
+                "content_block": {"type": "text", "text": ""},
+            },
+        ),
+        SSEEvent(
+            event="content_block_delta",
+            data={
+                "type": "content_block_delta",
+                "index": text_index,
+                "delta": {"type": "text_delta", "text": "Answer"},
+            },
+        ),
+        SSEEvent(
+            event="content_block_stop",
+            data={"type": "content_block_stop", "index": text_index},
+        ),
+        SSEEvent(event="message_stop", data={"type": "message_stop"}),
+    ])
+    return iter(events)
+
+
+def _google_events(*, include_reasoning=True):
+    parts = []
+    if include_reasoning:
+        parts.append({"text": "Plan", "thought": True})
+    parts.append({"text": "Answer"})
+    return iter([
+        SSEEvent(
+            event=None,
+            data={
+                "candidates": [{
+                    "content": {"parts": parts},
+                    "finishReason": "STOP",
+                }],
+            },
+        ),
+    ])
+
+
+PROVIDER_CASES = [
+    pytest.param(
+        lambda: OpenAIAdapter(api_key="test_api_key", model="gpt-5"),
+        OpenAISyncClient,
+        _openai_events,
+        {},
+        [("Plan", "summary"), ("Details", "content")],
+        id="openai-responses",
+    ),
+    pytest.param(
+        lambda: AnthropicAdapter(
+            api_key="test_api_key",
+            model="claude-sonnet-4-5",
+        ),
+        ClaudeSyncClient,
+        _anthropic_events,
+        {"max_tokens": 2048, "reasoning_level": 1024},
+        [("Plan", "summary")],
+        id="anthropic-messages",
+    ),
+    pytest.param(
+        lambda: GoogleAdapter(api_key="test_api_key", model="gemini-2.5-pro"),
+        GeminiSyncClient,
+        _google_events,
+        {},
+        [("Plan", "summary")],
+        id="google-generate-content",
+    ),
+]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("capture_reasoning", [True, False])
+@pytest.mark.parametrize(
+    "adapter_factory, client_class, event_factory, stream_kwargs, expected_reasoning",
+    PROVIDER_CASES,
+)
+def test_stream_reasoning_contract_is_provider_neutral(
+    capture_reasoning,
+    adapter_factory,
+    client_class,
+    event_factory,
+    stream_kwargs,
+    expected_reasoning,
+):
+    adapter = adapter_factory()
+    reasoning = []
+    deltas = []
+    done = []
+    callback_order = []
+
+    with patch.object(
+        client_class,
+        "stream",
+        return_value=event_factory(include_reasoning=True),
+    ):
+        output = list(
+            adapter.stream_chat(
+                [UserMessage("hi")],
+                capture_reasoning=capture_reasoning,
+                on_delta=lambda text: (
+                    deltas.append(text), callback_order.append(("delta", text))
+                ),
+                on_reasoning=lambda event: (
+                    reasoning.append(event), callback_order.append(("reasoning", event.text))
+                ),
+                on_done=lambda response: (
+                    done.append(response), callback_order.append(("done", response.content))
+                ),
+                **stream_kwargs,
+            )
+        )
+
+    expected_events = expected_reasoning if capture_reasoning else []
+    assert output == ["Answer"]
+    assert deltas == ["Answer"]
+    assert [(event.text, event.kind) for event in reasoning] == expected_events
+    assert [event.index for event in reasoning] == list(range(len(reasoning)))
+    assert all(event.elapsed_s >= 0.0 and event.delta_s >= 0.0 for event in reasoning)
+    assert callback_order[-2:] == [("delta", "Answer"), ("done", "Answer")]
+    assert len(done) == 1
+    assert done[0].reasoning_events == reasoning
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "adapter_factory, client_class, event_factory, stream_kwargs, expected_reasoning",
+    PROVIDER_CASES,
+)
+def test_stream_reasoning_contract_accepts_absent_provider_data(
+    adapter_factory,
+    client_class,
+    event_factory,
+    stream_kwargs,
+    expected_reasoning,
+):
+    adapter = adapter_factory()
+    reasoning = []
+    done = []
+
+    with patch.object(
+        client_class,
+        "stream",
+        return_value=event_factory(include_reasoning=False),
+    ):
+        output = list(
+            adapter.stream_chat(
+                [UserMessage("hi")],
+                capture_reasoning=True,
+                on_reasoning=reasoning.append,
+                on_done=done.append,
+                **stream_kwargs,
+            )
+        )
+
+    assert output == ["Answer"]
+    assert reasoning == []
+    assert done[0].reasoning_events == []

--- a/tests/unit/llms/anthropic/test_sync_client.py
+++ b/tests/unit/llms/anthropic/test_sync_client.py
@@ -139,6 +139,23 @@ def test_prepare_payload_legacy_sets_budget_tokens_thinking(client):
 
 
 @pytest.mark.unit
+def test_prepare_payload_capture_reasoning_requests_summarized_thinking(client):
+    kwargs = {
+        "messages": [],
+        "budget_tokens": 4096,
+        "is_adaptive_thinking": False,
+        "capture_reasoning": True,
+    }
+    payload = client._prepare_chat_payload_for_model("claude-opus-4-5", kwargs)
+    assert payload["thinking"] == {
+        "type": "enabled",
+        "budget_tokens": 4096,
+        "display": "summarized",
+    }
+    assert "capture_reasoning" not in payload
+
+
+@pytest.mark.unit
 def test_prepare_payload_is_adaptive_thinking_never_in_result(client):
     for flag in (True, False):
         kwargs = {"messages": [], "is_adaptive_thinking": flag}

--- a/tests/unit/llms/google/test_sync_client.py
+++ b/tests/unit/llms/google/test_sync_client.py
@@ -179,6 +179,18 @@ def test_stream_reuses_model_specific_thinking_payload_preparation(mock_post, cl
 
 
 @pytest.mark.unit
+def test_prepare_payload_allows_thought_summaries_without_budget(client):
+    payload = client._prepare_chat_payload_for_model(
+        "gemini-2.5-pro",
+        {"generationConfig": {"thinkingConfig": {"includeThoughts": True}}},
+    )
+
+    assert payload["generationConfig"] == {
+        "thinkingConfig": {"includeThoughts": True}
+    }
+
+
+@pytest.mark.unit
 @patch("src.llm_api_adapter.llms.streaming.requests.post")
 def test_stream_closes_response_when_consumer_stops_early(mock_post, client):
     response = StreamingResponse([

--- a/tests/unit/llms/openai/test_sync_client.py
+++ b/tests/unit/llms/openai/test_sync_client.py
@@ -191,6 +191,23 @@ def test_prepare_responses_payload_preserves_temperature_for_other_gpt5_models(c
 
 
 @pytest.mark.unit
+def test_prepare_responses_payload_merges_reasoning_summary_with_effort(client):
+    payload = client._prepare_responses_payload_for_model(
+        "gpt-5",
+        {
+            "reasoning_effort": "high",
+            "capture_reasoning": True,
+        },
+    )
+
+    assert payload["reasoning"] == {
+        "effort": "high",
+        "summary": "auto",
+    }
+    assert "capture_reasoning" not in payload
+
+
+@pytest.mark.unit
 @patch("src.llm_api_adapter.llms.streaming.requests.post")
 def test_stream_closes_response_when_consumer_stops_early(mock_post, client):
     response = StreamingResponse([

--- a/tests/unit/models/responses/test_chat_response.py
+++ b/tests/unit/models/responses/test_chat_response.py
@@ -5,6 +5,7 @@ from src.llm_api_adapter.errors.llm_api_error import (
     LLMAPIError,
 )
 from src.llm_api_adapter.models.responses.chat_response import ChatResponse, Usage
+from src.llm_api_adapter.models.responses.reasoning_event import ReasoningEvent
 from src.llm_api_adapter.models.tools import ToolCall
 
 
@@ -321,6 +322,37 @@ def test_from_openai_responses_response_parses_text_and_tool_calls():
         ToolCall(name="weather", arguments={"city": "Tel Aviv"}, call_id="call_1")
     ]
     assert response.finish_reason == "completed"
+
+
+@pytest.mark.unit
+def test_from_openai_responses_response_parses_reasoning_only_when_opted_in():
+    api_response = {
+        "model": "gpt-5",
+        "output": [
+            {
+                "type": "reasoning",
+                "summary": [{"type": "summary_text", "text": "Plan"}],
+                "content": [{"type": "reasoning_text", "text": "Details"}],
+            },
+            {
+                "type": "message",
+                "content": [{"type": "output_text", "text": "Answer"}],
+            },
+        ],
+    }
+
+    without_capture = ChatResponse.from_openai_responses_response(api_response)
+    with_capture = ChatResponse.from_openai_responses_response(
+        api_response,
+        capture_reasoning=True,
+    )
+
+    assert without_capture.reasoning_events == []
+    assert with_capture.reasoning_events == [
+        ReasoningEvent("Plan", "summary", 0, 0.0, 0.0),
+        ReasoningEvent("Details", "content", 1, 0.0, 0.0),
+    ]
+    assert with_capture.content == "Answer"
 
 
 @pytest.mark.unit

--- a/tests/unit/models/responses/test_chat_response.py
+++ b/tests/unit/models/responses/test_chat_response.py
@@ -522,6 +522,34 @@ def test_from_anthropic_response():
 
 
 @pytest.mark.unit
+def test_from_anthropic_response_captures_thinking_only_when_opted_in():
+    api_response = {
+        "model": "claude-sonnet-4-5",
+        "content": [
+            {
+                "type": "thinking",
+                "thinking": "Plan",
+                "signature": "do-not-expose",
+            },
+            {"type": "redacted_thinking", "data": "do-not-expose"},
+            {"type": "text", "text": "Answer"},
+        ],
+    }
+
+    without_capture = ChatResponse.from_anthropic_response(api_response)
+    with_capture = ChatResponse.from_anthropic_response(
+        api_response,
+        capture_reasoning=True,
+    )
+
+    assert without_capture.reasoning_events == []
+    assert with_capture.reasoning_events == [
+        ReasoningEvent("Plan", "summary", 0, 0.0, 0.0),
+    ]
+    assert with_capture.content == "Answer"
+
+
+@pytest.mark.unit
 def test_from_anthropic_response_parses_tool_use_blocks():
     api_response = {
         "usage": {"input_tokens": 5, "output_tokens": 7},

--- a/tests/unit/models/responses/test_chat_response.py
+++ b/tests/unit/models/responses/test_chat_response.py
@@ -616,6 +616,35 @@ def test_from_google_response():
 
 
 @pytest.mark.unit
+def test_from_google_response_captures_thought_parts_only_when_opted_in():
+    api_response = {
+        "candidates": [{
+            "content": {
+                "parts": [
+                    {"text": "Plan", "thought": True},
+                    {"text": "Answer"},
+                    {"text": "Details", "thought": True},
+                ]
+            }
+        }],
+    }
+
+    without_capture = ChatResponse.from_google_response(api_response)
+    with_capture = ChatResponse.from_google_response(
+        api_response,
+        capture_reasoning=True,
+    )
+
+    assert without_capture.content == "Answer"
+    assert without_capture.reasoning_events == []
+    assert with_capture.content == "Answer"
+    assert with_capture.reasoning_events == [
+        ReasoningEvent("Plan", "summary", 0, 0.0, 0.0),
+        ReasoningEvent("Details", "summary", 1, 0.0, 0.0),
+    ]
+
+
+@pytest.mark.unit
 def test_from_google_response_parses_usage_and_function_call():
     api_response = {
         "usageMetadata": {

--- a/tests/unit/models/responses/test_reasoning_event.py
+++ b/tests/unit/models/responses/test_reasoning_event.py
@@ -1,0 +1,52 @@
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from src.llm_api_adapter.models import ChatResponse, ReasoningEvent
+
+
+@pytest.mark.unit
+def test_chat_response_reasoning_events_default_to_an_independent_empty_list():
+    first = ChatResponse()
+    second = ChatResponse()
+
+    assert first.reasoning_events == []
+    assert first.reasoning_events is not second.reasoning_events
+
+    first.reasoning_events.append(
+        ReasoningEvent(
+            text="summary",
+            kind="summary",
+            index=0,
+            elapsed_s=0.1,
+            delta_s=0.1,
+        )
+    )
+    assert second.reasoning_events == []
+
+
+@pytest.mark.unit
+def test_reasoning_event_is_immutable():
+    event = ReasoningEvent(
+        text="thinking",
+        kind="content",
+        index=1,
+        elapsed_s=1.5,
+        delta_s=0.5,
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        event.text = "changed"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("kind", ["invalid", "", None])
+def test_reasoning_event_rejects_unknown_kind(kind):
+    with pytest.raises(ValueError, match="kind must be 'summary' or 'content'"):
+        ReasoningEvent(
+            text="thinking",
+            kind=kind,
+            index=0,
+            elapsed_s=0.0,
+            delta_s=0.0,
+        )

--- a/tests/unit/streaming/test_reasoning_collector.py
+++ b/tests/unit/streaming/test_reasoning_collector.py
@@ -1,0 +1,60 @@
+import pytest
+
+from src.llm_api_adapter.llms.streaming import StreamReasoningCollector
+from src.llm_api_adapter.models import ReasoningEvent
+
+
+class FakeClock:
+    def __init__(self, *values):
+        self._values = iter(values)
+
+    def __call__(self):
+        return next(self._values)
+
+
+@pytest.mark.unit
+def test_collector_assigns_sequential_indices_and_timing():
+    collector = StreamReasoningCollector(clock=FakeClock(10.0, 10.2, 10.7))
+
+    first = collector.add("first summary")
+    second = collector.add("second thought", kind="content")
+
+    assert first.text == "first summary"
+    assert first.kind == "summary"
+    assert first.index == 0
+    assert first.elapsed_s == pytest.approx(0.2)
+    assert first.delta_s == pytest.approx(0.2)
+    assert second.text == "second thought"
+    assert second.kind == "content"
+    assert second.index == 1
+    assert second.elapsed_s == pytest.approx(0.7)
+    assert second.delta_s == pytest.approx(0.5)
+
+
+@pytest.mark.unit
+def test_collector_snapshot_isolated_from_internal_state():
+    collector = StreamReasoningCollector(clock=FakeClock(0.0, 0.1))
+    event = collector.add("summary")
+
+    snapshot = collector.snapshot()
+    snapshot.clear()
+
+    assert collector.snapshot() == [event]
+    assert collector.snapshot() is not snapshot
+
+
+@pytest.mark.unit
+def test_collector_skips_empty_fragments_without_consuming_clock():
+    collector = StreamReasoningCollector(clock=FakeClock(0.0, 0.1))
+
+    assert collector.add("") is None
+    assert collector.snapshot() == []
+    assert collector.add("summary").elapsed_s == pytest.approx(0.1)
+
+
+@pytest.mark.unit
+def test_collector_rejects_non_string_fragments():
+    collector = StreamReasoningCollector(clock=FakeClock(0.0))
+
+    with pytest.raises(TypeError, match="text must be a string"):
+        collector.add(None)


### PR DESCRIPTION
Adds opt-in, cross-provider reasoning observability for v0.6.2.

## Changes

- Added normalized `ReasoningEvent` primitives.
- Added `capture_reasoning` and `on_reasoning` support.
- Implemented reasoning summary/thinking streaming for:
  - OpenAI Responses API
  - Anthropic Messages API
  - Google GenerateContent API
- Shared stream state and response finalization logic across adapters.
- Added unit and contract tests.
- Added documentation and standalone `scripts/reasoning_smoke.py`.
- Bumped package version to `0.6.2`.