### PR TITLE
Release 0.7.1: CI, testing, documentation, and Python support updates

### DIFF
--- a/.github/workflows/ci-dev-release.yml
+++ b/.github/workflows/ci-dev-release.yml
@@ -1,0 +1,75 @@
+name: CI (dev release candidate)
+
+env:
+  PYTHON_VERSION: "3.10"
+
+on:
+  pull_request:
+    branches: ["dev"]
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  publish-testpypi:
+    name: Publish to TestPyPI (merged dev candidate)
+    if: ${{ github.event.pull_request.merged == true }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+
+      - name: Build dist
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+          python -m build
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/
+          verbose: true
+          skip-existing: true
+
+  post-publish-e2e:
+    name: E2E tests (post-publish)
+    if: ${{ github.event.pull_request.merged == true }}
+    runs-on: ubuntu-latest
+    needs: publish-testpypi
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+
+      - name: Wait for TestPyPI
+        run: sleep 30
+
+      - name: Install test runner and dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r tests/requirements-test.txt
+
+      - name: Install package from TestPyPI
+        run: |
+          pip install --index-url https://test.pypi.org/simple/ \
+            --extra-index-url https://pypi.org/simple \
+            llm-api-adapter
+
+      - name: Run E2E tests
+        run: pytest -v -m e2e

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -1,8 +1,5 @@
 name: CI (dev)
 
-env:
-  PYTHON_VERSION: "3.10"
-
 on:
   push:
     branches: ["dev"]
@@ -14,22 +11,26 @@ permissions:
 
 jobs:
   test:
-    name: Test (dev)
+    name: Test (dev, Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ matrix.python-version }}
           cache: pip
 
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r tests/requirements-test.txt
-          pip install -e .
+          pip install -e ".[async]"
 
       - name: Unit tests
         run: pytest -v -m unit --cov=src/llm_api_adapter --cov-report=xml
@@ -38,69 +39,23 @@ jobs:
         run: pytest -v -m integration --cov=src/llm_api_adapter --cov-report=xml --cov-append
 
       - name: Upload coverage to Codecov
+        if: ${{ matrix.python-version == '3.10' }}
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
           fail_ci_if_error: false
 
-  publish-testpypi:
-    name: Publish to TestPyPI (dev)
+  test-gate:
+    name: Test (dev)
     runs-on: ubuntu-latest
     needs: test
+    if: ${{ always() }}
 
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          cache: pip
-
-      - name: Build dist
+      - name: Verify Python matrix
         run: |
-          python -m pip install --upgrade pip
-          pip install build
-          python -m build
-
-      - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository-url: https://test.pypi.org/legacy/
-          verbose: true
-          skip-existing: true
-
-  post-publish-e2e:
-    name: e2e tests (post-publish)
-    runs-on: ubuntu-latest
-    needs: publish-testpypi
-    env:
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          cache: pip
-        
-      - name: Wait for TestPyPI
-        run: sleep 30
-
-      - name: Install test runner + deps
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r tests/requirements-test.txt
-
-      - name: Install package from TestPyPI
-        run: |
-          pip install --index-url https://test.pypi.org/simple/ \
-            --extra-index-url https://pypi.org/simple \
-            llm-api-adapter
-
-      - name: e2e tests
-        run: pytest -v -m e2e
+          if [ "${{ needs.test.result }}" != "success" ]; then
+            echo "One or more deterministic matrix jobs failed."
+            exit 1
+          fi

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Show canonical coverage summary
         if: ${{ matrix.python-version == '3.10' }}
-        run: coverage report --show-missing
+        run: coverage report --show-missing --fail-under=90
 
       - name: Upload coverage to Codecov
         if: ${{ matrix.python-version == '3.10' }}

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -38,6 +38,10 @@ jobs:
       - name: Integration tests
         run: pytest -v -m integration --cov=src/llm_api_adapter --cov-report=xml --cov-append
 
+      - name: Show canonical coverage summary
+        if: ${{ matrix.python-version == '3.10' }}
+        run: coverage report --show-missing
+
       - name: Upload coverage to Codecov
         if: ${{ matrix.python-version == '3.10' }}
         uses: codecov/codecov-action@v4

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -1,8 +1,5 @@
 name: CI (main)
 
-env:
-  PYTHON_VERSION: "3.10"
-
 on:
   push:
     branches: ["main"]
@@ -16,29 +13,48 @@ permissions:
 
 jobs:
   test:
-    name: Test (main)
+    name: Test (main, Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ matrix.python-version }}
           cache: pip
 
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r tests/requirements-test.txt
+          pip install -e ".[async]"
 
       - name: Unit & Integration Tests
         run: python tests/tests_runner.py
 
+  test-gate:
+    name: Test (main)
+    runs-on: ubuntu-latest
+    needs: test
+    if: ${{ always() }}
+
+    steps:
+      - name: Verify Python matrix
+        run: |
+          if [ "${{ needs.test.result }}" != "success" ]; then
+            echo "One or more deterministic matrix jobs failed."
+            exit 1
+          fi
+
   publish-pypi:
     name: Publish to PyPI (tagged release)
     runs-on: ubuntu-latest
-    needs: test
+    needs: test-gate
     if: startsWith(github.ref, 'refs/tags/v')
 
     steps:
@@ -46,7 +62,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: "3.10"
           cache: pip
 
       - name: Build dist

--- a/ASYNC_API.md
+++ b/ASYNC_API.md
@@ -1,0 +1,868 @@
+# Asynchronous API
+
+[← Back to the main README](README.md)
+
+`llm-api-adapter` provides an optional asynchronous API for OpenAI, Anthropic,
+and Google. It uses `httpx` and keeps the same provider-neutral messages,
+tools, structured output, file inputs, pricing, usage, and reasoning options
+as the synchronous API.
+
+## Contents
+
+- [Installation and compatibility](#installation-and-compatibility)
+- [Async request](#async-request)
+- [Messages and providers](#messages-and-providers)
+- [Async streaming](#async-streaming)
+- [Tool calling](#tool-calling)
+- [Structured output](#structured-output)
+- [Vision input](#vision-input)
+- [Document input](#document-input)
+- [Usage and pricing](#usage-and-pricing)
+- [Lifecycle and errors](#lifecycle-and-errors)
+- [Timeouts](#timeouts)
+- [Reasoning level](#reasoning-level)
+- [Reasoning observability](#reasoning-observability)
+- [Logging](#logging)
+
+## Installation and compatibility
+
+Install the optional dependency before using asynchronous methods:
+
+```bash
+pip install "llm-api-adapter[async]"
+```
+
+The `[async]` extra adds `httpx`; it is imported lazily when an async request
+is made. The synchronous API continues to use `requests` and does not require
+`httpx`.
+
+`achat()` and `astream_chat()` are available through the same
+`UniversalLLMAPIAdapter` facade for OpenAI, Anthropic, and Google. They accept
+the same provider-neutral messages, tools, structured-output, file, pricing,
+usage, and reasoning options as their synchronous counterparts.
+
+Both async methods accept the common request parameters `messages`,
+`max_tokens`, `temperature`, `top_p`, `reasoning_level`, `timeout_s`, `tools`,
+`tool_choice`, `parallel_tool_calls`, `previous_response`, `json_schema`,
+`response_model`, and `capture_reasoning`. `astream_chat()` additionally
+accepts `on_delta`, `on_tool_call`, `on_done`, `buffer_chars`, `on_chunk`, and
+`on_reasoning`, and returns an async iterator of visible text strings.
+
+`ImagePart` and `DocumentPart` are supported by both async methods. File bytes
+are encoded locally and sent in the async HTTPX request; file URLs are passed
+to the provider and are not downloaded by the adapter. As with the synchronous
+API, `DocumentPart` URLs require OpenAI Responses API models; OpenAI Chat
+Completions supports PDF bytes but not PDF URLs.
+
+## Async request
+
+```python
+import asyncio
+import os
+
+from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
+
+
+async def main():
+    adapter = UniversalLLMAPIAdapter(
+        organization="openai",
+        model="gpt-5",
+        api_key=os.environ["OPENAI_API_KEY"],
+    )
+    response = await adapter.achat(
+        messages=[{"role": "user", "content": "Explain SSE in one sentence."}],
+        max_tokens=80,
+    )
+    print(response.content)
+
+
+asyncio.run(main())
+```
+
+## Messages and providers
+
+Async requests use the same typed messages as the synchronous API: `Prompt`
+sets context, `UserMessage` adds user input, and `AIMessage` represents an
+earlier assistant response. The adapter also accepts OpenAI-style dictionaries,
+including a mix of dictionaries and typed messages in one list.
+
+```python
+import asyncio
+import os
+
+from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
+
+
+async def main():
+    adapter = UniversalLLMAPIAdapter(
+        organization="openai",
+        model="gpt-5",
+        api_key=os.environ["OPENAI_API_KEY"],
+    )
+    messages = [
+        {
+            "role": "system",
+            "content": "You are a friendly assistant who answers only yes or no.",
+        },
+        {"role": "user", "content": "Do you know how AI learns?"},
+        {"role": "assistant", "content": "Yes."},
+        {"role": "user", "content": "Can you explain it in one sentence?"},
+    ]
+    response = await adapter.achat(messages=messages, max_tokens=50)
+    print(response.content)
+
+
+asyncio.run(main())
+```
+
+Each `UniversalLLMAPIAdapter` instance is tied to one provider and model. To
+switch providers, construct another instance and await the same request shape:
+
+```python
+import asyncio
+import os
+
+from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
+
+
+async def main():
+    messages = [{"role": "user", "content": "Explain SSE in one sentence."}]
+
+    gpt = UniversalLLMAPIAdapter(
+        organization="openai",
+        model="gpt-5",
+        api_key=os.environ["OPENAI_API_KEY"],
+    )
+    print((await gpt.achat(messages=messages)).content)
+
+    claude = UniversalLLMAPIAdapter(
+        organization="anthropic",
+        model="claude-sonnet-4-5",
+        api_key=os.environ["ANTHROPIC_API_KEY"],
+    )
+    print((await claude.achat(messages=messages)).content)
+
+    google = UniversalLLMAPIAdapter(
+        organization="google",
+        model="gemini-2.5-flash",
+        api_key=os.environ["GOOGLE_API_KEY"],
+    )
+    print((await google.achat(messages=messages)).content)
+
+
+asyncio.run(main())
+```
+
+### Multi-turn conversation
+
+Use typed messages to preserve application-side conversation context, then
+await the same request shape:
+
+```python
+import asyncio
+import os
+
+from llm_api_adapter.models.messages.chat_message import AIMessage, Prompt, UserMessage
+from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
+
+
+async def main():
+    messages = [
+        Prompt("You are a friendly assistant who explains complex concepts in simple terms."),
+        UserMessage("Hi! Can you explain how artificial intelligence works?"),
+        AIMessage(
+            "Sure! Artificial intelligence (AI) is a system that can perform "
+            "tasks requiring human-like intelligence, such as recognizing images "
+            "or understanding language."
+        ),
+        UserMessage("How does AI learn?"),
+    ]
+    adapter = UniversalLLMAPIAdapter(
+        organization="openai",
+        model="gpt-5",
+        api_key=os.environ["OPENAI_API_KEY"],
+    )
+    response = await adapter.achat(
+        messages=messages,
+        max_tokens=256,
+        temperature=1.0,
+        top_p=1.0,
+    )
+    print(response.content)
+
+
+asyncio.run(main())
+```
+
+## Async streaming
+
+```python
+import asyncio
+import os
+
+from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
+
+
+async def main():
+    adapter = UniversalLLMAPIAdapter(
+        organization="anthropic",
+        model="claude-sonnet-4-5",
+        api_key=os.environ["ANTHROPIC_API_KEY"],
+    )
+
+    async def on_chunk(chunk):
+        print(f"chunk {chunk.index}: {chunk.text!r}")
+
+    async def on_done(response):
+        print(f"\nusage: {response.usage}")
+
+    async for delta in adapter.astream_chat(
+        messages=[{"role": "user", "content": "Explain SSE in one sentence."}],
+        max_tokens=80,
+        buffer_chars=80,
+        on_chunk=on_chunk,
+        on_done=on_done,
+    ):
+        print(delta, end="", flush=True)
+
+
+asyncio.run(main())
+```
+
+`astream_chat()` always yields normalized visible text as `str`. It uses a
+separate `httpx.AsyncClient` transport, while preserving the same
+provider-neutral response and callback contract as `stream_chat()`.
+
+- `buffer_chars` accepts `None` (the default) or a positive integer. Buffered
+  chunks never exceed the configured size; remaining text is emitted during
+  normal completion.
+- `on_chunk(chunk)` receives a `StreamChunk` with `text`, monotonic `index`,
+  local `elapsed_s` / `delta_s`, and optional `usage` /
+  `output_tokens_delta` fields.
+- `on_delta(text)` is called for every yielded visible text chunk. The order is
+  always `on_chunk` → `on_delta` → `yield`.
+- `on_tool_call(tool_call)` receives completed, normalized `ToolCall` objects
+  after the provider stream finishes.
+- `on_done(response)` receives the finalized `ChatResponse`, including usage,
+  pricing, parsed structured output, and tool calls, after the final buffer
+  flush.
+- Token metadata is optional and comes only from provider usage payloads. When
+  a provider reports cumulative output usage, `output_tokens_delta` is the
+  local increment; no token estimation is performed.
+
+Async callbacks may be regular functions or `async def` functions. For every
+visible chunk, callbacks are processed serially in this order:
+`on_chunk` → `on_delta` → `yield`. Reasoning callbacks follow the same awaited
+ordering and reasoning text is never yielded as visible output.
+
+Buffering is pull-based and has no background worker or time-based flush. If a
+stream fails or a caller closes it early, pending text is not emitted as a
+successful final chunk and `on_done` is not called.
+
+Provider event references: [OpenAI Responses streaming](https://platform.openai.com/docs/api-reference/responses-streaming), [Anthropic streaming](https://platform.claude.com/docs/en/build-with-claude/streaming), and [Google `streamGenerateContent`](https://ai.google.dev/api/generate-content).
+
+## Tool calling
+
+`achat()` and `astream_chat()` accept the same `tools`, `tool_choice`, and
+`parallel_tool_calls` arguments as the synchronous API. `achat()` exposes
+normalized calls in `ChatResponse.tool_calls`. During async streaming,
+completed calls are delivered through `on_tool_call`, which may be a regular
+or async function.
+
+The adapter does not execute tools. Your application executes each call,
+appends the resulting `ToolMessage`, and makes the follow-up request. This
+complete async example handles every tool call in a response:
+
+```python
+import asyncio
+import json
+import os
+from typing import Any, Dict
+
+from llm_api_adapter.models.messages.chat_message import (
+    AIMessage,
+    Prompt,
+    ToolMessage,
+    UserMessage,
+)
+from llm_api_adapter.models.tools import ToolSpec
+from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
+
+
+tools = [
+    ToolSpec(
+        name="get_weather",
+        description="Get current weather for a city",
+        json_schema={
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+            "additionalProperties": False,
+        },
+    )
+]
+
+
+def run_tool(name: str, args: Dict[str, Any]) -> Dict[str, Any]:
+    if name == "get_weather":
+        return {"city": args["city"], "temperature": 22, "unit": "C"}
+    raise ValueError(f"Unknown tool: {name}")
+
+
+async def main():
+    adapter = UniversalLLMAPIAdapter(
+        organization="openai",
+        model="gpt-5.2",
+        api_key=os.environ["OPENAI_API_KEY"],
+    )
+    messages = [
+        Prompt("If the user asks about weather, call get_weather."),
+        UserMessage("What's the weather in Tel Aviv today?"),
+    ]
+
+    first = await adapter.achat(
+        messages=messages,
+        tools=tools,
+        tool_choice="auto",
+        max_tokens=1000,
+    )
+
+    if not first.tool_calls:
+        print(first.content)
+        return
+
+    messages.append(AIMessage(content="", tool_calls=first.tool_calls))
+    for tool_call in first.tool_calls:
+        result = run_tool(tool_call.name, tool_call.arguments)
+        messages.append(
+            ToolMessage(
+                tool_call_id=tool_call.call_id,
+                content=json.dumps(result),
+            )
+        )
+
+    final = await adapter.achat(
+        messages=messages,
+        previous_response=first,
+        max_tokens=1000,
+    )
+    print(final.content)
+
+
+asyncio.run(main())
+```
+
+For OpenAI Responses API models, `previous_response=first` preserves the
+provider-side conversation state. Anthropic and Google accept the parameter
+but carry context entirely through `messages`.
+
+## Structured output
+
+`achat()` accepts both `response_model` and `json_schema`. Its response has the
+same `parsed_model` and `parsed_json` fields as the synchronous API. With
+`astream_chat()`, inspect those fields on the final `ChatResponse` passed to
+`on_done`.
+
+### Pydantic model
+
+```python
+import asyncio
+import os
+
+from pydantic import BaseModel
+
+from llm_api_adapter.models.messages.chat_message import Prompt, UserMessage
+from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
+
+
+class Person(BaseModel):
+    name: str
+    age: int
+
+
+async def main():
+    adapter = UniversalLLMAPIAdapter(
+        organization="openai",
+        model="gpt-5",
+        api_key=os.environ["OPENAI_API_KEY"],
+    )
+    response = await adapter.achat(
+        messages=[
+            Prompt("Extract structured data from the user's message."),
+            UserMessage("My name is Alice and I'm 30 years old."),
+        ],
+        response_model=Person,
+        max_tokens=200,
+    )
+    print(response.parsed_model)  # Person(name='Alice', age=30)
+    print(response.parsed_json)   # {"name": "Alice", "age": 30}
+
+
+asyncio.run(main())
+```
+
+Pydantic is optional: install it separately with `pip install pydantic`.
+
+### Raw JSON Schema
+
+```python
+import asyncio
+import os
+
+from llm_api_adapter.models.messages.chat_message import Prompt, UserMessage
+from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
+
+
+schema = {
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "age": {"type": "integer"},
+    },
+    "required": ["name", "age"],
+}
+
+
+async def main():
+    adapter = UniversalLLMAPIAdapter(
+        organization="openai",
+        model="gpt-5",
+        api_key=os.environ["OPENAI_API_KEY"],
+    )
+    response = await adapter.achat(
+        messages=[
+            Prompt("Extract structured data from the user's message."),
+            UserMessage("My name is Alice and I'm 30 years old."),
+        ],
+        json_schema=schema,
+        max_tokens=200,
+    )
+    print(response.content)      # '{"name": "Alice", "age": 30}'
+    print(response.parsed_json)  # {"name": "Alice", "age": 30}
+
+
+asyncio.run(main())
+```
+
+`response_model`, `json_schema`, and `tools` cannot be combined in one
+request. Invalid schemas or non-JSON structured responses raise
+`JSONSchemaError`.
+
+## Vision input
+
+Use `ImagePart` with `UserMessage.files`, then await `achat()` exactly as for a
+text-only request. URL images and raw bytes work with all supported providers.
+
+```python
+import asyncio
+import os
+
+from llm_api_adapter.models.messages.chat_message import UserMessage
+from llm_api_adapter.models.messages.file_parts import ImagePart
+from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
+
+
+async def main():
+    adapter = UniversalLLMAPIAdapter(
+        organization="openai",
+        model="gpt-5",
+        api_key=os.environ["OPENAI_API_KEY"],
+    )
+    message = UserMessage(
+        "What is in this image?",
+        files=[ImagePart(url="https://example.com/photo.jpg")],
+    )
+    response = await adapter.achat(messages=[message], max_tokens=200)
+    print(response.content)
+
+
+asyncio.run(main())
+```
+
+```python
+import asyncio
+import os
+
+from llm_api_adapter.models.messages.chat_message import UserMessage
+from llm_api_adapter.models.messages.file_parts import ImagePart
+from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
+
+
+async def main():
+    with open("photo.png", "rb") as image_file:
+        image_bytes = image_file.read()
+
+    adapter = UniversalLLMAPIAdapter(
+        organization="openai",
+        model="gpt-5",
+        api_key=os.environ["OPENAI_API_KEY"],
+    )
+    message = UserMessage(
+        "Describe this image.",
+        files=[ImagePart(data=image_bytes, media_type="image/png")],
+    )
+    response = await adapter.achat(messages=[message], max_tokens=200)
+    print(response.content)
+
+
+asyncio.run(main())
+```
+
+Multiple images use the same `files` list:
+
+```python
+message = UserMessage(
+    "Compare these two images.",
+    files=[
+        ImagePart(url="https://example.com/before.jpg"),
+        ImagePart(url="https://example.com/after.jpg"),
+    ],
+)
+```
+
+`ImagePart` accepts MIME types that start with `image/`; for URLs without a
+file extension, pass `media_type` explicitly. Existing OpenAI-style image
+dictionaries are also accepted:
+
+```python
+import asyncio
+import os
+
+from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
+
+
+async def main():
+    adapter = UniversalLLMAPIAdapter(
+        organization="openai",
+        model="gpt-5",
+        api_key=os.environ["OPENAI_API_KEY"],
+    )
+    messages = [{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "What is this?"},
+            {"type": "image_url", "image_url": {"url": "https://example.com/img.jpg"}},
+        ],
+    }]
+    response = await adapter.achat(messages=messages, max_tokens=200)
+    print(response.content)
+
+
+asyncio.run(main())
+```
+
+## Document input
+
+Use `DocumentPart` with `UserMessage.files` for PDF URLs or bytes:
+
+```python
+import asyncio
+import os
+
+from llm_api_adapter.models.messages.chat_message import UserMessage
+from llm_api_adapter.models.messages.file_parts import DocumentPart
+from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
+
+
+async def main():
+    adapter = UniversalLLMAPIAdapter(
+        organization="openai",
+        model="gpt-5",
+        api_key=os.environ["OPENAI_API_KEY"],
+    )
+    message = UserMessage(
+        "Summarize this document in one sentence.",
+        files=[DocumentPart(url="https://example.com/report.pdf")],
+    )
+    response = await adapter.achat(messages=[message], max_tokens=200)
+    print(response.content)
+
+
+asyncio.run(main())
+```
+
+```python
+import asyncio
+import os
+
+from llm_api_adapter.models.messages.chat_message import UserMessage
+from llm_api_adapter.models.messages.file_parts import DocumentPart
+from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
+
+
+async def main():
+    with open("report.pdf", "rb") as document_file:
+        pdf_bytes = document_file.read()
+
+    adapter = UniversalLLMAPIAdapter(
+        organization="openai",
+        model="gpt-5",
+        api_key=os.environ["OPENAI_API_KEY"],
+    )
+    message = UserMessage(
+        "Summarize this document in one sentence.",
+        files=[DocumentPart(data=pdf_bytes, media_type="application/pdf")],
+    )
+    response = await adapter.achat(messages=[message], max_tokens=200)
+    print(response.content)
+
+
+asyncio.run(main())
+```
+
+The adapter encodes bytes locally and does not download file URLs. Anthropic,
+Google, and OpenAI Responses API models accept PDF URLs; OpenAI Chat
+Completions models below `gpt-5` require PDF bytes instead.
+
+## Usage and pricing
+
+`achat()` returns the same `usage`, `currency`, and cost fields as `chat()`.
+For `astream_chat()`, the finalized response passed to `on_done` has those
+fields, while `StreamChunk.usage` is available when a provider reports usage
+during streaming.
+
+```python
+import asyncio
+import os
+
+from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
+
+
+async def main():
+    google = UniversalLLMAPIAdapter(
+        organization="google",
+        model="gemini-2.5-flash",
+        api_key=os.environ["GOOGLE_API_KEY"],
+    )
+    response = await google.achat(
+        messages=[{"role": "user", "content": "Explain token usage briefly."}],
+    )
+
+    print(response.usage.input_tokens, "tokens", f"({response.cost_input} {response.currency})")
+    print(response.usage.output_tokens, "tokens", f"({response.cost_output} {response.currency})")
+    print(response.usage.total_tokens, "tokens", f"({response.cost_total} {response.currency})")
+
+
+asyncio.run(main())
+```
+
+Override registry pricing or currency on an adapter instance before awaiting
+the request:
+
+```python
+import asyncio
+import os
+
+from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
+
+
+async def main():
+    google = UniversalLLMAPIAdapter(
+        organization="google",
+        model="gemini-2.5-flash",
+        api_key=os.environ["GOOGLE_API_KEY"],
+    )
+    google.pricing.set_in_per_1m(1.5)
+    google.pricing.set_out_per_1m(3)
+    google.pricing.set_currency("EUR")
+
+    response = await google.achat(
+        messages=[{"role": "user", "content": "Explain token usage briefly."}],
+    )
+    print(response.content)
+    print(response.usage.total_tokens, "tokens", f"({response.cost_total} {response.currency})")
+
+
+asyncio.run(main())
+```
+
+## Lifecycle and errors
+
+Async requests do not add automatic retries, provider fallback, or idempotency
+behavior. If a task is cancelled, the HTTP response and client are closed;
+pending text is not flushed and `on_done` is not called. The same cleanup
+applies when an async stream is closed before normal completion.
+
+Async HTTPX requests use the same `LLMAPIError` hierarchy as synchronous
+requests. Authentication, rate-limit, client, server, and timeout failures are
+normalized to the same provider-neutral exceptions. See [error handling in the
+main README](README.md#handling-errors) for the exception reference.
+
+## Timeouts
+
+`timeout_s` applies to `achat()` and `astream_chat()` as well as the
+synchronous methods. It limits the full request lifecycle; if it expires, the
+adapter raises `LLMAPITimeoutError`.
+
+```python
+import asyncio
+import os
+
+from llm_api_adapter.errors import LLMAPITimeoutError
+from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
+
+
+async def main():
+    adapter = UniversalLLMAPIAdapter(
+        organization="openai",
+        model="gpt-5.2",
+        api_key=os.environ["OPENAI_API_KEY"],
+    )
+    try:
+        response = await adapter.achat(
+            messages=[{"role": "user", "content": "Explain timeouts briefly."}],
+            timeout_s=2.5,
+        )
+        print(response.content)
+    except LLMAPITimeoutError:
+        # Retry, fall back, or abort according to your application policy.
+        print("LLM request timed out")
+
+
+asyncio.run(main())
+```
+
+## Reasoning level
+
+`reasoning_level` is provider-neutral and applies to `achat()` and
+`astream_chat()`. It accepts an explicit integer or one of `"none"`, `"low"`,
+`"medium"`, and `"high"`. The adapters translate this intent to the native
+provider setting; availability and token semantics remain model-dependent.
+
+```python
+import asyncio
+import os
+
+from llm_api_adapter.models.messages.chat_message import UserMessage
+from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
+
+
+async def main():
+    adapter = UniversalLLMAPIAdapter(
+        organization="openai",
+        model="gpt-5",
+        api_key=os.environ["OPENAI_API_KEY"],
+    )
+
+    named_level = await adapter.achat(
+        messages=[UserMessage("Explain this")],
+        reasoning_level="medium",
+    )
+    print(named_level.content)
+
+    explicit_level = await adapter.achat(
+        messages=[UserMessage("Solve this step-by-step")],
+        reasoning_level=2048,
+    )
+    print(explicit_level.content)
+
+    default_level = await adapter.achat(
+        messages=[UserMessage("Simple answer, no reasoning")],
+    )
+    print(default_level.content)
+
+
+asyncio.run(main())
+```
+
+## Reasoning observability
+
+Reasoning observability is opt-in and additive. Set `capture_reasoning=True` to
+retain provider-emitted reasoning summaries or readable thinking content in
+`ChatResponse.reasoning_events`.
+
+With `achat()`, the events are available on the returned `ChatResponse`. With
+`astream_chat()`, they are delivered through `on_reasoning` and included in the
+final response passed to `on_done`.
+
+The stream still yields only visible text. Reasoning events are never sent to
+`on_delta` and never appear in the iterator. When supplied,
+`on_reasoning(event)` is called as each event is normalized;
+`on_done(response)` receives the complete `response.reasoning_events` list.
+
+```python
+import asyncio
+import os
+
+from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
+
+
+async def main():
+    adapter = UniversalLLMAPIAdapter(
+        organization="openai",
+        model="gpt-5",
+        api_key=os.environ["OPENAI_API_KEY"],
+    )
+
+    async def observe_reasoning(event):
+        # Application code decides what to log, redact, retain, or display.
+        print(f"reasoning[{event.index}]: {event.text}")
+
+    async def on_done(response):
+        print(f"captured {len(response.reasoning_events)} reasoning events")
+
+    async for text in adapter.astream_chat(
+        messages=[{"role": "user", "content": "Explain SSE briefly."}],
+        capture_reasoning=True,
+        on_reasoning=observe_reasoning,
+        on_done=on_done,
+    ):
+        print(text, end="", flush=True)
+
+
+asyncio.run(main())
+```
+
+`ReasoningEvent` contains `text`, `kind`, `index`, `elapsed_s`, and `delta_s`.
+Availability and content depend on the provider and model; an empty list is a
+valid result. The library does not automatically log, display, redact, or send
+reasoning to telemetry, and it does not promise access to a model's private
+chain of thought. Applications should apply their own redaction and retention
+policy.
+
+## Logging
+
+Async requests use the same standard-library logging setup as synchronous
+requests. The library configures no handlers; its loggers are under
+`llm_api_adapter.*`. API keys and request bodies are excluded from library logs.
+
+```python
+import logging
+
+logging.basicConfig(level=logging.INFO)  # or DEBUG
+logging.getLogger("llm_api_adapter").setLevel(logging.DEBUG)
+```
+
+```python
+import logging
+
+handler = logging.FileHandler("llm_api_adapter.log")
+handler.setFormatter(logging.Formatter(
+    "%(asctime)s %(levelname)s %(name)s %(message)s"
+))
+root = logging.getLogger()
+root.setLevel(logging.INFO)
+root.addHandler(handler)
+```
+
+Use `LoggerAdapter` for an application-level request ID:
+
+```python
+import logging
+
+logger = logging.LoggerAdapter(
+    logging.getLogger("llm_api_adapter"),
+    {"request_id": "req-123"},
+)
+logger.info("starting async request")
+```
+
+Add `%(request_id)s` to the formatter to display that value. To reduce noise,
+adjust the library and HTTPX logger levels:
+
+```python
+import logging
+
+logging.getLogger("llm_api_adapter").setLevel(logging.WARNING)
+logging.getLogger("httpx").setLevel(logging.WARNING)
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,8 @@ python -m pytest -v -m integration
 python tests/tests_runner.py
 ```
 
+The `dev` and `main` CI workflows run this deterministic coverage across Python 3.9, 3.10, 3.11, 3.12, and 3.13. Provider keys and live E2E calls are excluded from every matrix job.
+
 Keep deterministic tests free of network access, provider credentials, and model-specific prompt tuning. New provider behavior should use sanitized fixtures or mocked transports.
 
 ## E2E tests and provider keys
@@ -73,7 +75,7 @@ The required environment variables are:
 
 Async E2E checks use the latest registered model for each provider by default; providers without configured API keys are skipped. Override a provider's model only when needed with `ASYNC_E2E_OPENAI_MODEL`, `ASYNC_E2E_ANTHROPIC_MODEL`, or `ASYNC_E2E_GOOGLE_MODEL`.
 
-For a release candidate, open a pull request to `main` first. After review and deterministic CI pass, the maintainer promotes that exact candidate commit to `dev`. The current [dev workflow](.github/workflows/ci-dev.yml) runs deterministic unit and integration tests with coverage, publishes the package to TestPyPI, and then runs the paid E2E marker. That marker currently exercises all registered models in the synchronous scenarios, while async scenarios select one latest registered model per provider. After the workflow passes, the maintainer manually installs the TestPyPI package and verifies the changed behavior and critical flows before merging the pull request. Do not ask contributors to push to `dev`, open pull requests to `dev`, run the paid job as part of a deterministic PR matrix, or multiply it across Python versions.
+For a release candidate, open a pull request to `main` first. After review and deterministic CI pass, the maintainer promotes that exact candidate commit through a staging pull request to `dev`. The `dev` branch is protected by an active repository ruleset: direct updates are restricted, pull requests are required, and only repository administrators are on the bypass list. The [dev workflow](.github/workflows/ci-dev.yml) runs deterministic unit and integration tests with coverage. Only after the staging pull request is merged does the separate [dev release workflow](.github/workflows/ci-dev-release.yml) publish the package to TestPyPI and run E2E tests that make paid calls to the configured providers. The synchronous scenarios currently exercise all registered models, while async scenarios select one latest registered model per provider. After the workflow passes, the maintainer manually installs the TestPyPI package and verifies the changed behavior and critical flows before merging the pull request to `main`. Do not push directly to `dev`, and do not run these paid provider calls as part of a deterministic PR matrix or multiply them across Python versions.
 
 ## Provider-key safety
 
@@ -124,9 +126,11 @@ Use `--prompt` to test another task. The script prints reasoning summaries and v
    ```
 
 4. Open or update the pull request to `main`. Wait for review and the deterministic main CI to pass.
-5. The maintainer pushes that exact candidate commit to `dev`. The dev workflow publishes it to TestPyPI and runs the current post-publish E2E job. Provide keys through CI Secrets only, and remember that the current synchronous E2E scenarios may exercise every registered model. Do not use a pull request to `dev` for this promotion.
+5. The maintainer opens and merges a staging pull request containing that exact candidate commit into protected `dev`. The dev release workflow then publishes it to TestPyPI and runs E2E tests that make paid calls to the configured providers. Only an approved repository administrator should merge this staging pull request. Provide keys through CI Secrets only, and remember that the current synchronous E2E scenarios may exercise every registered model.
 6. After the E2E job passes, the maintainer manually installs the package from TestPyPI and verifies the changed behavior, critical flows, and absence of regressions.
 7. Merge the already verified pull request into `main`.
 8. After the pull request is merged, create the release tag so the main workflow publishes the final package.
 
-The post-publish E2E job is a release-candidate gate, not a general development check. Keep it out of pull-request jobs and Python-version matrices so paid calls remain bounded.
+The post-publish E2E job is a release-candidate gate, not a general development check. Keep it out of pull-request jobs and Python-version matrices so paid provider calls remain bounded.
+
+To keep this gate maintainer-controlled, protect `dev` with an active repository ruleset that targets only `dev`, requires a pull request before merging, restricts updates, blocks force pushes, and grants bypass only to the approved repository administrators. The `Require a pull request before merging` rule is essential: `Restrict updates` alone still permits an administrator to push directly to `dev`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ Keep deterministic tests free of network access, provider credentials, and model
 
 ## Coverage baseline
 
-The recorded deterministic baseline (2026-08-03) is **93.29% line coverage** (`2,946 / 3,158` lines), measured on Python 3.10 across the unit and mocked-integration suites. The measured scope is `src/llm_api_adapter`; E2E tests, provider calls, and credentials are excluded. Python 3.10 is the canonical coverage lane, while the other matrix versions verify compatibility. This baseline is informational for now; no minimum threshold is enforced yet. Do not update it for ordinary releases; refresh it only when intentionally approving a new baseline and threshold.
+The recorded deterministic baseline (2026-08-03) is **93.29% line coverage** (`2,946 / 3,158` lines), measured on Python 3.10 across the unit and mocked-integration suites. The measured scope is `src/llm_api_adapter`; E2E tests, provider calls, and credentials are excluded. Python 3.10 is the canonical coverage lane, while the other matrix versions verify compatibility. CI now enforces a **90% non-regression threshold** on this canonical report. Do not update the baseline for ordinary releases; refresh it only when intentionally approving a new baseline and threshold.
 
 To reproduce the combined report locally:
 
@@ -72,6 +72,7 @@ python -m pytest -q -m integration \
   --cov-append \
   --cov-report=term-missing \
   --cov-report=xml:coverage.xml
+python -m coverage report --show-missing --fail-under=90
 ```
 
 ## E2E tests and provider keys

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ This guide covers local development, deterministic tests, paid provider checks, 
 
 ## Local setup
 
-The project supports Python 3.9 and newer. It uses a `src/` layout and keeps provider SDKs out of the runtime dependencies.
+The project supports Python 3.10 and newer. It uses a `src/` layout and keeps provider SDKs out of the runtime dependencies.
 
 Create an isolated environment and install the test and editable package dependencies:
 
@@ -53,7 +53,7 @@ python -m pytest -v -m integration
 python tests/tests_runner.py
 ```
 
-The `dev` and `main` CI workflows run this deterministic coverage across Python 3.9, 3.10, 3.11, 3.12, 3.13, and 3.14. Provider keys and live E2E calls are excluded from every matrix job.
+The `dev` and `main` CI workflows run this deterministic coverage across Python 3.10, 3.11, 3.12, 3.13, and 3.14. Provider keys and live E2E calls are excluded from every matrix job.
 
 Keep deterministic tests free of network access, provider credentials, and model-specific prompt tuning. New provider behavior should use sanitized fixtures or mocked transports.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,132 @@
+# Contributing
+
+This guide covers local development, deterministic tests, paid provider checks, documentation maintenance, and releases for `llm-api-adapter`.
+
+## Local setup
+
+The project supports Python 3.9 and newer. It uses a `src/` layout and keeps provider SDKs out of the runtime dependencies.
+
+Create an isolated environment and install the test and editable package dependencies:
+
+```bash
+python -m venv .venv
+```
+
+PowerShell:
+
+```powershell
+.\.venv\Scripts\Activate.ps1
+python -m pip install --upgrade pip
+python -m pip install -r tests/requirements-test.txt
+python -m pip install -e .
+```
+
+POSIX shells:
+
+```bash
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -r tests/requirements-test.txt
+python -m pip install -e .
+```
+
+## Deterministic test suite
+
+Unit tests are offline. Integration tests use mocked HTTP and provider-shaped responses. Neither suite requires provider credentials or makes paid API calls.
+
+Run both deterministic suites:
+
+```bash
+python -m pytest -q -m "unit or integration"
+```
+
+Run one suite while iterating:
+
+```bash
+python -m pytest -v -m unit
+python -m pytest -v -m integration
+```
+
+`tests/tests_runner.py` is the same unit-then-integration sequence used by the main CI workflow:
+
+```bash
+python tests/tests_runner.py
+```
+
+Keep deterministic tests free of network access, provider credentials, and model-specific prompt tuning. New provider behavior should use sanitized fixtures or mocked transports.
+
+## E2E tests and provider keys
+
+E2E tests make real provider requests and may incur charges. Run them only deliberately, outside pull-request and Python-version matrix jobs.
+
+The full E2E marker runs the scenarios under `tests/e2e/`; many scenarios iterate over the models registered for each provider, so this command can make more than one request per provider:
+
+```bash
+python -m pytest -v -m e2e
+```
+
+The required environment variables are:
+
+- `OPENAI_API_KEY`
+- `ANTHROPIC_API_KEY`
+- `GOOGLE_API_KEY`
+
+Async E2E checks use the latest registered model for each provider by default; providers without configured API keys are skipped. Override a provider's model only when needed with `ASYNC_E2E_OPENAI_MODEL`, `ASYNC_E2E_ANTHROPIC_MODEL`, or `ASYNC_E2E_GOOGLE_MODEL`.
+
+For a release candidate, open a pull request to `main` first. After review and deterministic CI pass, the maintainer promotes that exact candidate commit to `dev`. The current [dev workflow](.github/workflows/ci-dev.yml) runs deterministic unit and integration tests with coverage, publishes the package to TestPyPI, and then runs the paid E2E marker. That marker currently exercises all registered models in the synchronous scenarios, while async scenarios select one latest registered model per provider. After the workflow passes, the maintainer manually installs the TestPyPI package and verifies the changed behavior and critical flows before merging the pull request. Do not ask contributors to push to `dev`, open pull requests to `dev`, run the paid job as part of a deterministic PR matrix, or multiply it across Python versions.
+
+## Provider-key safety
+
+- Keep keys in local environment variables, an ignored local `.env`, or GitHub Actions Secrets.
+- Never commit keys or place them in fixtures, examples, issue reports, logs, CI artifacts, or documentation.
+- Review `git diff` before sharing changes or artifacts.
+- Treat reasoning output, tool arguments, and `--dump-raw` SSE payloads as potentially sensitive. Redact them before sharing.
+- Do not add provider credentials to a test just to make it pass locally.
+
+## Reasoning smoke script
+
+`scripts/reasoning_smoke.py` is a manual live check, not part of the pytest E2E suite or CI. It uses the default dog-and-potato prompt unless another prompt is supplied:
+
+```powershell
+python scripts/reasoning_smoke.py `
+  --provider openai `
+  --model gpt-5.6-sol `
+  --require-reasoning `
+  --dump-raw
+```
+
+Use `--prompt` to test another task. The script prints reasoning summaries and visible answers as they arrive and can dump raw provider events for diagnostics. Raw output may contain model-generated reasoning, tool arguments, or other sensitive response data; keep it local and redact it before sharing.
+
+## Documentation maintenance
+
+- Keep README focused on the public package contract, installation, and user-facing examples.
+- Keep contributor setup, test commands, provider-key rules, CI details, and release procedures in this guide.
+- Update the relevant documentation when public behavior, provider mappings, or test workflows change. Keep `docs/architecture.json` minimal and place topical details in its linked detail files.
+- Examples must not require credentials merely to import. Live calls should be explicit and documented.
+- When code or project artifacts change, run `graphify update .` and review the resulting diff.
+
+## Release flow
+
+1. Confirm the package version and release notes describe the user-visible changes.
+2. Run the same deterministic unit-then-integration sequence used by the main CI workflow, without provider keys:
+
+   ```bash
+   python tests/tests_runner.py
+   ```
+
+   The dev workflow collects coverage separately while running its unit and integration jobs.
+
+3. Build and inspect the distribution:
+
+   ```bash
+   python -m pip install build
+   python -m build
+   ```
+
+4. Open or update the pull request to `main`. Wait for review and the deterministic main CI to pass.
+5. The maintainer pushes that exact candidate commit to `dev`. The dev workflow publishes it to TestPyPI and runs the current post-publish E2E job. Provide keys through CI Secrets only, and remember that the current synchronous E2E scenarios may exercise every registered model. Do not use a pull request to `dev` for this promotion.
+6. After the E2E job passes, the maintainer manually installs the package from TestPyPI and verifies the changed behavior, critical flows, and absence of regressions.
+7. Merge the already verified pull request into `main`.
+8. After the pull request is merged, create the release tag so the main workflow publishes the final package.
+
+The post-publish E2E job is a release-candidate gate, not a general development check. Keep it out of pull-request jobs and Python-version matrices so paid calls remain bounded.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,23 @@ The `dev` and `main` CI workflows run this deterministic coverage across Python 
 
 Keep deterministic tests free of network access, provider credentials, and model-specific prompt tuning. New provider behavior should use sanitized fixtures or mocked transports.
 
+## Coverage baseline
+
+The recorded deterministic baseline (2026-08-03) is **93.29% line coverage** (`2,946 / 3,158` lines), measured on Python 3.10 across the unit and mocked-integration suites. The measured scope is `src/llm_api_adapter`; E2E tests, provider calls, and credentials are excluded. Python 3.10 is the canonical coverage lane, while the other matrix versions verify compatibility. This baseline is informational for now; no minimum threshold is enforced yet. Do not update it for ordinary releases; refresh it only when intentionally approving a new baseline and threshold.
+
+To reproduce the combined report locally:
+
+```bash
+python -m pytest -q -m unit \
+  --cov=src/llm_api_adapter \
+  --cov-report=
+python -m pytest -q -m integration \
+  --cov=src/llm_api_adapter \
+  --cov-append \
+  --cov-report=term-missing \
+  --cov-report=xml:coverage.xml
+```
+
 ## E2E tests and provider keys
 
 E2E tests make real provider requests and may incur charges. Run them only deliberately, outside pull-request and Python-version matrix jobs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ python -m pytest -v -m integration
 python tests/tests_runner.py
 ```
 
-The `dev` and `main` CI workflows run this deterministic coverage across Python 3.9, 3.10, 3.11, 3.12, and 3.13. Provider keys and live E2E calls are excluded from every matrix job.
+The `dev` and `main` CI workflows run this deterministic coverage across Python 3.9, 3.10, 3.11, 3.12, 3.13, and 3.14. Provider keys and live E2E calls are excluded from every matrix job.
 
 Keep deterministic tests free of network access, provider credentials, and model-specific prompt tuning. New provider behavior should use sanitized fixtures or mocked transports.
 

--- a/README.md
+++ b/README.md
@@ -1153,65 +1153,7 @@ provider-neutral interface unchanged.
 
 ## Development & Testing
 
-> **Note**  
-> This section is intended for developers working with the source code from GitHub.  
-> It is **not** relevant for users installing the package from PyPI.
-
-This project uses `pytest` for testing. Tests are located in the `tests/` directory.
-
-### Test suites
-
-- **unit**: fast, offline, no real provider calls
-- **integration**: adapter-level integration tests (may use mocked/provider-shaped responses)
-- **e2e**: real API calls against providers (requires API keys)
-
-### Running tests
-
-Run everything:
-
-```bash
-pytest
-```
-
-Run by marker:
-
-```bash
-pytest -m unit
-pytest -m integration
-pytest -m e2e
-```
-
-### E2E requirements
-
-E2E tests require provider API keys to be present in environment variables:
-
-- `OPENAI_API_KEY`
-- `ANTHROPIC_API_KEY`
-- `GOOGLE_API_KEY`
-
-### Reasoning smoke script
-
-The standalone [reasoning_smoke.py](scripts/reasoning_smoke.py) script is intended for
-manual live checks and is not part of the pytest E2E suite or CI. It uses the
-default dog-and-potato prompt unless another prompt is supplied:
-
-```powershell
-python scripts/reasoning_smoke.py `
-  --provider openai `
-  --model gpt-5.6-sol `
-  --require-reasoning `
-  --dump-raw
-```
-
-Use `--prompt` to test another task. During the request, the reasoning summary
-is printed under `[summary]`, and the visible answer under a `-------------`
-separator and `[final answer]`, as they arrive. A successful run ends after
-the final answer; diagnostic JSON is printed only when expected reasoning is
-missing or callback finalization differs. The script also captures every
-decoded provider SSE event before adapter parsing. If no normalized reasoning
-event is found or the stream fails, it prints event names and payload keys;
-`--dump-raw` also prints the complete payloads. Raw output may contain
-model-generated reasoning, tool arguments, or other sensitive response data.
+Developer setup, deterministic unit and mocked-integration commands, paid E2E requirements, provider-key safety, documentation rules, and the release flow are documented in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ This table is a positioning snapshot. Provider capabilities change independently
 ### Use something else when
 
 - **LiteLLM** — you need providers beyond OpenAI, Anthropic/Claude, and Google, or a gateway/router layer with retries, fallbacks, load balancing, and observability
+- **AISuite** — you prefer an OpenAI-compatible client across more providers, or built-in agents, MCP, and automatic tool-execution abstractions
 - **LangChain** — you need chains, memory, RAG, agents, or a larger orchestration framework
 - **Provider SDK directly** — you use one provider and need an API or feature outside this SDK's provider-neutral contract
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,15 @@
 [![Python versions](https://img.shields.io/pypi/pyversions/llm-api-adapter.svg)](https://pypi.org/project/llm-api-adapter/)
 [![codecov](https://codecov.io/github/Inozem/llm_api_adapter/branch/dev/graph/badge.svg?token=T83ZPH1F7Z)](https://codecov.io/github/Inozem/llm_api_adapter)
 
-<details>
-<summary>Contents</summary>
+## Overview
+
+Calling an LLM from Python usually means choosing between a provider-specific SDK, a larger application framework, or an API gateway.
+
+**llm-api-adapter** is a minimal, typed multi-provider adapter for OpenAI, Anthropic, and Google. It provides one provider-neutral contract for messages, tools, structured output, multimodal input, errors, usage, cost, and streaming — with one runtime dependency and no provider SDKs or orchestration framework. Switching providers means changing two arguments.
+
+Supports Python 3.9–3.14.
+
+## Contents
 
 - [Overview](#overview)
 - [Why this library?](#why-this-library)
@@ -29,15 +36,6 @@
 - [Related project](#related-project)
 - [Development & Testing](#development--testing)
 - [License](#license)
-</details>
-
-## Overview
-
-Calling an LLM from Python usually means choosing between a provider-specific SDK, a larger application framework, or an API gateway.
-
-**llm-api-adapter** is a minimal, typed multi-provider adapter for OpenAI, Anthropic, and Google. It provides one provider-neutral contract for messages, tools, structured output, multimodal input, errors, usage, cost, and streaming — with one runtime dependency and no provider SDKs or orchestration framework. Switching providers means changing two arguments.
-
-Supports Python 3.9–3.14.
 
 ## Why this library?
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,33 @@
 [![Python versions](https://img.shields.io/pypi/pyversions/llm-api-adapter.svg)](https://pypi.org/project/llm-api-adapter/)
 [![codecov](https://codecov.io/github/Inozem/llm_api_adapter/branch/dev/graph/badge.svg?token=T83ZPH1F7Z)](https://codecov.io/github/Inozem/llm_api_adapter)
 
+<details>
+<summary>Contents</summary>
+
+- [Overview](#overview)
+- [Why this library?](#why-this-library)
+- [Features](#features)
+- [Installation](#installation)
+- [Getting Started](#getting-started)
+- [Streaming](#streaming)
+- [Async API](#async-api)
+- [Handling Errors](#handling-errors)
+- [Configuration and Management](#configuration-and-management)
+- [Example Use Case](#example-use-case)
+- [Timeout Support](#timeout-support)
+- [Reasoning Support](#reasoning-support)
+- [Tool / Function Calling](#tool--function-calling)
+- [Structured Output](#structured-output)
+- [Vision Input](#vision-input)
+- [Document Input](#document-input)
+- [Token Usage and Pricing](#token-usage-and-pricing)
+- [Logging](#logging)
+- [Adoption](#adoption)
+- [Related project](#related-project)
+- [Development & Testing](#development--testing)
+- [License](#license)
+</details>
+
 ## Overview
 
 Calling an LLM from Python usually means choosing between a provider-specific SDK, a larger application framework, or an API gateway.
@@ -51,14 +78,14 @@ This table is a positioning snapshot. Provider capabilities change independently
 
 ### Use something else when
 
-- **LiteLLM** — you need providers beyond OpenAI, Anthropic/Claude, and Google (for example AWS Bedrock-hosted models), or a gateway/router layer with retries, fallbacks, and observability
-- **LangChain** — you need chains, memory, RAG, agents, async workflows, or a larger orchestration framework
-- **Provider SDK directly** — you'll never switch, need provider-specific async features, and don't need cost tracking
+- **LiteLLM** — you need providers beyond OpenAI, Anthropic/Claude, and Google, or a gateway/router layer with retries, fallbacks, load balancing, and observability
+- **LangChain** — you need chains, memory, RAG, agents, or a larger orchestration framework
+- **Provider SDK directly** — you use one provider and need an API or feature outside this SDK's provider-neutral contract
 
 ## Features
 
 - **Synchronous Streaming**: Iterate normalized text with `stream_chat()` across OpenAI, Anthropic, and Google. Optionally coalesce it into bounded chunks and observe per-chunk metadata without changing the yielded `str` contract.
-- **Asynchronous API**: Use `achat()` and `astream_chat()` with the optional `[async]` installation for non-blocking HTTPX requests and awaitable callbacks.
+- **Asynchronous API**: Use `achat()` and `astream_chat()` with the optional `[async]` installation for non-blocking HTTPX requests and awaitable callbacks. See the [Async API guide](ASYNC_API.md).
 - **Reasoning Observability**: Opt in to provider-emitted reasoning summaries through `capture_reasoning=True`, `ReasoningEvent`, and the `on_reasoning` callback without mixing reasoning into visible text.
 - **Provider-Neutral Messages and Responses**: Use the same typed messages, `ChatResponse`, usage, pricing, parsed output, and tool-call fields regardless of the provider.
 - **Vision Input**: Send images alongside text via `ImagePart` — URL or raw bytes, all providers handled automatically.
@@ -78,16 +105,8 @@ To install the SDK, you can use pip:
 pip install llm-api-adapter
 ```
 
-The asynchronous API is an optional dependency:
-
-```bash
-pip install "llm-api-adapter[async]"
-```
-
-The base installation keeps `requests` as its only runtime dependency. The
-`[async]` extra adds `httpx`; it is imported lazily when an async request is
-made. The synchronous API continues to use `requests` and does not require
-`httpx`.
+For non-blocking requests, install the optional `[async]` extra and follow the
+[Async API guide](ASYNC_API.md).
 
 **Note:** You will need to obtain API keys from each LLM provider you wish to use (OpenAI, Anthropic, Google). Refer to their respective documentation for instructions on obtaining API keys.
 
@@ -199,157 +218,17 @@ for chunk in chunk_metadata:
 
 Buffering is pull-based and has no background worker or time-based flush. If the stream fails or a caller closes the iterator early, pending text is not emitted as a successful final chunk and `on_done` is not called.
 
-Streaming is text-first for both APIs. Synchronous streaming uses the existing
-`requests` transport; asynchronous streaming uses a separate `httpx.AsyncClient`
-transport. The two transports share the provider-neutral response and callback
-contract, while provider-specific event parsing remains inside each adapter.
+`stream_chat()` uses the synchronous `requests` transport. For the matching
+`astream_chat()` contract and its `httpx.AsyncClient` transport, see the
+[Async API guide](ASYNC_API.md#async-streaming).
 
 Provider event references: [OpenAI Responses streaming](https://platform.openai.com/docs/api-reference/responses-streaming), [Anthropic streaming](https://platform.claude.com/docs/en/build-with-claude/streaming), and [Google `streamGenerateContent`](https://ai.google.dev/api/generate-content).
 
 ## Async API
 
-Install the optional dependency before using asynchronous methods:
-
-```bash
-pip install "llm-api-adapter[async]"
-```
-
-`achat()` and `astream_chat()` are available through the same
-`UniversalLLMAPIAdapter` facade for OpenAI, Anthropic, and Google. They accept
-the same provider-neutral messages, tools, structured-output, file, pricing,
-usage, and reasoning options as their synchronous counterparts.
-
-Both async methods accept the common request parameters `messages`,
-`max_tokens`, `temperature`, `top_p`, `reasoning_level`, `timeout_s`, `tools`,
-`tool_choice`, `parallel_tool_calls`, `previous_response`, `json_schema`,
-`response_model`, and `capture_reasoning`. `astream_chat()` additionally
-accepts `on_delta`, `on_tool_call`, `on_done`, `buffer_chars`, `on_chunk`, and
-`on_reasoning`, and returns an async iterator of visible text strings.
-
-`ImagePart` and `DocumentPart` are supported by both async methods. File bytes
-are encoded locally and sent in the async HTTPX request; file URLs are passed
-to the provider and are not downloaded by the adapter. As with the synchronous
-API, `DocumentPart` URLs require OpenAI Responses API models; OpenAI Chat
-Completions supports PDF bytes but not PDF URLs.
-
-### Async request
-
-```python
-import asyncio
-import os
-
-from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
-
-
-async def main():
-    adapter = UniversalLLMAPIAdapter(
-        organization="openai",
-        model="gpt-5",
-        api_key=os.environ["OPENAI_API_KEY"],
-    )
-    response = await adapter.achat(
-        messages=[{"role": "user", "content": "Explain SSE in one sentence."}],
-        max_tokens=80,
-    )
-    print(response.content)
-
-
-asyncio.run(main())
-```
-
-### Async streaming
-
-```python
-import asyncio
-import os
-
-from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
-
-
-async def main():
-    adapter = UniversalLLMAPIAdapter(
-        organization="anthropic",
-        model="claude-sonnet-4-5",
-        api_key=os.environ["ANTHROPIC_API_KEY"],
-    )
-
-    async def on_chunk(chunk):
-        print(f"chunk {chunk.index}: {chunk.text!r}")
-
-    async def on_done(response):
-        print(f"\nusage: {response.usage}")
-
-    async for delta in adapter.astream_chat(
-        messages=[{"role": "user", "content": "Explain SSE in one sentence."}],
-        max_tokens=80,
-        buffer_chars=80,
-        on_chunk=on_chunk,
-        on_done=on_done,
-    ):
-        print(delta, end="", flush=True)
-
-
-asyncio.run(main())
-```
-
-Async callbacks may be regular functions or `async def` functions. For every
-visible chunk, callbacks are processed serially in this order:
-`on_chunk` → `on_delta` → `yield`. Reasoning callbacks follow the same awaited
-ordering and reasoning text is never yielded as visible output.
-
-Async requests do not add automatic retries, provider fallback, or idempotency
-behavior. If a task is cancelled, the HTTP response and client are closed;
-pending text is not flushed and `on_done` is not called. The same cleanup
-applies when an async stream is closed before normal completion.
-
-Async HTTPX requests use the same `LLMAPIError` hierarchy as synchronous
-requests. Authentication, rate-limit, client, server, and timeout failures are
-normalized to the same provider-neutral exceptions.
-
-### Reasoning observability
-
-Reasoning observability is opt-in and additive. Set `capture_reasoning=True` to retain provider-emitted reasoning summaries or readable thinking content in `ChatResponse.reasoning_events`.
-
-With `achat()`, the events are available on the returned `ChatResponse`. With
-`astream_chat()`, they are delivered through `on_reasoning` and included in the
-final response passed to `on_done`.
-
-The stream still yields only visible text. Reasoning events are never sent to `on_delta` and never appear in the iterator. When supplied, `on_reasoning(event)` is called as each event is normalized; `on_done(response)` receives the complete `response.reasoning_events` list.
-
-```python
-import asyncio
-import os
-
-from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
-
-
-async def main():
-    adapter = UniversalLLMAPIAdapter(
-        organization="openai",
-        model="gpt-5",
-        api_key=os.environ["OPENAI_API_KEY"],
-    )
-
-    async def observe_reasoning(event):
-        # Application code decides what to log, redact, retain, or display.
-        print(f"reasoning[{event.index}]: {event.text}")
-
-    async def on_done(response):
-        print(f"captured {len(response.reasoning_events)} reasoning events")
-
-    async for text in adapter.astream_chat(
-        messages=[{"role": "user", "content": "Explain SSE briefly."}],
-        capture_reasoning=True,
-        on_reasoning=observe_reasoning,
-        on_done=on_done,
-    ):
-        print(text, end="", flush=True)
-
-
-asyncio.run(main())
-```
-
-`ReasoningEvent` contains `text`, `kind`, `index`, `elapsed_s`, and `delta_s`. Availability and content depend on the provider and model; an empty list is a valid result. The library does not automatically log, display, redact, or send reasoning to telemetry, and it does not promise access to a model's private chain of thought. Applications should apply their own redaction and retention policy.
+The optional asynchronous client, installation command, `achat()` and
+`astream_chat()` examples, callback ordering, cancellation behavior, and
+reasoning observability are documented in the [Async API guide](ASYNC_API.md).
 
 ## Handling Errors
 
@@ -658,16 +537,13 @@ All request methods support the same tool parameters:
 
 - `tools`
 - `tool_choice`
+- `parallel_tool_calls`
 
-This includes `chat()`, `achat()`, `stream_chat()`, and `astream_chat()`.
-The async methods return the same normalized `ToolCall` objects as the sync
-methods. During streaming, completed calls are delivered through
-`on_tool_call`; the callback may be synchronous or asynchronous. The adapter
-does not execute tools, so the caller must append the resulting `ToolMessage`
-and make the follow-up request itself.
+Tool calls are returned as normalized `ToolCall` objects. The adapter does not
+execute them, so the caller appends each resulting `ToolMessage` and makes the
+follow-up request itself.
 
-`parallel_tool_calls` is also accepted by all request methods. Its effect is
-provider-dependent and matches the synchronous API: Anthropic can enable or
+`parallel_tool_calls` is provider-dependent: Anthropic can enable or
 disable parallel tool use, OpenAI supports it for Chat Completions, and Google
 ignores it because Gemini has no equivalent option.
 
@@ -745,23 +621,7 @@ if first.tool_calls:
     print(final.content)
 ```
 
-The same tool round-trip is asynchronous when using `achat()`:
-
-```python
-first = await adapter.achat(
-    messages=messages,
-    tools=tools,
-    tool_choice="auto",
-    max_tokens=1000,
-)
-
-# Execute first.tool_calls and append AIMessage/ToolMessage as above.
-final = await adapter.achat(
-    messages=messages,
-    previous_response=first,
-    max_tokens=1000,
-)
-```
+For a complete async tool round-trip, see the [Async API guide](ASYNC_API.md#tool-calling).
 
 ### `previous_response` parameter
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Calling an LLM from Python usually means choosing between a provider-specific SD
 
 **llm-api-adapter** is a minimal, typed multi-provider adapter for OpenAI, Anthropic, and Google. It provides one provider-neutral contract for messages, tools, structured output, multimodal input, errors, usage, cost, and streaming — with one runtime dependency and no provider SDKs or orchestration framework. Switching providers means changing two arguments.
 
-Supports Python 3.9–3.14.
+Supports Python 3.10–3.14.
 
 ## Contents
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # LLM API Adapter SDK for Python
 [![PyPI Downloads](https://static.pepy.tech/personalized-badge/llm-api-adapter?period=total&units=INTERNATIONAL_SYSTEM&left_color=BLACK&right_color=GREEN&left_text=downloads)](https://pepy.tech/projects/llm-api-adapter)
 [![Tests](https://github.com/Inozem/llm_api_adapter/actions/workflows/ci-main.yml/badge.svg)](https://github.com/Inozem/llm_api_adapter/actions/workflows/ci-main.yml)
+[![Python versions](https://img.shields.io/pypi/pyversions/llm-api-adapter.svg)](https://pypi.org/project/llm-api-adapter/)
 [![codecov](https://codecov.io/github/Inozem/llm_api_adapter/branch/dev/graph/badge.svg?token=T83ZPH1F7Z)](https://codecov.io/github/Inozem/llm_api_adapter)
 
 ## Overview
@@ -8,6 +9,8 @@
 Calling an LLM from Python usually means choosing between a provider-specific SDK, a larger application framework, or an API gateway.
 
 **llm-api-adapter** is a minimal, typed multi-provider adapter for OpenAI, Anthropic, and Google. It provides one provider-neutral contract for messages, tools, structured output, multimodal input, errors, usage, cost, and streaming — with one runtime dependency and no provider SDKs or orchestration framework. Switching providers means changing two arguments.
+
+Supports Python 3.9–3.14.
 
 ## Why this library?
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,12 @@ name = "llm-api-adapter"
 version = "0.7.0"
 description = "Lightweight, pluggable adapter for multiple LLM APIs (OpenAI, Anthropic, Google)"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {file = "LICENSE"}
 authors = [{name = "Sergey Inozemtsev"}]
 keywords = ["llm", "adapter", "lightweight", "api"]
 classifiers = [
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,11 @@ keywords = ["llm", "adapter", "lightweight", "api"]
 classifiers = [
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Typing :: Typed",
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-api-adapter"
-version = "0.7.0"
+version = "0.7.1"
 description = "Lightweight, pluggable adapter for multiple LLM APIs (OpenAI, Anthropic, Google)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/integration/test_streaming.py
+++ b/tests/integration/test_streaming.py
@@ -8,7 +8,11 @@ import requests
 import requests_mock
 from pydantic import BaseModel
 
-from src.llm_api_adapter.errors.llm_api_error import JSONSchemaError
+from src.llm_api_adapter.errors.llm_api_error import (
+    JSONSchemaError,
+    LLMAPIRateLimitError,
+    LLMAPIServerError,
+)
 from src.llm_api_adapter.models.messages.chat_message import UserMessage
 from src.llm_api_adapter.models.responses.chat_response import Usage
 from src.llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
@@ -169,6 +173,241 @@ _STRUCTURED_STREAM_CASES = [
         ),
         {},
         id="google",
+    ),
+]
+
+
+def _reasoning_events(provider: str):
+    if provider == "openai":
+        return [
+            (
+                "response.reasoning_summary_text.delta",
+                {
+                    "type": "response.reasoning_summary_text.delta",
+                    "delta": "Plan",
+                },
+            ),
+            (
+                "response.output_text.delta",
+                {"type": "response.output_text.delta", "delta": "Answer"},
+            ),
+            (
+                "response.completed",
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "id": "reasoning_resp_123",
+                        "model": "gpt-5",
+                        "status": "completed",
+                        "output": [
+                            {
+                                "type": "reasoning",
+                                "summary": [{"type": "summary_text", "text": "Plan"}],
+                            },
+                            {
+                                "type": "message",
+                                "content": [{"type": "output_text", "text": "Answer"}],
+                            },
+                        ],
+                    },
+                },
+            ),
+        ]
+    if provider == "anthropic":
+        return [
+            (
+                "message_start",
+                {
+                    "type": "message_start",
+                    "message": {
+                        "id": "reasoning_msg_123",
+                        "model": "claude-sonnet-4-5",
+                        "content": [],
+                        "usage": {"input_tokens": 2, "output_tokens": 0},
+                    },
+                },
+            ),
+            (
+                "content_block_start",
+                {
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": {"type": "thinking", "thinking": ""},
+                },
+            ),
+            (
+                "content_block_delta",
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "thinking_delta", "thinking": "Plan"},
+                },
+            ),
+            (
+                "content_block_start",
+                {
+                    "type": "content_block_start",
+                    "index": 1,
+                    "content_block": {"type": "text", "text": ""},
+                },
+            ),
+            (
+                "content_block_delta",
+                {
+                    "type": "content_block_delta",
+                    "index": 1,
+                    "delta": {"type": "text_delta", "text": "Answer"},
+                },
+            ),
+            (
+                "message_delta",
+                {
+                    "type": "message_delta",
+                    "delta": {"stop_reason": "end_turn"},
+                    "usage": {"output_tokens": 2},
+                },
+            ),
+            ("message_stop", {"type": "message_stop"}),
+        ]
+    if provider == "google":
+        return [
+            (
+                None,
+                {
+                    "candidates": [{
+                        "content": {"parts": [{"text": "Plan", "thought": True}]}
+                    }]
+                },
+            ),
+            (
+                None,
+                {
+                    "candidates": [{
+                        "content": {"parts": [{"text": "Answer"}]},
+                        "finishReason": "STOP",
+                    }],
+                    "usageMetadata": {
+                        "promptTokenCount": 2,
+                        "candidatesTokenCount": 1,
+                        "totalTokenCount": 3,
+                    },
+                },
+            ),
+        ]
+    raise AssertionError(f"Unsupported provider: {provider}")
+
+
+def _failure_events(provider: str):
+    if provider == "openai":
+        return [
+            (
+                "response.output_text.delta",
+                {"type": "response.output_text.delta", "delta": "partial"},
+            ),
+            (
+                "response.failed",
+                {
+                    "type": "response.failed",
+                    "response": {
+                        "error": {
+                            "type": "server_error",
+                            "message": "provider failed",
+                        }
+                    },
+                },
+            ),
+        ]
+    if provider == "anthropic":
+        return [
+            (
+                "message_start",
+                {
+                    "type": "message_start",
+                    "message": {
+                        "id": "failed_msg_123",
+                        "model": "claude-sonnet-4-5",
+                        "content": [],
+                        "usage": {"input_tokens": 2, "output_tokens": 0},
+                    },
+                },
+            ),
+            (
+                "content_block_start",
+                {
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": {"type": "text", "text": ""},
+                },
+            ),
+            (
+                "content_block_delta",
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": "partial"},
+                },
+            ),
+            (
+                "error",
+                {
+                    "type": "error",
+                    "error": {
+                        "type": "overloaded_error",
+                        "message": "provider overloaded",
+                    },
+                },
+            ),
+        ]
+    if provider == "google":
+        return [
+            (
+                None,
+                {
+                    "candidates": [{
+                        "content": {"parts": [{"text": "partial"}]}
+                    }]
+                },
+            ),
+            (
+                None,
+                {
+                    "error": {
+                        "status": "RESOURCE_EXHAUSTED",
+                        "message": "quota exhausted",
+                    }
+                },
+            ),
+        ]
+    raise AssertionError(f"Unsupported provider: {provider}")
+
+
+_FAILURE_STREAM_CASES = [
+    pytest.param(
+        "openai",
+        "gpt-5",
+        "https://api.openai.com/v1/responses",
+        LLMAPIServerError,
+        {"max_tokens": 64},
+        id="openai-response-failed",
+    ),
+    pytest.param(
+        "anthropic",
+        "claude-sonnet-4-5",
+        "https://api.anthropic.com/v1/messages",
+        LLMAPIServerError,
+        {"max_tokens": 64},
+        id="anthropic-error-event",
+    ),
+    pytest.param(
+        "google",
+        "gemini-2.5-pro",
+        (
+            "https://generativelanguage.googleapis.com/v1beta/"
+            "models/gemini-2.5-pro:streamGenerateContent?alt=sse"
+        ),
+        LLMAPIRateLimitError,
+        {},
+        id="google-resource-exhausted",
     ),
 ]
 
@@ -694,3 +933,125 @@ async def test_async_structured_stream_failure_skips_on_done(
     assert route.call_count == 1
     assert yielded == fragments
     assert done == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    ("provider", "model", "url", "expected_error", "stream_kwargs"),
+    _FAILURE_STREAM_CASES,
+)
+async def test_async_provider_stream_failure_closes_and_skips_completion(
+    provider,
+    model,
+    url,
+    expected_error,
+    stream_kwargs,
+):
+    with respx.mock(assert_all_called=False) as router:
+        route = router.post(url)
+        route.return_value = httpx.Response(
+            200,
+            text=_sse(*_failure_events(provider)),
+            headers={"content-type": "text/event-stream"},
+        )
+        adapter = UniversalLLMAPIAdapter(
+            organization=provider,
+            model=model,
+            api_key="dummy_key",
+        )
+        chunks = []
+        deltas = []
+        done = []
+        yielded = []
+
+        async def on_chunk(chunk):
+            chunks.append(chunk)
+
+        async def on_delta(text):
+            deltas.append(text)
+
+        with pytest.raises(expected_error):
+            async for text in adapter.astream_chat(
+                messages=[UserMessage("Stream an answer.")],
+                buffer_chars=16,
+                on_chunk=on_chunk,
+                on_delta=on_delta,
+                on_done=done.append,
+                **stream_kwargs,
+            ):
+                yielded.append(text)
+
+    assert route.call_count == 1
+    assert route.calls[0].response.is_closed is True
+    assert chunks == []
+    assert deltas == []
+    assert yielded == []
+    assert done == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    ("provider", "model", "url", "stream_kwargs"),
+    _STRUCTURED_STREAM_CASES,
+)
+async def test_async_reasoning_callbacks_precede_visible_chunks_and_done(
+    provider,
+    model,
+    url,
+    stream_kwargs,
+):
+    with respx.mock(assert_all_called=False) as router:
+        route = router.post(url)
+        route.return_value = httpx.Response(
+            200,
+            text=_sse(*_reasoning_events(provider)),
+            headers={"content-type": "text/event-stream"},
+        )
+        adapter = UniversalLLMAPIAdapter(
+            organization=provider,
+            model=model,
+            api_key="dummy_key",
+        )
+        order = []
+        done = []
+
+        async def on_reasoning(event):
+            order.append(("reasoning", event.text))
+
+        async def on_chunk(chunk):
+            order.append(("chunk", chunk.text))
+
+        async def on_delta(text):
+            order.append(("delta", text))
+
+        async def on_done(response):
+            done.append(response)
+            order.append(("done", response.content))
+
+        yielded = []
+        async for text in adapter.astream_chat(
+            messages=[UserMessage("Think, then answer.")],
+            capture_reasoning=True,
+            on_reasoning=on_reasoning,
+            on_chunk=on_chunk,
+            on_delta=on_delta,
+            on_done=on_done,
+            **stream_kwargs,
+        ):
+            yielded.append(text)
+            order.append(("yield", text))
+
+    assert route.call_count == 1
+    assert route.calls[0].response.is_closed is True
+    assert yielded == ["Answer"]
+    assert order == [
+        ("reasoning", "Plan"),
+        ("chunk", "Answer"),
+        ("delta", "Answer"),
+        ("yield", "Answer"),
+        ("done", "Answer"),
+    ]
+    assert len(done) == 1
+    assert [event.text for event in done[0].reasoning_events] == ["Plan"]

--- a/tests/integration/test_streaming.py
+++ b/tests/integration/test_streaming.py
@@ -1,10 +1,14 @@
 import json
 from unittest.mock import patch
 
+import httpx
 import pytest
+import respx
 import requests
 import requests_mock
+from pydantic import BaseModel
 
+from src.llm_api_adapter.errors.llm_api_error import JSONSchemaError
 from src.llm_api_adapter.models.messages.chat_message import UserMessage
 from src.llm_api_adapter.models.responses.chat_response import Usage
 from src.llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
@@ -19,6 +23,154 @@ def _sse(*events: tuple[str | None, dict]) -> str:
         lines.append(f"data: {json.dumps(payload)}")
         chunks.append("\n".join(lines))
     return "\n\n".join(chunks) + "\n\n"
+
+
+STRUCTURED_JSON = '{"answer":"ok"}'
+STRUCTURED_SCHEMA = {
+    "type": "object",
+    "properties": {"answer": {"type": "string"}},
+    "required": ["answer"],
+}
+
+
+class StreamAnswer(BaseModel):
+    answer: str
+
+
+def _structured_events(provider: str, content: str):
+    first, second = content[:10], content[10:]
+    if provider == "openai":
+        return [
+            (
+                "response.output_text.delta",
+                {"type": "response.output_text.delta", "delta": first},
+            ),
+            (
+                "response.output_text.delta",
+                {"type": "response.output_text.delta", "delta": second},
+            ),
+            (
+                "response.completed",
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "id": "structured_resp_123",
+                        "model": "gpt-5",
+                        "status": "completed",
+                        "output": [
+                            {
+                                "type": "message",
+                                "content": [
+                                    {"type": "output_text", "text": content}
+                                ],
+                            }
+                        ],
+                    },
+                },
+            ),
+        ]
+    if provider == "anthropic":
+        return [
+            (
+                "message_start",
+                {
+                    "type": "message_start",
+                    "message": {
+                        "id": "structured_msg_123",
+                        "model": "claude-sonnet-4-5",
+                        "content": [],
+                        "usage": {"input_tokens": 2, "output_tokens": 0},
+                    },
+                },
+            ),
+            (
+                "content_block_start",
+                {
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": {"type": "text", "text": ""},
+                },
+            ),
+            (
+                "content_block_delta",
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": first},
+                },
+            ),
+            (
+                "content_block_delta",
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": second},
+                },
+            ),
+            (
+                "message_delta",
+                {
+                    "type": "message_delta",
+                    "delta": {"stop_reason": "end_turn"},
+                    "usage": {"output_tokens": 2},
+                },
+            ),
+            ("message_stop", {"type": "message_stop"}),
+        ]
+    if provider == "google":
+        return [
+            (
+                None,
+                {"candidates": [{"content": {"parts": [{"text": first}]}}]},
+            ),
+            (
+                None,
+                {
+                    "candidates": [{
+                        "content": {"parts": [{"text": second}]},
+                        "finishReason": "STOP",
+                    }],
+                    "usageMetadata": {
+                        "promptTokenCount": 2,
+                        "candidatesTokenCount": 2,
+                        "totalTokenCount": 4,
+                    },
+                },
+            ),
+        ]
+    raise AssertionError(f"Unsupported provider: {provider}")
+
+
+def _content_fragments(content: str):
+    return [fragment for fragment in (content[:10], content[10:]) if fragment]
+
+
+_STRUCTURED_STREAM_CASES = [
+    pytest.param(
+        "openai",
+        "gpt-5",
+        "https://api.openai.com/v1/responses",
+        {"max_tokens": 64},
+        id="openai-responses",
+    ),
+    pytest.param(
+        "anthropic",
+        "claude-sonnet-4-5",
+        "https://api.anthropic.com/v1/messages",
+        {"max_tokens": 64},
+        id="anthropic",
+    ),
+    pytest.param(
+        "google",
+        "gemini-2.5-pro",
+        (
+            "https://generativelanguage.googleapis.com/v1beta/"
+            "models/gemini-2.5-pro:streamGenerateContent?alt=sse"
+        ),
+        {},
+        id="google",
+    ),
+]
 
 
 @pytest.mark.integration
@@ -406,3 +558,139 @@ def test_streaming_contract_is_consistent_for_all_providers(
         ("yield", "o!"),
         ("done", "Hello!"),
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    ("provider", "model", "url", "stream_kwargs"),
+    _STRUCTURED_STREAM_CASES,
+)
+@pytest.mark.parametrize(
+    ("option_name", "option_value"),
+    [
+        pytest.param("json_schema", STRUCTURED_SCHEMA, id="json-schema"),
+        pytest.param("response_model", StreamAnswer, id="response-model"),
+    ],
+)
+async def test_async_structured_stream_finalization(
+    provider,
+    model,
+    url,
+    stream_kwargs,
+    option_name,
+    option_value,
+):
+    fragments = _content_fragments(STRUCTURED_JSON)
+    with respx.mock(assert_all_called=False) as router:
+        route = router.post(url)
+        route.return_value = httpx.Response(
+            200,
+            text=_sse(*_structured_events(provider, STRUCTURED_JSON)),
+            headers={"content-type": "text/event-stream"},
+        )
+        adapter = UniversalLLMAPIAdapter(
+            organization=provider,
+            model=model,
+            api_key="dummy_key",
+        )
+        done = []
+        order = []
+
+        async def on_delta(text):
+            order.append(("delta", text))
+
+        async def on_done(response):
+            done.append(response)
+            order.append(("done", response.content))
+
+        yielded = []
+        yielded_kwargs = {
+            "messages": [UserMessage("Return a structured answer.")],
+            **stream_kwargs,
+            option_name: option_value,
+            "on_delta": on_delta,
+            "on_done": on_done,
+        }
+        async for text in adapter.astream_chat(**yielded_kwargs):
+            yielded.append(text)
+            order.append(("yield", text))
+
+    assert route.call_count == 1
+    assert yielded == fragments
+    assert order == [
+        ("delta", fragments[0]),
+        ("yield", fragments[0]),
+        ("delta", fragments[1]),
+        ("yield", fragments[1]),
+        ("done", STRUCTURED_JSON),
+    ]
+    assert len(done) == 1
+    assert done[0].content == STRUCTURED_JSON
+    assert done[0].parsed_json == {"answer": "ok"}
+    if option_name == "response_model":
+        assert done[0].parsed_model == StreamAnswer(answer="ok")
+    else:
+        assert done[0].parsed_model is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    ("provider", "model", "url", "stream_kwargs"),
+    _STRUCTURED_STREAM_CASES,
+)
+@pytest.mark.parametrize(
+    ("option_name", "option_value", "invalid_content"),
+    [
+        pytest.param(
+            "json_schema",
+            STRUCTURED_SCHEMA,
+            '{"answer":',
+            id="json-schema-invalid-json",
+        ),
+        pytest.param(
+            "response_model",
+            StreamAnswer,
+            "{}",
+            id="response-model-validation-error",
+        ),
+    ],
+)
+async def test_async_structured_stream_failure_skips_on_done(
+    provider,
+    model,
+    url,
+    stream_kwargs,
+    option_name,
+    option_value,
+    invalid_content,
+):
+    fragments = _content_fragments(invalid_content)
+    with respx.mock(assert_all_called=False) as router:
+        route = router.post(url)
+        route.return_value = httpx.Response(
+            200,
+            text=_sse(*_structured_events(provider, invalid_content)),
+            headers={"content-type": "text/event-stream"},
+        )
+        adapter = UniversalLLMAPIAdapter(
+            organization=provider,
+            model=model,
+            api_key="dummy_key",
+        )
+        done = []
+        yielded = []
+        yielded_kwargs = {
+            "messages": [UserMessage("Return a structured answer.")],
+            **stream_kwargs,
+            option_name: option_value,
+            "on_done": done.append,
+        }
+        with pytest.raises(JSONSchemaError):
+            async for text in adapter.astream_chat(**yielded_kwargs):
+                yielded.append(text)
+
+    assert route.call_count == 1
+    assert yielded == fragments
+    assert done == []

--- a/tests/integration/test_tools.py
+++ b/tests/integration/test_tools.py
@@ -1,6 +1,8 @@
 import json
 
+import httpx
 import pytest
+import respx
 import requests_mock
 
 from src.llm_api_adapter.models.messages.chat_message import (
@@ -25,6 +27,50 @@ TOOLS = [
         },
     )
 ]
+
+MULTI_TOOLS = TOOLS + [
+    ToolSpec(
+        name="get_time",
+        description="Get the local time for a city",
+        json_schema={
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+            "additionalProperties": False,
+        },
+    )
+]
+
+
+def _multi_tool_messages():
+    return [
+        Prompt("Use the available tools to answer the user's question."),
+        UserMessage("What's the weather and local time in Tel Aviv today?"),
+    ]
+
+
+def _append_multi_tool_results(messages, response):
+    assert response.tool_calls is not None
+    messages.append(AIMessage(content="", tool_calls=response.tool_calls))
+    results = {
+        "get_weather": {"city": "Tel Aviv", "temperature": 22, "unit": "C"},
+        "get_time": {"city": "Tel Aviv", "time": "14:30", "timezone": "Asia/Jerusalem"},
+    }
+    for tool_call in response.tool_calls:
+        messages.append(
+            ToolMessage(
+                tool_call_id=tool_call.call_id,
+                content=json.dumps(results[tool_call.name], ensure_ascii=False),
+            )
+        )
+
+
+def _assert_multi_tool_calls(response, expected):
+    assert response.tool_calls is not None
+    assert [
+        (tool_call.name, tool_call.arguments, tool_call.call_id)
+        for tool_call in response.tool_calls
+    ] == expected
 
 
 @pytest.fixture
@@ -164,6 +210,168 @@ def google_tools_mock():
                             }
                         ],
                         "usageMetadata": {"totalTokenCount": 50},
+                    }
+                },
+            ],
+        )
+        yield mock
+
+
+@pytest.fixture
+def openai_multi_tools_mock():
+    with requests_mock.Mocker() as mock:
+        mock.post(
+            "https://api.openai.com/v1/responses",
+            [
+                {
+                    "json": {
+                        "id": "resp_multi_1",
+                        "model": "gpt-5.2-pro",
+                        "status": "completed",
+                        "output": [
+                            {
+                                "type": "function_call",
+                                "name": "get_weather",
+                                "arguments": '{"city":"Tel Aviv"}',
+                                "call_id": "call_weather",
+                            },
+                            {
+                                "type": "function_call",
+                                "name": "get_time",
+                                "arguments": '{"city":"Tel Aviv"}',
+                                "call_id": "call_time",
+                            },
+                        ],
+                        "usage": {
+                            "input_tokens": 12,
+                            "output_tokens": 8,
+                            "total_tokens": 20,
+                        },
+                    }
+                },
+                {
+                    "json": {
+                        "id": "resp_multi_2",
+                        "model": "gpt-5.2-pro",
+                        "status": "completed",
+                        "output": [
+                            {
+                                "type": "message",
+                                "role": "assistant",
+                                "content": [
+                                    {
+                                        "type": "output_text",
+                                        "text": "Tel Aviv: 22 C, 14:30 local time.",
+                                    }
+                                ],
+                            }
+                        ],
+                        "usage": {
+                            "input_tokens": 20,
+                            "output_tokens": 9,
+                            "total_tokens": 29,
+                        },
+                    }
+                },
+            ],
+        )
+        yield mock
+
+
+@pytest.fixture
+def anthropic_multi_tools_mock():
+    with requests_mock.Mocker() as mock:
+        mock.post(
+            "https://api.anthropic.com/v1/messages",
+            [
+                {
+                    "json": {
+                        "id": "msg_multi_1",
+                        "model": "claude-sonnet-4-5",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "toolu_weather",
+                                "name": "get_weather",
+                                "input": {"city": "Tel Aviv"},
+                            },
+                            {
+                                "type": "tool_use",
+                                "id": "toolu_time",
+                                "name": "get_time",
+                                "input": {"city": "Tel Aviv"},
+                            },
+                        ],
+                        "usage": {"input_tokens": 8, "output_tokens": 10},
+                        "stop_reason": "tool_use",
+                    }
+                },
+                {
+                    "json": {
+                        "id": "msg_multi_2",
+                        "model": "claude-sonnet-4-5",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "Tel Aviv: 22 C, 14:30 local time.",
+                            }
+                        ],
+                        "usage": {"input_tokens": 18, "output_tokens": 9},
+                        "stop_reason": "end_turn",
+                    }
+                },
+            ],
+        )
+        yield mock
+
+
+@pytest.fixture
+def google_multi_tools_mock():
+    with requests_mock.Mocker() as mock:
+        mock.post(
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent",
+            [
+                {
+                    "json": {
+                        "candidates": [
+                            {
+                                "content": {
+                                    "parts": [
+                                        {
+                                            "functionCall": {
+                                                "name": "get_weather",
+                                                "args": {"city": "Tel Aviv"},
+                                            }
+                                        },
+                                        {
+                                            "functionCall": {
+                                                "name": "get_time",
+                                                "args": {"city": "Tel Aviv"},
+                                            }
+                                        },
+                                    ]
+                                },
+                                "finishReason": "STOP",
+                            }
+                        ],
+                        "usageMetadata": {"totalTokenCount": 20},
+                    }
+                },
+                {
+                    "json": {
+                        "candidates": [
+                            {
+                                "content": {
+                                    "parts": [
+                                        {
+                                            "text": "Tel Aviv: 22 C, 14:30 local time."
+                                        }
+                                    ]
+                                },
+                                "finishReason": "STOP",
+                            }
+                        ],
+                        "usageMetadata": {"totalTokenCount": 29},
                     }
                 },
             ],
@@ -499,3 +707,455 @@ def test_google_tool_call_and_tool_result_protocol(google_tools_mock):
             }
         ],
     }
+
+
+@pytest.mark.integration
+def test_openai_gpt5_multi_tool_round_trip(openai_multi_tools_mock):
+    adapter = UniversalLLMAPIAdapter(
+        organization="openai",
+        model="gpt-5.2-pro",
+        api_key="dummy_key",
+    )
+    messages = _multi_tool_messages()
+
+    first = adapter.chat(
+        messages=messages,
+        tools=MULTI_TOOLS,
+        tool_choice="auto",
+        max_tokens=128,
+    )
+
+    _assert_multi_tool_calls(
+        first,
+        [
+            ("get_weather", {"city": "Tel Aviv"}, "call_weather"),
+            ("get_time", {"city": "Tel Aviv"}, "call_time"),
+        ],
+    )
+    assert first.response_id == "resp_multi_1"
+
+    _append_multi_tool_results(messages, first)
+    final = adapter.chat(messages=messages, max_tokens=256, previous_response=first)
+
+    assert final.content == "Tel Aviv: 22 C, 14:30 local time."
+    assert final.tool_calls is None
+    assert final.response_id == "resp_multi_2"
+
+    assert len(openai_multi_tools_mock.request_history) == 2
+    second_payload = openai_multi_tools_mock.request_history[1].json()
+    assert second_payload["previous_response_id"] == "resp_multi_1"
+    assert second_payload["input"] == [
+        {"role": "user", "content": "What's the weather and local time in Tel Aviv today?"},
+        {
+            "type": "function_call_output",
+            "call_id": "call_weather",
+            "output": json.dumps(
+                {"city": "Tel Aviv", "temperature": 22, "unit": "C"},
+                ensure_ascii=False,
+            ),
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_time",
+            "output": json.dumps(
+                {"city": "Tel Aviv", "time": "14:30", "timezone": "Asia/Jerusalem"},
+                ensure_ascii=False,
+            ),
+        },
+    ]
+
+
+@pytest.mark.integration
+def test_anthropic_multi_tool_round_trip(anthropic_multi_tools_mock):
+    adapter = UniversalLLMAPIAdapter(
+        organization="anthropic",
+        model="claude-sonnet-4-5",
+        api_key="dummy_key",
+    )
+    messages = _multi_tool_messages()
+
+    first = adapter.chat(
+        messages=messages,
+        max_tokens=256,
+        tools=MULTI_TOOLS,
+        tool_choice="auto",
+    )
+
+    _assert_multi_tool_calls(
+        first,
+        [
+            ("get_weather", {"city": "Tel Aviv"}, "toolu_weather"),
+            ("get_time", {"city": "Tel Aviv"}, "toolu_time"),
+        ],
+    )
+    assert first.response_id == "msg_multi_1"
+
+    _append_multi_tool_results(messages, first)
+    final = adapter.chat(messages=messages, max_tokens=256)
+
+    assert final.content == "Tel Aviv: 22 C, 14:30 local time."
+    assert final.tool_calls is None
+    assert final.response_id == "msg_multi_2"
+
+    assert len(anthropic_multi_tools_mock.request_history) == 2
+    second_payload = anthropic_multi_tools_mock.request_history[1].json()
+    assert second_payload["messages"] == [
+        {"role": "user", "content": "What's the weather and local time in Tel Aviv today?"},
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "toolu_weather",
+                    "name": "get_weather",
+                    "input": {"city": "Tel Aviv"},
+                },
+                {
+                    "type": "tool_use",
+                    "id": "toolu_time",
+                    "name": "get_time",
+                    "input": {"city": "Tel Aviv"},
+                },
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_weather",
+                    "content": json.dumps(
+                        {"city": "Tel Aviv", "temperature": 22, "unit": "C"},
+                        ensure_ascii=False,
+                    ),
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_time",
+                    "content": json.dumps(
+                        {"city": "Tel Aviv", "time": "14:30", "timezone": "Asia/Jerusalem"},
+                        ensure_ascii=False,
+                    ),
+                }
+            ],
+        },
+    ]
+
+
+@pytest.mark.integration
+def test_google_multi_tool_round_trip(google_multi_tools_mock):
+    adapter = UniversalLLMAPIAdapter(
+        organization="google",
+        model="gemini-2.5-pro",
+        api_key="dummy_key",
+    )
+    messages = _multi_tool_messages()
+
+    first = adapter.chat(
+        messages=messages,
+        tools=MULTI_TOOLS,
+        tool_choice="auto",
+        max_tokens=128,
+    )
+
+    _assert_multi_tool_calls(
+        first,
+        [
+            ("get_weather", {"city": "Tel Aviv"}, "get_weather"),
+            ("get_time", {"city": "Tel Aviv"}, "get_time"),
+        ],
+    )
+
+    _append_multi_tool_results(messages, first)
+    final = adapter.chat(messages=messages, max_tokens=256)
+
+    assert final.content == "Tel Aviv: 22 C, 14:30 local time."
+    assert final.tool_calls is None
+
+    assert len(google_multi_tools_mock.request_history) == 2
+    second_payload = google_multi_tools_mock.request_history[1].json()
+    assert second_payload["contents"] == [
+        {
+            "role": "user",
+            "parts": [
+                {"text": "What's the weather and local time in Tel Aviv today?"}
+            ],
+        },
+        {
+            "role": "model",
+            "parts": [
+                {"functionCall": {"name": "get_weather", "args": {"city": "Tel Aviv"}}},
+                {"functionCall": {"name": "get_time", "args": {"city": "Tel Aviv"}}},
+            ],
+        },
+        {
+            "role": "user",
+            "parts": [
+                {
+                    "functionResponse": {
+                        "name": "get_weather",
+                        "response": {
+                            "city": "Tel Aviv",
+                            "temperature": 22,
+                            "unit": "C",
+                        },
+                    }
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "parts": [
+                {
+                    "functionResponse": {
+                        "name": "get_time",
+                        "response": {
+                            "city": "Tel Aviv",
+                            "time": "14:30",
+                            "timezone": "Asia/Jerusalem",
+                        },
+                    }
+                }
+            ],
+        },
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_openai_async_gpt5_multi_tool_round_trip():
+    responses = [
+        {
+            "id": "async_resp_multi_1",
+            "model": "gpt-5.2-pro",
+            "status": "completed",
+            "output": [
+                {
+                    "type": "function_call",
+                    "name": "get_weather",
+                    "arguments": '{"city":"Tel Aviv"}',
+                    "call_id": "async_call_weather",
+                },
+                {
+                    "type": "function_call",
+                    "name": "get_time",
+                    "arguments": '{"city":"Tel Aviv"}',
+                    "call_id": "async_call_time",
+                },
+            ],
+        },
+        {
+            "id": "async_resp_multi_2",
+            "model": "gpt-5.2-pro",
+            "status": "completed",
+            "output": [
+                {
+                    "type": "message",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "Tel Aviv: 22 C, 14:30 local time.",
+                        }
+                    ],
+                }
+            ],
+        },
+    ]
+    with respx.mock(assert_all_called=False) as router:
+        route = router.post("https://api.openai.com/v1/responses")
+        route.side_effect = lambda request: httpx.Response(200, json=responses.pop(0))
+
+        adapter = UniversalLLMAPIAdapter(
+            organization="openai",
+            model="gpt-5.2-pro",
+            api_key="dummy_key",
+        )
+        messages = _multi_tool_messages()
+        first = await adapter.achat(
+            messages=messages,
+            tools=MULTI_TOOLS,
+            tool_choice="auto",
+            max_tokens=128,
+        )
+
+        _assert_multi_tool_calls(
+            first,
+            [
+                ("get_weather", {"city": "Tel Aviv"}, "async_call_weather"),
+                ("get_time", {"city": "Tel Aviv"}, "async_call_time"),
+            ],
+        )
+        _append_multi_tool_results(messages, first)
+        final = await adapter.achat(
+            messages=messages,
+            max_tokens=256,
+            previous_response=first,
+        )
+
+        assert final.content == "Tel Aviv: 22 C, 14:30 local time."
+        assert final.tool_calls is None
+        assert final.response_id == "async_resp_multi_2"
+        assert route.call_count == 2
+        second_payload = json.loads(route.calls[1].request.content)
+        assert [item["call_id"] for item in second_payload["input"][1:]] == [
+            "async_call_weather",
+            "async_call_time",
+        ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_anthropic_async_multi_tool_round_trip():
+    responses = [
+        {
+            "id": "async_msg_multi_1",
+            "model": "claude-sonnet-4-5",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "async_toolu_weather",
+                    "name": "get_weather",
+                    "input": {"city": "Tel Aviv"},
+                },
+                {
+                    "type": "tool_use",
+                    "id": "async_toolu_time",
+                    "name": "get_time",
+                    "input": {"city": "Tel Aviv"},
+                },
+            ],
+            "usage": {"input_tokens": 8, "output_tokens": 10},
+            "stop_reason": "tool_use",
+        },
+        {
+            "id": "async_msg_multi_2",
+            "model": "claude-sonnet-4-5",
+            "content": [
+                {"type": "text", "text": "Tel Aviv: 22 C, 14:30 local time."}
+            ],
+            "usage": {"input_tokens": 18, "output_tokens": 9},
+            "stop_reason": "end_turn",
+        },
+    ]
+    with respx.mock(assert_all_called=False) as router:
+        route = router.post("https://api.anthropic.com/v1/messages")
+        route.side_effect = lambda request: httpx.Response(200, json=responses.pop(0))
+
+        adapter = UniversalLLMAPIAdapter(
+            organization="anthropic",
+            model="claude-sonnet-4-5",
+            api_key="dummy_key",
+        )
+        messages = _multi_tool_messages()
+        first = await adapter.achat(
+            messages=messages,
+            max_tokens=256,
+            tools=MULTI_TOOLS,
+            tool_choice="auto",
+        )
+
+        _assert_multi_tool_calls(
+            first,
+            [
+                ("get_weather", {"city": "Tel Aviv"}, "async_toolu_weather"),
+                ("get_time", {"city": "Tel Aviv"}, "async_toolu_time"),
+            ],
+        )
+        _append_multi_tool_results(messages, first)
+        final = await adapter.achat(messages=messages, max_tokens=256)
+
+        assert final.content == "Tel Aviv: 22 C, 14:30 local time."
+        assert final.tool_calls is None
+        assert final.response_id == "async_msg_multi_2"
+        assert route.call_count == 2
+        second_payload = json.loads(route.calls[1].request.content)
+        assistant_blocks = second_payload["messages"][1]["content"]
+        result_blocks = [item["content"][0] for item in second_payload["messages"][2:]]
+        assert [block["id"] for block in assistant_blocks] == [
+            "async_toolu_weather",
+            "async_toolu_time",
+        ]
+        assert [block["tool_use_id"] for block in result_blocks] == [
+            "async_toolu_weather",
+            "async_toolu_time",
+        ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_google_async_multi_tool_round_trip():
+    responses = [
+        {
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [
+                            {"functionCall": {"name": "get_weather", "args": {"city": "Tel Aviv"}}},
+                            {"functionCall": {"name": "get_time", "args": {"city": "Tel Aviv"}}},
+                        ]
+                    },
+                    "finishReason": "STOP",
+                }
+            ],
+            "usageMetadata": {"totalTokenCount": 20},
+        },
+        {
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [{"text": "Tel Aviv: 22 C, 14:30 local time."}]
+                    },
+                    "finishReason": "STOP",
+                }
+            ],
+            "usageMetadata": {"totalTokenCount": 29},
+        },
+    ]
+    with respx.mock(assert_all_called=False) as router:
+        route = router.post(
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent"
+        )
+        route.side_effect = lambda request: httpx.Response(200, json=responses.pop(0))
+
+        adapter = UniversalLLMAPIAdapter(
+            organization="google",
+            model="gemini-2.5-pro",
+            api_key="dummy_key",
+        )
+        messages = _multi_tool_messages()
+        first = await adapter.achat(
+            messages=messages,
+            tools=MULTI_TOOLS,
+            tool_choice="auto",
+            max_tokens=128,
+        )
+
+        _assert_multi_tool_calls(
+            first,
+            [
+                ("get_weather", {"city": "Tel Aviv"}, "get_weather"),
+                ("get_time", {"city": "Tel Aviv"}, "get_time"),
+            ],
+        )
+        _append_multi_tool_results(messages, first)
+        final = await adapter.achat(messages=messages, max_tokens=256)
+
+        assert final.content == "Tel Aviv: 22 C, 14:30 local time."
+        assert final.tool_calls is None
+        assert route.call_count == 2
+        second_payload = json.loads(route.calls[1].request.content)
+        model_parts = second_payload["contents"][1]["parts"]
+        response_parts = second_payload["contents"][2:]
+        assert [part["functionCall"]["name"] for part in model_parts] == [
+            "get_weather",
+            "get_time",
+        ]
+        assert [part["functionResponse"]["name"] for item in response_parts for part in item["parts"]] == [
+            "get_weather",
+            "get_time",
+        ]


### PR DESCRIPTION
Prepares release 0.7.1:

- adds deterministic regression coverage for tools, async structured streaming, provider stream failures, and reasoning callback order;
- documents contributor setup, testing, and the maintainer-controlled release flow;
- runs deterministic CI on Python 3.10–3.14 and enforces the 90% coverage gate;
- separates the full async guide into ASYNC_API.md and keeps README focused on the sync API;
- drops end-of-life Python 3.9 support and sets the package version to 0.7.1.
