### PR TITLE
Feat/registry request rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,11 +172,16 @@ different supplied value is also removed, but emits one `UserWarning` and one
 `WARNING` log record per ignored parameter. Treat that warning as a prompt to
 remove the setting or select a model that supports it.
 
-Rules match the **exact** model names in the bundled registry. The adapter does
-not infer behavior from a name prefix. An unregistered alias receives no
-compatibility transformation; in particular, an unknown OpenAI model uses Chat
-Completions rather than the Responses API. Use a listed model or request a
-verified registry addition when a provider adds a new alias or model.
+Rules match the **exact** model names in the bundled registry, with two narrow
+snapshot exceptions for direct provider APIs: Anthropic
+`claude-...-YYYYMMDD` and OpenAI `gpt-...-YYYY-MM-DD` IDs inherit a registered
+unsuffixed base model's metadata when the date is valid. The requested snapshot
+ID is still sent to the provider. The adapter does not infer behavior from a
+name prefix; Google aliases and preview IDs, fine-tuned IDs, and any snapshot
+whose base model is unregistered receive no compatibility transformation. An
+unknown OpenAI model uses Chat Completions rather than the Responses API. Use a
+listed model or request a verified registry addition when a provider adds a new
+alias or model.
 
 ### Alternative Message Format
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Supports Python 3.10–3.14.
 - [Features](#features)
 - [Installation](#installation)
 - [Getting Started](#getting-started)
+- [Model-specific request compatibility](#model-specific-request-compatibility)
 - [Streaming](#streaming)
 - [Async API](#async-api)
 - [Handling Errors](#handling-errors)
@@ -91,7 +92,7 @@ This table is a positioning snapshot. Provider capabilities change independently
 - **Strict JSON Mode**: Pass one JSON Schema to `chat()` and get a parsed object in `ChatResponse.parsed_json` — provider-specific schema formats and restrictions are handled automatically.
 - **Pydantic Integration**: Pass a Pydantic model as `response_model` and get a typed instance back in `ChatResponse.parsed_model` — no manual schema writing required.
 - **Request Timeouts**: Per-request timeout control via `timeout_s`; raises `LLMAPITimeoutError` on expiry.
-- **Flexible Configuration**: `temperature`, `max_tokens`, `top_p`, and other parameters passed through to the provider.
+- **Flexible Configuration**: `temperature`, `max_tokens`, `top_p`, and other parameters are translated to a verified provider payload; known unsupported fields are omitted predictably.
 - **Pricing Registry**: Model prices stored in a bundled JSON registry with per-model input/output rates; overridable per instance.
 
 ## Installation
@@ -158,6 +159,24 @@ print(response.content)
 - **temperature**: Controls the randomness of the response. Higher values (e.g., 0.8) make the output more random, while lower values (e.g., 0.2) make it more focused and deterministic. Default value: `1.0` (range: 0 to 2).
 
 - **top\_p**: Limits the response to a certain cumulative probability. This is used to create more focused and coherent responses by considering only the highest probability options. Default value: `1.0` (range: 0 to 1).
+
+### Model-specific request compatibility
+
+The public `chat()`, `achat()`, `stream_chat()`, and `astream_chat()` methods
+keep the same arguments across providers. For a verified model, the adapter
+applies its registered payload compatibility rules before making the request;
+sync and async calls use the same rules.
+
+If a rule omits a parameter, its documented default is removed silently. A
+different supplied value is also removed, but emits one `UserWarning` and one
+`WARNING` log record per ignored parameter. Treat that warning as a prompt to
+remove the setting or select a model that supports it.
+
+Rules match the **exact** model names in the bundled registry. The adapter does
+not infer behavior from a name prefix. An unregistered alias receives no
+compatibility transformation; in particular, an unknown OpenAI model uses Chat
+Completions rather than the Responses API. Use a listed model or request a
+verified registry addition when a provider adds a new alias or model.
 
 ### Alternative Message Format
 
@@ -843,7 +862,7 @@ messages = [{
 response = adapter.chat(messages=messages, max_tokens=200)
 ```
 
-> **Note:** `ImagePart` is supported in v0.5.0; `DocumentPart` is introduced in v0.5.1. Google already supports audio input, but `AudioPart` is postponed because Anthropic does not support audio and OpenAI uses a separate audio API (`gpt-audio-1.5` with `modalities`), so there is no common provider-neutral contract yet.
+> **Note:** `ImagePart` is supported in v0.5.0; `DocumentPart` is introduced in v0.5.1. Google already supports audio input, but `AudioPart` is postponed because Anthropic does not support audio and OpenAI uses a separate audio API, so there is no common provider-neutral contract yet.
 
 ## Document Input
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-api-adapter"
-version = "0.8.1"
+version = "0.8.2"
 description = "Lightweight, pluggable adapter for multiple LLM APIs (OpenAI, Anthropic, Google)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/llm_api_adapter/adapters/base_adapter.py
+++ b/src/llm_api_adapter/adapters/base_adapter.py
@@ -27,7 +27,12 @@ from ..errors.llm_api_error import (
     LLMAPIError,
     ToolChoiceError,
 )
-from ..llm_registry.llm_registry import LLM_REGISTRY, ModelSpec, Pricing
+from ..llm_registry.llm_registry import (
+    LLM_REGISTRY,
+    ModelSpec,
+    Pricing,
+    resolve_model_spec,
+)
 from ..llm_registry.reasoning import ReasoningResolution, resolve_reasoning_level
 from ..models.messages.chat_message import Messages
 from ..models.responses.chat_response import ChatResponse
@@ -95,8 +100,7 @@ class LLMAdapterBase(ABC):
             error_message = "api_key must be a non-empty string"
             logger.error(error_message)
             raise ValueError(error_message)
-        provider = LLM_REGISTRY.providers.get(self.company)
-        model_spec = provider.models.get(self.model) if provider else None
+        model_spec = resolve_model_spec(LLM_REGISTRY, self.company, self.model)
         self.model_spec = model_spec
         if not model_spec:
             warnings.warn(

--- a/src/llm_api_adapter/llm_registry/llm_registry.json
+++ b/src/llm_api_adapter/llm_registry/llm_registry.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 10,
+  "schema_version": 11,
   "effective_date": "2026-08-10",
   "provider_files": {
     "openai": "providers/openai.json",

--- a/src/llm_api_adapter/llm_registry/llm_registry.py
+++ b/src/llm_api_adapter/llm_registry/llm_registry.py
@@ -3,6 +3,11 @@ import json
 from pathlib import Path
 from typing import Any, Dict, Optional, Sequence
 
+from .request_rules import (
+    RequestRuleRegistry,
+    RequestRules,
+    request_rule_registry_for_provider,
+)
 
 DEFAULT_REGISTRY_PATH = Path(__file__).with_name("llm_registry.json")
 
@@ -237,6 +242,7 @@ class ModelSpec:
     pricing_tiers: Pricing
     reasoning_capability: Optional[ReasoningCapability] = None
     is_adaptive_thinking: bool = False
+    request_rules: RequestRules = RequestRules()
 
     @property
     def is_reasoning(self) -> bool:
@@ -250,6 +256,7 @@ class ModelSpec:
         data: Dict[str, Any],
         *,
         currency: str = "USD",
+        request_rule_registry: Optional[RequestRuleRegistry] = None,
     ) -> "ModelSpec":
         if "pricing" in data:
             raise ValueError(
@@ -266,6 +273,20 @@ class ModelSpec:
             else None
         )
         is_adaptive_thinking = bool(data.get("is_adaptive_thinking", False))
+        raw_request_rules = data.get("request_rules", [])
+        if request_rule_registry is None:
+            if not isinstance(raw_request_rules, list):
+                raise ValueError("request_rules must be an array")
+            if raw_request_rules:
+                raise ValueError(
+                    f"Model '{name}' defines request_rules without a provider schema"
+                )
+            request_rules = RequestRules()
+        else:
+            request_rules = RequestRules.from_dict(
+                raw_request_rules,
+                rule_registry=request_rule_registry,
+            )
         if is_adaptive_thinking and reasoning_capability is None:
             raise ValueError(
                 f"Model '{name}' enables adaptive thinking without "
@@ -288,6 +309,7 @@ class ModelSpec:
             ),
             reasoning_capability=reasoning_capability,
             is_adaptive_thinking=is_adaptive_thinking,
+            request_rules=request_rules,
         )
 
 
@@ -302,11 +324,13 @@ class ProviderSpec:
         currency = data.get("currency", "USD")
         if not isinstance(currency, str) or not currency:
             raise ValueError(f"Provider '{name}' has an invalid currency")
+        request_rule_registry = request_rule_registry_for_provider(name)
         models = {
             model_name: ModelSpec.from_dict(
                 model_name,
                 model_spec,
                 currency=currency,
+                request_rule_registry=request_rule_registry,
             )
             for model_name, model_spec in (data.get("models") or {}).items()
         }

--- a/src/llm_api_adapter/llm_registry/llm_registry.py
+++ b/src/llm_api_adapter/llm_registry/llm_registry.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field, replace
+from datetime import date
 import json
 from pathlib import Path
+import re
 from typing import Any, Dict, Optional, Sequence
 
 from .request_rules import (
@@ -10,6 +12,9 @@ from .request_rules import (
 )
 
 DEFAULT_REGISTRY_PATH = Path(__file__).with_name("llm_registry.json")
+
+_ANTHROPIC_SNAPSHOT_ID = re.compile(r"^(claude-[a-z]+-\d+-\d+)-(\d{8})$")
+_OPENAI_SNAPSHOT_ID = re.compile(r"^(gpt-[A-Za-z0-9.-]+)-(\d{4}-\d{2}-\d{2})$")
 
 
 def _positive_int(value: Any, field_name: str) -> int:
@@ -394,6 +399,53 @@ class RegistrySpec:
         if not isinstance(provider_data, dict):
             raise ValueError(f"Provider registry data for '{provider_name}' must be an object")
         return provider_data
+
+
+def _is_valid_snapshot_date(value: str, *, compact: bool) -> bool:
+    """Return whether a provider snapshot suffix is a real calendar date."""
+    if compact:
+        value = f"{value[:4]}-{value[4:6]}-{value[6:]}"
+    try:
+        date.fromisoformat(value)
+    except ValueError:
+        return False
+    return True
+
+
+def _snapshot_base_model_name(provider_name: str, model_name: str) -> Optional[str]:
+    """Return a supported direct-provider snapshot's unsuffixed model ID."""
+    if provider_name == "anthropic":
+        match = _ANTHROPIC_SNAPSHOT_ID.fullmatch(model_name)
+        if match and _is_valid_snapshot_date(match.group(2), compact=True):
+            return match.group(1)
+    elif provider_name == "openai":
+        match = _OPENAI_SNAPSHOT_ID.fullmatch(model_name)
+        if match and _is_valid_snapshot_date(match.group(2), compact=False):
+            return match.group(1)
+    return None
+
+
+def resolve_model_spec(
+    registry: RegistrySpec,
+    provider_name: str,
+    model_name: str,
+) -> Optional[ModelSpec]:
+    """Resolve an exact model or a supported provider snapshot to its base spec.
+
+    The caller must continue to send ``model_name`` to the provider. This
+    resolver only supplies verified registry metadata for direct Anthropic and
+    OpenAI snapshot IDs whose unsuffixed base is registered.
+    """
+    provider = registry.providers.get(provider_name)
+    if not provider:
+        return None
+
+    model_spec = provider.models.get(model_name)
+    if model_spec:
+        return model_spec
+
+    base_model_name = _snapshot_base_model_name(provider_name, model_name)
+    return provider.models.get(base_model_name) if base_model_name else None
 
 
 LLM_REGISTRY = RegistrySpec()

--- a/src/llm_api_adapter/llm_registry/providers/anthropic.json
+++ b/src/llm_api_adapter/llm_registry/providers/anthropic.json
@@ -125,6 +125,9 @@
         "min_budget_tokens": 1024,
         "max_budget_tokens": 128000
       },
+      "request_rules": [
+        {"handler": "drop_parameter", "arguments": {"path": "top_p", "default": 1.0}}
+      ],
       "limits": {
         "context_window_tokens": 200000,
         "max_output_tokens": 128000
@@ -142,6 +145,9 @@
         "min_budget_tokens": 1024,
         "max_budget_tokens": 64000
       },
+      "request_rules": [
+        {"handler": "drop_parameter", "arguments": {"path": "top_p", "default": 1.0}}
+      ],
       "limits": {
         "context_window_tokens": 200000,
         "max_output_tokens": 64000
@@ -159,6 +165,9 @@
         "min_budget_tokens": 1024,
         "max_budget_tokens": 64000
       },
+      "request_rules": [
+        {"handler": "drop_parameter", "arguments": {"path": "top_p", "default": 1.0}}
+      ],
       "limits": {
         "context_window_tokens": 200000,
         "max_output_tokens": 64000

--- a/src/llm_api_adapter/llm_registry/providers/google.json
+++ b/src/llm_api_adapter/llm_registry/providers/google.json
@@ -75,6 +75,9 @@
         "min_budget_tokens": 128,
         "max_budget_tokens": 32768
       },
+      "request_rules": [
+        {"handler": "drop_parameter", "arguments": {"path": "generationConfig.maxOutputTokens", "default": null}}
+      ],
       "limits": {
         "context_window_tokens": 1048576,
         "max_output_tokens": 65536
@@ -97,6 +100,9 @@
         "min_budget_tokens": 0,
         "max_budget_tokens": 24576
       },
+      "request_rules": [
+        {"handler": "drop_parameter", "arguments": {"path": "generationConfig.maxOutputTokens", "default": null}}
+      ],
       "limits": {
         "context_window_tokens": 1048576,
         "max_output_tokens": 65536

--- a/src/llm_api_adapter/llm_registry/providers/openai.json
+++ b/src/llm_api_adapter/llm_registry/providers/openai.json
@@ -5,6 +5,10 @@
       "reasoning_capability": {
         "allowed_values": ["none", "low", "medium", "high", "xhigh", "max"]
       },
+      "request_rules": [
+        {"handler": "select_api_variant", "arguments": {"variant": "responses"}},
+        {"handler": "drop_parameter", "arguments": {"path": "top_p", "default": 1.0}}
+      ],
       "limits": {
         "context_window_tokens": 1050000,
         "max_output_tokens": 128000
@@ -26,6 +30,10 @@
       "reasoning_capability": {
         "allowed_values": ["none", "low", "medium", "high", "xhigh", "max"]
       },
+      "request_rules": [
+        {"handler": "select_api_variant", "arguments": {"variant": "responses"}},
+        {"handler": "drop_parameter", "arguments": {"path": "top_p", "default": 1.0}}
+      ],
       "limits": {
         "context_window_tokens": 1050000,
         "max_output_tokens": 128000
@@ -47,6 +55,10 @@
       "reasoning_capability": {
         "allowed_values": ["none", "low", "medium", "high", "xhigh", "max"]
       },
+      "request_rules": [
+        {"handler": "select_api_variant", "arguments": {"variant": "responses"}},
+        {"handler": "drop_parameter", "arguments": {"path": "top_p", "default": 1.0}}
+      ],
       "limits": {
         "context_window_tokens": 1050000,
         "max_output_tokens": 128000
@@ -68,6 +80,10 @@
       "reasoning_capability": {
         "allowed_values": ["none", "low", "medium", "high", "xhigh"]
       },
+      "request_rules": [
+        {"handler": "select_api_variant", "arguments": {"variant": "responses"}},
+        {"handler": "drop_parameter", "arguments": {"path": "top_p", "default": 1.0}}
+      ],
       "limits": {
         "context_window_tokens": 1050000,
         "max_output_tokens": 128000
@@ -89,6 +105,10 @@
       "reasoning_capability": {
         "allowed_values": ["none", "low", "medium", "high", "xhigh"]
       },
+      "request_rules": [
+        {"handler": "select_api_variant", "arguments": {"variant": "responses"}},
+        {"handler": "drop_parameter", "arguments": {"path": "top_p", "default": 1.0}}
+      ],
       "limits": {
         "context_window_tokens": 1050000,
         "max_output_tokens": 128000
@@ -110,6 +130,10 @@
       "reasoning_capability": {
         "allowed_values": ["none", "low", "medium", "high", "xhigh"]
       },
+      "request_rules": [
+        {"handler": "select_api_variant", "arguments": {"variant": "responses"}},
+        {"handler": "drop_parameter", "arguments": {"path": "top_p", "default": 1.0}}
+      ],
       "limits": {
         "context_window_tokens": 400000,
         "max_output_tokens": 128000
@@ -126,6 +150,10 @@
       "reasoning_capability": {
         "allowed_values": ["none", "low", "medium", "high", "xhigh"]
       },
+      "request_rules": [
+        {"handler": "select_api_variant", "arguments": {"variant": "responses"}},
+        {"handler": "drop_parameter", "arguments": {"path": "top_p", "default": 1.0}}
+      ],
       "limits": {
         "context_window_tokens": 400000,
         "max_output_tokens": 128000
@@ -142,6 +170,10 @@
       "reasoning_capability": {
         "allowed_values": ["none", "low", "medium", "high", "xhigh"]
       },
+      "request_rules": [
+        {"handler": "select_api_variant", "arguments": {"variant": "responses"}},
+        {"handler": "drop_parameter", "arguments": {"path": "top_p", "default": 1.0}}
+      ],
       "limits": {
         "context_window_tokens": 400000,
         "max_output_tokens": 128000
@@ -158,6 +190,10 @@
       "reasoning_capability": {
         "allowed_values": ["none", "low", "medium", "high"]
       },
+      "request_rules": [
+        {"handler": "select_api_variant", "arguments": {"variant": "responses"}},
+        {"handler": "drop_parameter", "arguments": {"path": "top_p", "default": 1.0}}
+      ],
       "limits": {
         "context_window_tokens": 400000,
         "max_output_tokens": 128000
@@ -174,6 +210,10 @@
       "reasoning_capability": {
         "allowed_values": ["minimal", "low", "medium", "high"]
       },
+      "request_rules": [
+        {"handler": "select_api_variant", "arguments": {"variant": "responses"}},
+        {"handler": "drop_parameter", "arguments": {"path": "top_p", "default": 1.0}}
+      ],
       "limits": {
         "context_window_tokens": 400000,
         "max_output_tokens": 128000
@@ -190,6 +230,10 @@
       "reasoning_capability": {
         "allowed_values": ["minimal", "low", "medium", "high"]
       },
+      "request_rules": [
+        {"handler": "select_api_variant", "arguments": {"variant": "responses"}},
+        {"handler": "drop_parameter", "arguments": {"path": "top_p", "default": 1.0}}
+      ],
       "limits": {
         "context_window_tokens": 400000,
         "max_output_tokens": 128000
@@ -206,6 +250,11 @@
       "reasoning_capability": {
         "allowed_values": ["minimal", "low", "medium", "high"]
       },
+      "request_rules": [
+        {"handler": "select_api_variant", "arguments": {"variant": "responses"}},
+        {"handler": "drop_parameter", "arguments": {"path": "top_p", "default": 1.0}},
+        {"handler": "drop_parameter", "arguments": {"path": "temperature", "default": 1.0}}
+      ],
       "limits": {
         "context_window_tokens": 400000,
         "max_output_tokens": 128000
@@ -219,6 +268,9 @@
       ]
     },
     "gpt-4.1": {
+      "request_rules": [
+        {"handler": "rename_parameter", "arguments": {"from": "max_tokens", "to": "max_completion_tokens"}}
+      ],
       "limits": {
         "context_window_tokens": 1047576,
         "max_output_tokens": 32768
@@ -232,6 +284,9 @@
       ]
     },
     "gpt-4.1-mini": {
+      "request_rules": [
+        {"handler": "rename_parameter", "arguments": {"from": "max_tokens", "to": "max_completion_tokens"}}
+      ],
       "limits": {
         "context_window_tokens": 1047576,
         "max_output_tokens": 32768
@@ -245,6 +300,9 @@
       ]
     },
     "gpt-4.1-nano": {
+      "request_rules": [
+        {"handler": "rename_parameter", "arguments": {"from": "max_tokens", "to": "max_completion_tokens"}}
+      ],
       "limits": {
         "context_window_tokens": 1047576,
         "max_output_tokens": 32768

--- a/src/llm_api_adapter/llm_registry/request_rules.py
+++ b/src/llm_api_adapter/llm_registry/request_rules.py
@@ -1,0 +1,269 @@
+"""Provider-scoped schemas for registry-backed request rule metadata.
+
+The registry JSON selects only known handler IDs and validated data. It never
+imports code, evaluates expressions, or carries arbitrary callback payloads.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, ClassVar, Dict, Optional
+
+
+class RequestRuleRegistry:
+    """Base schema shared by provider-specific request rule registries."""
+
+    SELECT_API_VARIANT: ClassVar[str] = "select_api_variant"
+    RENAME_PARAMETER: ClassVar[str] = "rename_parameter"
+    DROP_PARAMETER: ClassVar[str] = "drop_parameter"
+
+    HANDLERS: ClassVar[frozenset[str]] = frozenset(
+        {
+            SELECT_API_VARIANT,
+            RENAME_PARAMETER,
+            DROP_PARAMETER,
+        }
+    )
+    HANDLER_PHASES: ClassVar[Dict[str, int]] = {
+        SELECT_API_VARIANT: 0,
+        RENAME_PARAMETER: 1,
+        DROP_PARAMETER: 2,
+    }
+
+    provider_name: ClassVar[str] = "base"
+    supported_handlers: ClassVar[frozenset[str]] = frozenset()
+    supported_api_variants: ClassVar[frozenset[str]] = frozenset()
+    supported_parameter_renames: ClassVar[frozenset[tuple[str, str]]] = (
+        frozenset()
+    )
+    droppable_parameter_defaults: ClassVar[Dict[str, Any]] = {}
+
+    def validate_arguments(self, handler: str, arguments: Dict[str, Any]) -> None:
+        """Validate one rule against this provider's supported payload fields."""
+        if handler not in self.HANDLERS:
+            raise ValueError(f"unknown request rule handler: {handler!r}")
+        if handler not in self.supported_handlers:
+            raise ValueError(
+                f"request rule handler {handler!r} is not supported for provider "
+                f"{self.provider_name!r}"
+            )
+
+        if handler == self.SELECT_API_VARIANT:
+            self._validate_api_variant(arguments)
+        elif handler == self.RENAME_PARAMETER:
+            self._validate_parameter_rename(arguments)
+        else:
+            self._validate_parameter_drop(arguments)
+
+    def _validate_api_variant(self, arguments: Dict[str, Any]) -> None:
+        if set(arguments) != {"variant"}:
+            raise ValueError(
+                "select_api_variant arguments must contain only variant"
+            )
+        if arguments["variant"] not in self.supported_api_variants:
+            supported = ", ".join(sorted(self.supported_api_variants))
+            raise ValueError(
+                "select_api_variant.variant must be one of: "
+                f"{supported}"
+            )
+
+    def _validate_parameter_rename(self, arguments: Dict[str, Any]) -> None:
+        if set(arguments) != {"from", "to"}:
+            raise ValueError(
+                "rename_parameter arguments must contain only from and to"
+            )
+        source = arguments["from"]
+        target = arguments["to"]
+        if (source, target) not in self.supported_parameter_renames:
+            raise ValueError(
+                f"unsupported request parameter rename: {source!r} -> {target!r}"
+            )
+
+    def _validate_parameter_drop(self, arguments: Dict[str, Any]) -> None:
+        if set(arguments) not in ({"path"}, {"path", "default"}):
+            raise ValueError(
+                "drop_parameter arguments must contain path and optional default"
+            )
+        path = arguments["path"]
+        self._validate_droppable_path(path)
+        if "default" not in arguments:
+            return
+        default = arguments["default"]
+        expected_default = self.droppable_parameter_defaults[path]
+        if isinstance(default, bool) or default != expected_default:
+            raise ValueError(
+                f"request rule default for {path!r} must be {expected_default!r}"
+            )
+
+    def _validate_droppable_path(self, path: Any) -> None:
+        if (
+            not isinstance(path, str)
+            or path not in self.droppable_parameter_defaults
+        ):
+            raise ValueError(f"unsupported request parameter path: {path!r}")
+
+
+class SamplingRequestRuleRegistry(RequestRuleRegistry):
+    """Shared sampling-parameter rules used by OpenAI and Anthropic."""
+
+    supported_handlers = frozenset(
+        {
+            RequestRuleRegistry.DROP_PARAMETER,
+        }
+    )
+    droppable_parameter_defaults = {"top_p": 1.0}
+
+
+class OpenAIRequestRuleRegistry(SamplingRequestRuleRegistry):
+    provider_name = "openai"
+    supported_handlers = SamplingRequestRuleRegistry.supported_handlers | frozenset(
+        {
+            RequestRuleRegistry.SELECT_API_VARIANT,
+            RequestRuleRegistry.RENAME_PARAMETER,
+        }
+    )
+    supported_api_variants = frozenset({"chat_completions", "responses"})
+    supported_parameter_renames = frozenset(
+        {
+            ("max_tokens", "max_completion_tokens"),
+        }
+    )
+    droppable_parameter_defaults = {
+        **SamplingRequestRuleRegistry.droppable_parameter_defaults,
+        "temperature": 1.0,
+    }
+
+
+class AnthropicRequestRuleRegistry(SamplingRequestRuleRegistry):
+    provider_name = "anthropic"
+
+
+class GoogleRequestRuleRegistry(RequestRuleRegistry):
+    provider_name = "google"
+    supported_handlers = frozenset(
+        {
+            RequestRuleRegistry.DROP_PARAMETER,
+        }
+    )
+    droppable_parameter_defaults = {"generationConfig.maxOutputTokens": None}
+
+
+REQUEST_RULE_REGISTRIES: Dict[str, RequestRuleRegistry] = {
+    "openai": OpenAIRequestRuleRegistry(),
+    "anthropic": AnthropicRequestRuleRegistry(),
+    "google": GoogleRequestRuleRegistry(),
+}
+REQUEST_RULE_HANDLERS = RequestRuleRegistry.HANDLERS
+
+
+@dataclass(frozen=True)
+class RequestRule:
+    """One validated request transformation selected by a model's metadata."""
+
+    handler: str
+    arguments: Dict[str, Any]
+
+    @classmethod
+    def from_dict(
+        cls,
+        data: Any,
+        *,
+        rule_registry: RequestRuleRegistry,
+    ) -> "RequestRule":
+        if not isinstance(data, dict) or set(data) != {"handler", "arguments"}:
+            raise ValueError("request rule must contain only handler and arguments")
+
+        handler = data["handler"]
+        arguments = data["arguments"]
+        if not isinstance(handler, str):
+            raise ValueError(f"unknown request rule handler: {handler!r}")
+        if not isinstance(arguments, dict):
+            raise ValueError("request rule arguments must be an object")
+
+        rule_registry.validate_arguments(handler, arguments)
+        return cls(handler=handler, arguments=dict(arguments))
+
+    @property
+    def affected_paths(self) -> tuple[str, ...]:
+        """Return the payload paths that this rule reads or writes."""
+        if self.handler == RequestRuleRegistry.RENAME_PARAMETER:
+            return (self.arguments["from"], self.arguments["to"])
+        if self.handler == RequestRuleRegistry.DROP_PARAMETER:
+            return (self.arguments["path"],)
+        return ()
+
+
+@dataclass(frozen=True)
+class RequestRules:
+    """Ordered, conflict-free request rules attached to one ``ModelSpec``."""
+
+    rules: tuple[RequestRule, ...] = ()
+
+    @classmethod
+    def from_dict(
+        cls,
+        data: Any,
+        *,
+        rule_registry: RequestRuleRegistry,
+    ) -> "RequestRules":
+        if not isinstance(data, list):
+            raise ValueError("request_rules must be an array")
+        rules = tuple(
+            RequestRule.from_dict(rule_data, rule_registry=rule_registry)
+            for rule_data in data
+        )
+        cls._validate_rule_order(rules)
+        return cls(rules=rules)
+
+    @staticmethod
+    def _validate_rule_order(rules: tuple[RequestRule, ...]) -> None:
+        last_phase = -1
+        selected_api_variant = False
+        affected_paths: set[str] = set()
+        for rule in rules:
+            phase = RequestRuleRegistry.HANDLER_PHASES[rule.handler]
+            if phase < last_phase:
+                raise ValueError("request rules have a conflicting execution order")
+            last_phase = phase
+
+            if rule.handler == RequestRuleRegistry.SELECT_API_VARIANT:
+                if selected_api_variant:
+                    raise ValueError("request rules select more than one API variant")
+                selected_api_variant = True
+
+            conflicts = affected_paths.intersection(rule.affected_paths)
+            if conflicts:
+                raise ValueError(
+                    "request rules conflict on parameter path(s): "
+                    f"{', '.join(sorted(conflicts))}"
+                )
+            affected_paths.update(rule.affected_paths)
+
+    @property
+    def api_variant(self) -> Optional[str]:
+        """Return the model-selected OpenAI API variant, if one is declared."""
+        for rule in self.rules:
+            if rule.handler == RequestRuleRegistry.SELECT_API_VARIANT:
+                return rule.arguments["variant"]
+        return None
+
+
+def request_rule_registry_for_provider(
+    provider_name: str,
+) -> Optional[RequestRuleRegistry]:
+    """Return a provider's closed rule schema, if the provider defines one."""
+    return REQUEST_RULE_REGISTRIES.get(provider_name)
+
+
+__all__ = [
+    "AnthropicRequestRuleRegistry",
+    "GoogleRequestRuleRegistry",
+    "OpenAIRequestRuleRegistry",
+    "REQUEST_RULE_HANDLERS",
+    "REQUEST_RULE_REGISTRIES",
+    "RequestRule",
+    "RequestRuleRegistry",
+    "RequestRules",
+    "SamplingRequestRuleRegistry",
+    "request_rule_registry_for_provider",
+]

--- a/src/llm_api_adapter/llm_registry/request_rules.py
+++ b/src/llm_api_adapter/llm_registry/request_rules.py
@@ -6,8 +6,15 @@ imports code, evaluates expressions, or carries arbitrary callback payloads.
 
 from __future__ import annotations
 
+import copy
 from dataclasses import dataclass
-from typing import Any, ClassVar, Dict, Optional
+import logging
+from typing import Any, ClassVar, Dict, Mapping, Optional
+import warnings
+
+
+logger = logging.getLogger(__name__)
+_MISSING = object()
 
 
 class RequestRuleRegistry:
@@ -248,6 +255,90 @@ class RequestRules:
         return None
 
 
+@dataclass(frozen=True)
+class AppliedRequestRule:
+    """One request rule that changed a payload during execution."""
+
+    handler: str
+    path: str
+    target_path: Optional[str] = None
+    warning_emitted: bool = False
+
+
+def apply_request_rules(
+    payload: Mapping[str, Any],
+    request_rules: RequestRules,
+    *,
+    model: str,
+) -> tuple[dict[str, Any], tuple[AppliedRequestRule, ...]]:
+    """Apply registry request rules to a copied payload.
+
+    API variant selection is transport metadata, so it is intentionally not a
+    payload transformation. A parameter with a declared default is removed
+    quietly when its value matches that default; any other removed value emits
+    one warning and one log record.
+    """
+    transformed_payload = copy.deepcopy(dict(payload))
+    applied_rules: list[AppliedRequestRule] = []
+
+    for rule in request_rules.rules:
+        if rule.handler == RequestRuleRegistry.RENAME_PARAMETER:
+            source = rule.arguments["from"]
+            target = rule.arguments["to"]
+            value = transformed_payload.pop(source, _MISSING)
+            if value is _MISSING:
+                continue
+            transformed_payload[target] = value
+            applied_rules.append(
+                AppliedRequestRule(
+                    handler=rule.handler,
+                    path=source,
+                    target_path=target,
+                )
+            )
+            continue
+
+        if rule.handler == RequestRuleRegistry.DROP_PARAMETER:
+            path = rule.arguments["path"]
+            value = _pop_payload_path(transformed_payload, path)
+            if value is _MISSING:
+                continue
+
+            warning_emitted = False
+            if "default" in rule.arguments and value != rule.arguments["default"]:
+                _warn_ignored_parameter(path, model)
+                warning_emitted = True
+            applied_rules.append(
+                AppliedRequestRule(
+                    handler=rule.handler,
+                    path=path,
+                    warning_emitted=warning_emitted,
+                )
+            )
+
+    return transformed_payload, tuple(applied_rules)
+
+
+def _pop_payload_path(payload: dict[str, Any], path: str) -> Any:
+    """Pop a validated dotted path, returning a sentinel when it is absent."""
+    target = payload
+    *parents, leaf = path.split(".")
+    for parent in parents:
+        nested = target.get(parent)
+        if not isinstance(nested, dict):
+            return _MISSING
+        target = nested
+    return target.pop(leaf, _MISSING)
+
+
+def _warn_ignored_parameter(path: str, model: str) -> None:
+    message = (
+        f"Parameter {path!r} is not supported for model {model!r} and will be ignored."
+    )
+    warnings.warn(message, UserWarning, stacklevel=3)
+    logger.warning(message)
+
+
 def request_rule_registry_for_provider(
     provider_name: str,
 ) -> Optional[RequestRuleRegistry]:
@@ -256,6 +347,7 @@ def request_rule_registry_for_provider(
 
 
 __all__ = [
+    "AppliedRequestRule",
     "AnthropicRequestRuleRegistry",
     "GoogleRequestRuleRegistry",
     "OpenAIRequestRuleRegistry",
@@ -265,5 +357,6 @@ __all__ = [
     "RequestRuleRegistry",
     "RequestRules",
     "SamplingRequestRuleRegistry",
+    "apply_request_rules",
     "request_rule_registry_for_provider",
 ]

--- a/src/llm_api_adapter/llms/anthropic/sync_client.py
+++ b/src/llm_api_adapter/llms/anthropic/sync_client.py
@@ -12,6 +12,7 @@ from ...errors.llm_api_error import (
     LLMAPIServerError,
     LLMAPITimeoutError,
 )
+from ..request_rules import apply_model_request_rules
 from ..streaming import SSEEvent, stream_request
 
 logger = logging.getLogger(__name__)
@@ -49,6 +50,7 @@ class ClaudeSyncClient:
         return self._stream_request(url, payload, timeout_s)
 
     def _prepare_chat_payload_for_model(self, model: str, kwargs: dict) -> dict:
+        kwargs = dict(kwargs)
         budget_tokens = kwargs.pop("budget_tokens", None)
         effort = kwargs.pop("effort", None)
         is_adaptive_thinking = kwargs.pop("is_adaptive_thinking", False)
@@ -60,17 +62,18 @@ class ClaudeSyncClient:
                 existing = kwargs.get("output_config", {})
                 kwargs["output_config"] = {**existing, "effort": effort}
         else:
-            if model.startswith(
-                ("claude-sonnet-4-5", "claude-haiku-4-5", "claude-opus-4-5")
-            ):
-                kwargs.pop("top_p", None)
             if budget_tokens:
                 kwargs["thinking"] = {"type": "enabled", "budget_tokens": budget_tokens}
         if capture_reasoning:
             thinking = kwargs.get("thinking")
             if isinstance(thinking, dict):
                 kwargs["thinking"] = {**thinking, "display": "summarized"}
-        return {"model": model, **kwargs}
+        payload, _ = apply_model_request_rules(
+            "anthropic",
+            model,
+            {"model": model, **kwargs},
+        )
+        return payload
 
     def _send_request(self, url: str, payload: dict, timeout_s: float | None = None):
         try:

--- a/src/llm_api_adapter/llms/google/sync_client.py
+++ b/src/llm_api_adapter/llms/google/sync_client.py
@@ -11,6 +11,7 @@ from ...errors.llm_api_error import (
     LLMAPIServerError,
     LLMAPITimeoutError,
 )
+from ..request_rules import apply_model_request_rules
 from ..streaming import SSEEvent, stream_request
 
 logger = logging.getLogger(__name__)
@@ -45,12 +46,12 @@ class GeminiSyncClient:
         return self._stream_request(url, payload, timeout_s)
 
     def _prepare_chat_payload_for_model(self, model: str, kwargs: dict) -> dict:
-        gen_cfg = kwargs.get("generationConfig", {})
-        if "maxOutputTokens" in gen_cfg:
-            if model.startswith(("gemini-2.5")):
-                gen_cfg.pop("maxOutputTokens", None)
-                kwargs["generationConfig"] = gen_cfg
-        return {"model": model, **kwargs}
+        payload, _ = apply_model_request_rules(
+            "google",
+            model,
+            {"model": model, **kwargs},
+        )
+        return payload
 
     def _send_request(self, url: str, payload: dict, timeout_s: float | None = None):
         try:

--- a/src/llm_api_adapter/llms/openai/sync_client.py
+++ b/src/llm_api_adapter/llms/openai/sync_client.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass
 import logging
 from typing import Iterator, Mapping
 import requests
-import warnings
 
 from ...errors.llm_api_error import (
     LLMAPIAuthorizationError,
@@ -12,6 +11,12 @@ from ...errors.llm_api_error import (
     LLMAPIServerError,
     LLMAPITimeoutError,
     LLMAPIUsageLimitError,
+)
+from ...llm_registry.llm_registry import CategoricalReasoningCapability
+from ..request_rules import (
+    apply_model_request_rules,
+    model_api_variant,
+    model_spec_for,
 )
 from ..streaming import SSEEvent, stream_request
 
@@ -75,14 +80,15 @@ class OpenAISyncClient:
         return self._stream_request(url, payload, timeout)
 
     def _should_use_responses_api(self, model: str) -> bool:
-        return model.startswith("gpt-5")
+        return model_api_variant("openai", model) == "responses"
 
     def _prepare_chat_payload_for_model(self, model: str, kwargs: dict) -> dict:
-        kwargs = dict(kwargs)
-        if model.startswith(("gpt-4.1", "o1")):
-            if "max_tokens" in kwargs:
-                kwargs["max_completion_tokens"] = kwargs.pop("max_tokens")
-        return {"model": model, **kwargs}
+        payload, _ = apply_model_request_rules(
+            "openai",
+            model,
+            {"model": model, **kwargs},
+        )
+        return payload
 
     def _prepare_responses_payload_for_model(self, model: str, kwargs: dict) -> dict:
         payload = {"model": model, **dict(kwargs)}
@@ -94,30 +100,26 @@ class OpenAISyncClient:
         capture_reasoning = payload.pop("capture_reasoning", False)
         reasoning: dict = {}
         if reasoning_effort is not None:
-            if model in ("gpt-5", "gpt-5-nano", "gpt-5-mini") and reasoning_effort == "none":
+            if self._uses_minimal_reasoning_for_none(model) and reasoning_effort == "none":
                 reasoning_effort = "minimal"
             reasoning["effort"] = reasoning_effort
         if capture_reasoning:
             reasoning["summary"] = "auto"
         if reasoning:
             payload["reasoning"] = reasoning
-        if model.startswith("gpt-5-nano"):
-            temperature = payload.pop("temperature", None)
-            if temperature not in (None, 1.0):
-                warning_message = (
-                    f"Parameter 'temperature' is not supported for model '{model}' "
-                    "and will be ignored."
-                )
-                warnings.warn(warning_message, stacklevel=2)
-                logger.warning(warning_message)
-        if model.startswith("gpt-5") and "top_p" in payload:
-            warning_message = (
-                f"Parameter 'top_p' is not supported for model '{model}' and will be ignored."
-            )
-            warnings.warn(warning_message, stacklevel=2)
-            logger.warning(warning_message)
-            payload.pop("top_p")
+        payload, _ = apply_model_request_rules("openai", model, payload)
         return payload
+
+    @staticmethod
+    def _uses_minimal_reasoning_for_none(model: str) -> bool:
+        """Map legacy ``none`` to the first native effort level when required."""
+        model_spec = model_spec_for("openai", model)
+        capability = model_spec.reasoning_capability if model_spec else None
+        return (
+            isinstance(capability, CategoricalReasoningCapability)
+            and "none" not in capability.allowed_values
+            and "minimal" in capability.allowed_values
+        )
 
     def _send_request(self, url: str, payload: dict, timeout: float | None = None):
         try:

--- a/src/llm_api_adapter/llms/request_rules.py
+++ b/src/llm_api_adapter/llms/request_rules.py
@@ -1,0 +1,42 @@
+"""Shared registry lookups for provider-client request payloads."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+from ..llm_registry.llm_registry import LLM_REGISTRY, ModelSpec
+from ..llm_registry.request_rules import (
+    AppliedRequestRule,
+    RequestRules,
+    apply_request_rules,
+)
+
+
+def model_spec_for(provider_name: str, model_name: str) -> Optional[ModelSpec]:
+    """Return the verified model metadata for a provider, if it is known."""
+    provider = LLM_REGISTRY.providers.get(provider_name)
+    return provider.models.get(model_name) if provider else None
+
+
+def model_api_variant(provider_name: str, model_name: str) -> Optional[str]:
+    """Return the API variant selected by a model's registered request rules."""
+    model_spec = model_spec_for(provider_name, model_name)
+    return model_spec.request_rules.api_variant if model_spec else None
+
+
+def apply_model_request_rules(
+    provider_name: str,
+    model_name: str,
+    payload: Mapping[str, Any],
+) -> tuple[dict[str, Any], tuple[AppliedRequestRule, ...]]:
+    """Apply a verified model's request rules, or no rules for an unknown model."""
+    model_spec = model_spec_for(provider_name, model_name)
+    request_rules = model_spec.request_rules if model_spec else RequestRules()
+    return apply_request_rules(payload, request_rules, model=model_name)
+
+
+__all__ = [
+    "apply_model_request_rules",
+    "model_api_variant",
+    "model_spec_for",
+]

--- a/src/llm_api_adapter/llms/request_rules.py
+++ b/src/llm_api_adapter/llms/request_rules.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Optional
 
-from ..llm_registry.llm_registry import LLM_REGISTRY, ModelSpec
+from ..llm_registry.llm_registry import LLM_REGISTRY, ModelSpec, resolve_model_spec
 from ..llm_registry.request_rules import (
     AppliedRequestRule,
     RequestRules,
@@ -13,9 +13,8 @@ from ..llm_registry.request_rules import (
 
 
 def model_spec_for(provider_name: str, model_name: str) -> Optional[ModelSpec]:
-    """Return the verified model metadata for a provider, if it is known."""
-    provider = LLM_REGISTRY.providers.get(provider_name)
-    return provider.models.get(model_name) if provider else None
+    """Return verified metadata for an exact model or supported snapshot ID."""
+    return resolve_model_spec(LLM_REGISTRY, provider_name, model_name)
 
 
 def model_api_variant(provider_name: str, model_name: str) -> Optional[str]:

--- a/tests/integration/test_llm_adapter_chat.py
+++ b/tests/integration/test_llm_adapter_chat.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 import requests_mock
 
@@ -128,6 +130,30 @@ def test_openai_chat_gpt5_responses_api(openai_responses_mock):
 
 
 @pytest.mark.integration
+def test_openai_snapshot_uses_responses_api_and_registered_base_rules(
+    openai_responses_mock,
+):
+    model = "gpt-5-2025-08-07"
+    adapter = UniversalLLMAPIAdapter(
+        organization="openai",
+        model=model,
+        api_key="dummy_key",
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        response = adapter.chat([UserMessage("Hi")], max_tokens=64, top_p=1.0)
+
+    request = openai_responses_mock.last_request
+    assert response.content == "Hello from mocked OpenAI!"
+    assert request.url == "https://api.openai.com/v1/responses"
+    assert request.json()["model"] == model
+    assert request.json()["max_output_tokens"] == 64
+    assert "top_p" not in request.json()
+    assert caught == []
+
+
+@pytest.mark.integration
 def test_openai_chat_with_raw_dict_messages_gpt5_responses_api(
     openai_responses_mock,
 ):
@@ -228,6 +254,28 @@ def test_anthropic_chat(anthropic_client_mock):
     resp = adapter.chat(messages=messages, max_tokens=2000)
 
     assert resp.content == "Hello from mocked Anthropic!"
+
+
+@pytest.mark.integration
+def test_anthropic_snapshot_uses_registered_base_rules(anthropic_client_mock):
+    model = "claude-sonnet-4-5-20250929"
+    adapter = UniversalLLMAPIAdapter(
+        organization="anthropic",
+        model=model,
+        api_key="dummy_key",
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        response = adapter.chat([UserMessage("Hi")], max_tokens=64, top_p=1.0)
+
+    request = anthropic_client_mock.last_request
+    assert response.content == "Hello from mocked Anthropic!"
+    assert request.url == "https://api.anthropic.com/v1/messages"
+    assert request.json()["model"] == model
+    assert request.json()["max_tokens"] == 64
+    assert "top_p" not in request.json()
+    assert caught == []
 
 
 @pytest.mark.integration

--- a/tests/integration/test_streaming.py
+++ b/tests/integration/test_streaming.py
@@ -459,11 +459,7 @@ def test_openai_responses_streams_through_universal_adapter():
         )
         done = []
 
-        with pytest.warns(
-            UserWarning,
-            match="Parameter 'top_p' is not supported for model 'gpt-5'",
-        ):
-            assert list(adapter.stream_chat([UserMessage("Hi")], on_done=done.append)) == ["Hello"]
+        assert list(adapter.stream_chat([UserMessage("Hi")], on_done=done.append)) == ["Hello"]
 
     request = mock.last_request
     assert mock_post.call_args.args[0] == "https://api.openai.com/v1/responses"
@@ -472,6 +468,7 @@ def test_openai_responses_streams_through_universal_adapter():
     assert request.headers["Content-Type"] == "application/json"
     assert request.json()["stream"] is True
     assert request.json()["input"] == [{"role": "user", "content": "Hi"}]
+    assert "top_p" not in request.json()
     assert done[0].response_id == "resp_123"
     assert done[0].usage.total_tokens == 3
 

--- a/tests/integration/test_tools.py
+++ b/tests/integration/test_tools.py
@@ -82,7 +82,7 @@ def openai_tools_mock():
                 {
                     "json": {
                         "id": "resp_1",
-                        "model": "gpt-5.2-pro",
+                        "model": "gpt-5.2",
                         "status": "completed",
                         "output": [
                             {
@@ -102,7 +102,7 @@ def openai_tools_mock():
                 {
                     "json": {
                         "id": "resp_2",
-                        "model": "gpt-5.2-pro",
+                        "model": "gpt-5.2",
                         "status": "completed",
                         "output": [
                             {
@@ -226,7 +226,7 @@ def openai_multi_tools_mock():
                 {
                     "json": {
                         "id": "resp_multi_1",
-                        "model": "gpt-5.2-pro",
+                        "model": "gpt-5.2",
                         "status": "completed",
                         "output": [
                             {
@@ -252,7 +252,7 @@ def openai_multi_tools_mock():
                 {
                     "json": {
                         "id": "resp_multi_2",
-                        "model": "gpt-5.2-pro",
+                        "model": "gpt-5.2",
                         "status": "completed",
                         "output": [
                             {
@@ -383,7 +383,7 @@ def google_multi_tools_mock():
 def test_openai_gpt5_tool_call_parsing_and_request_mapping(openai_tools_mock):
     adapter = UniversalLLMAPIAdapter(
         organization="openai",
-        model="gpt-5.2-pro",
+        model="gpt-5.2",
         api_key="dummy_key",
     )
     messages = [
@@ -410,7 +410,7 @@ def test_openai_gpt5_tool_call_parsing_and_request_mapping(openai_tools_mock):
     first_request = openai_tools_mock.request_history[0]
     payload = first_request.json()
 
-    assert payload["model"] == "gpt-5.2-pro"
+    assert payload["model"] == "gpt-5.2"
     assert payload["input"] == [{"role": "user", "content": "What's the weather in Tel Aviv today?"}]
     assert payload["instructions"] == "You are a helpful assistant. If user asks about weather, call get_weather."
     assert payload["tool_choice"] == "auto"
@@ -435,7 +435,7 @@ def test_openai_gpt5_tool_call_parsing_and_request_mapping(openai_tools_mock):
 def test_openai_gpt5_tool_loop_with_previous_response(openai_tools_mock):
     adapter = UniversalLLMAPIAdapter(
         organization="openai",
-        model="gpt-5.2-pro",
+        model="gpt-5.2",
         api_key="dummy_key",
     )
     messages = [
@@ -713,7 +713,7 @@ def test_google_tool_call_and_tool_result_protocol(google_tools_mock):
 def test_openai_gpt5_multi_tool_round_trip(openai_multi_tools_mock):
     adapter = UniversalLLMAPIAdapter(
         organization="openai",
-        model="gpt-5.2-pro",
+        model="gpt-5.2",
         api_key="dummy_key",
     )
     messages = _multi_tool_messages()
@@ -932,7 +932,7 @@ async def test_openai_async_gpt5_multi_tool_round_trip():
     responses = [
         {
             "id": "async_resp_multi_1",
-            "model": "gpt-5.2-pro",
+            "model": "gpt-5.2",
             "status": "completed",
             "output": [
                 {
@@ -951,7 +951,7 @@ async def test_openai_async_gpt5_multi_tool_round_trip():
         },
         {
             "id": "async_resp_multi_2",
-            "model": "gpt-5.2-pro",
+            "model": "gpt-5.2",
             "status": "completed",
             "output": [
                 {
@@ -972,7 +972,7 @@ async def test_openai_async_gpt5_multi_tool_round_trip():
 
         adapter = UniversalLLMAPIAdapter(
             organization="openai",
-            model="gpt-5.2-pro",
+            model="gpt-5.2",
             api_key="dummy_key",
         )
         messages = _multi_tool_messages()

--- a/tests/unit/adapters/test_base_adapter.py
+++ b/tests/unit/adapters/test_base_adapter.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 from inspect import signature
 from unittest.mock import patch
+import warnings
 
 import pytest
 from pydantic import BaseModel
@@ -74,6 +75,24 @@ def make_tool(name="weather", schema=None, description="desc"):
             },
         }
     return ToolSpec(name=name, description=description, json_schema=schema)
+
+
+@pytest.mark.unit
+def test_snapshot_model_uses_its_registered_base_metadata_without_warning():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        adapter = _TestAdapter(
+            company="openai",
+            api_key="dummy_key",
+            model="gpt-5-2025-08-07",
+        )
+
+    assert caught == []
+    assert adapter.model == "gpt-5-2025-08-07"
+    assert adapter.model_spec is not None
+    assert adapter.model_spec.name == "gpt-5"
+    assert adapter.pricing is not None
+    assert adapter.is_reasoning is True
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/adapters/test_request_rule_conformance.py
+++ b/tests/unit/adapters/test_request_rule_conformance.py
@@ -1,0 +1,216 @@
+"""Conformance checks for registry-backed payload rules at the adapter boundary."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+from unittest.mock import AsyncMock, Mock, patch
+import warnings
+
+import pytest
+
+from src.llm_api_adapter.adapters.anthropic.adapter import AnthropicAdapter
+from src.llm_api_adapter.adapters.google.adapter import GoogleAdapter
+from src.llm_api_adapter.adapters.openai.adapter import OpenAIAdapter
+from src.llm_api_adapter.llms.anthropic.async_client import ClaudeAsyncClient
+from src.llm_api_adapter.llms.anthropic.sync_client import ClaudeSyncClient
+from src.llm_api_adapter.llms.google.async_client import GeminiAsyncClient
+from src.llm_api_adapter.llms.google.sync_client import GeminiSyncClient
+from src.llm_api_adapter.llms.openai.async_client import OpenAIAsyncClient
+from src.llm_api_adapter.llms.openai.sync_client import OpenAISyncClient
+from src.llm_api_adapter.models.messages.chat_message import UserMessage
+
+
+@dataclass(frozen=True)
+class _Response:
+    data: dict[str, Any]
+
+    def json(self) -> dict[str, Any]:
+        return self.data
+
+
+@dataclass(frozen=True)
+class RequestRuleConformanceCase:
+    name: str
+    adapter_class: type[Any]
+    sync_client_class: type[Any]
+    async_client_class: type[Any]
+    model: str
+    message_key: str
+    ignored_paths: tuple[str, ...]
+    default_kwargs: dict[str, Any]
+    non_default_kwargs: dict[str, Any]
+    response_factory: Callable[[], dict[str, Any]]
+
+
+def _openai_response() -> dict[str, Any]:
+    return {
+        "id": "resp_123",
+        "model": "gpt-5-nano",
+        "created_at": 123,
+        "status": "completed",
+        "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+        "output": [{
+            "type": "message",
+            "content": [{"type": "output_text", "text": "ok"}],
+        }],
+    }
+
+
+def _anthropic_response() -> dict[str, Any]:
+    return {
+        "id": "msg_123",
+        "model": "claude-sonnet-4-5",
+        "stop_reason": "end_turn",
+        "content": [{"type": "text", "text": "ok"}],
+        "usage": {"input_tokens": 1, "output_tokens": 1},
+    }
+
+
+def _google_response() -> dict[str, Any]:
+    return {
+        "modelVersion": "gemini-2.5-flash",
+        "candidates": [{
+            "content": {"parts": [{"text": "ok"}]},
+            "finishReason": "STOP",
+        }],
+        "usageMetadata": {
+            "promptTokenCount": 1,
+            "candidatesTokenCount": 1,
+            "totalTokenCount": 2,
+        },
+    }
+
+
+CASES = (
+    pytest.param(
+        RequestRuleConformanceCase(
+            name="openai",
+            adapter_class=OpenAIAdapter,
+            sync_client_class=OpenAISyncClient,
+            async_client_class=OpenAIAsyncClient,
+            model="gpt-5-nano",
+            message_key="input",
+            ignored_paths=("top_p", "temperature"),
+            default_kwargs={"max_tokens": 64, "top_p": 1.0, "temperature": 1.0},
+            non_default_kwargs={"max_tokens": 64, "top_p": 0.2, "temperature": 0.2},
+            response_factory=_openai_response,
+        ),
+        id="openai",
+    ),
+    pytest.param(
+        RequestRuleConformanceCase(
+            name="anthropic",
+            adapter_class=AnthropicAdapter,
+            sync_client_class=ClaudeSyncClient,
+            async_client_class=ClaudeAsyncClient,
+            model="claude-sonnet-4-5",
+            message_key="messages",
+            ignored_paths=("top_p",),
+            default_kwargs={"max_tokens": 64, "top_p": 1.0},
+            non_default_kwargs={"max_tokens": 64, "top_p": 0.2},
+            response_factory=_anthropic_response,
+        ),
+        id="anthropic",
+    ),
+    pytest.param(
+        RequestRuleConformanceCase(
+            name="google",
+            adapter_class=GoogleAdapter,
+            sync_client_class=GeminiSyncClient,
+            async_client_class=GeminiAsyncClient,
+            model="gemini-2.5-flash",
+            message_key="contents",
+            ignored_paths=("generationConfig.maxOutputTokens",),
+            default_kwargs={"max_tokens": None},
+            non_default_kwargs={"max_tokens": 64},
+            response_factory=_google_response,
+        ),
+        id="google",
+    ),
+)
+
+
+def _make_adapter(case: RequestRuleConformanceCase):
+    return case.adapter_class(api_key="test_api_key", model=case.model)
+
+
+def _sync_chat(case: RequestRuleConformanceCase, kwargs: dict[str, Any]):
+    transport = Mock(return_value=_Response(case.response_factory()))
+    with patch.object(case.sync_client_class, "_send_request", new=transport):
+        response = _make_adapter(case).chat([UserMessage("hi")], **kwargs)
+    return response, transport.call_args.args[1]
+
+
+async def _async_chat(case: RequestRuleConformanceCase, kwargs: dict[str, Any]):
+    transport = AsyncMock(return_value=case.response_factory())
+    with patch.object(case.async_client_class, "_send_request", new=transport):
+        response = await _make_adapter(case).achat([UserMessage("hi")], **kwargs)
+    return response, transport.await_args.args[1]
+
+
+def _assert_paths_are_absent(payload: dict[str, Any], paths: tuple[str, ...]) -> None:
+    for path in paths:
+        target = payload
+        *parents, leaf = path.split(".")
+        for parent in parents:
+            target = target[parent]
+        assert leaf not in target
+
+
+def _expected_warning_messages(case: RequestRuleConformanceCase) -> list[str]:
+    return [
+        f"Parameter {path!r} is not supported for model {case.model!r} and will be ignored."
+        for path in case.ignored_paths
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+@pytest.mark.parametrize("case", CASES)
+async def test_adapter_chat_silently_omits_registered_default_values(case):
+    with warnings.catch_warnings(record=True) as sync_warnings:
+        warnings.simplefilter("always")
+        sync_response, sync_payload = _sync_chat(
+            case,
+            dict(case.default_kwargs),
+        )
+    with warnings.catch_warnings(record=True) as async_warnings:
+        warnings.simplefilter("always")
+        async_response, async_payload = await _async_chat(
+            case,
+            dict(case.default_kwargs),
+        )
+
+    assert sync_response.content == async_response.content == "ok"
+    assert sync_payload == async_payload
+    assert sync_payload["model"] == case.model
+    assert sync_payload[case.message_key]
+    _assert_paths_are_absent(sync_payload, case.ignored_paths)
+    assert sync_warnings == []
+    assert async_warnings == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+@pytest.mark.parametrize("case", CASES)
+async def test_adapter_chat_warns_for_registered_non_default_values(case):
+    with warnings.catch_warnings(record=True) as sync_warnings:
+        warnings.simplefilter("always")
+        sync_response, sync_payload = _sync_chat(
+            case,
+            dict(case.non_default_kwargs),
+        )
+    with warnings.catch_warnings(record=True) as async_warnings:
+        warnings.simplefilter("always")
+        async_response, async_payload = await _async_chat(
+            case,
+            dict(case.non_default_kwargs),
+        )
+
+    assert sync_response.content == async_response.content == "ok"
+    assert sync_payload == async_payload
+    _assert_paths_are_absent(sync_payload, case.ignored_paths)
+    expected_messages = _expected_warning_messages(case)
+    assert [str(warning.message) for warning in sync_warnings] == expected_messages
+    assert [str(warning.message) for warning in async_warnings] == expected_messages

--- a/tests/unit/llm_registry/test_llm_registry.py
+++ b/tests/unit/llm_registry/test_llm_registry.py
@@ -143,9 +143,9 @@ def test_pricing_tier_for_prompt_tokens_uses_inclusive_boundaries():
 def test_model_and_provider_from_dict():
     model_data = _model_data()
 
-    model = ModelSpec.from_dict("gpt-test", model_data)
+    model = ModelSpec.from_dict("gpt-5", model_data)
 
-    assert model.name == "gpt-test"
+    assert model.name == "gpt-5"
     assert model.limits == ModelLimits(
         context_window_tokens=128_000,
         max_output_tokens=16_384,
@@ -160,14 +160,14 @@ def test_model_and_provider_from_dict():
 
     provider = ProviderSpec.from_dict(
         "prov",
-        {"currency": "EUR", "models": {"gpt-test": model_data}},
+        {"currency": "EUR", "models": {"gpt-5": model_data}},
     )
 
     assert provider.name == "prov"
     assert provider.currency == "EUR"
-    assert "gpt-test" in provider.models
-    assert isinstance(provider.models["gpt-test"], ModelSpec)
-    assert provider.models["gpt-test"].pricing_tiers.currency == "EUR"
+    assert "gpt-5" in provider.models
+    assert isinstance(provider.models["gpt-5"], ModelSpec)
+    assert provider.models["gpt-5"].pricing_tiers.currency == "EUR"
 
 
 @pytest.mark.unit
@@ -185,7 +185,7 @@ def test_model_request_rules_load_as_validated_metadata():
     ]
 
     model = ModelSpec.from_dict(
-        "gpt-test",
+        "gpt-5",
         model_data,
         request_rule_registry=OpenAIRequestRuleRegistry(),
     )
@@ -336,7 +336,7 @@ def test_request_rule_schemas_are_scoped_to_their_provider():
 
     with pytest.raises(ValueError, match="not supported for provider 'anthropic'"):
         ModelSpec.from_dict(
-            "claude-test",
+            "claude-sonnet-4-5",
             model_data,
             request_rule_registry=AnthropicRequestRuleRegistry(),
         )
@@ -349,7 +349,7 @@ def test_request_rule_schemas_are_scoped_to_their_provider():
     ]
     with pytest.raises(ValueError, match="unsupported request parameter path"):
         ModelSpec.from_dict(
-            "gemini-test",
+            "gemini-2.5-flash",
             model_data,
             request_rule_registry=GoogleRequestRuleRegistry(),
         )

--- a/tests/unit/llm_registry/test_llm_registry.py
+++ b/tests/unit/llm_registry/test_llm_registry.py
@@ -14,6 +14,8 @@ from src.llm_api_adapter.llm_registry.llm_registry import (
     PricingTier,
     ProviderSpec,
     RegistrySpec,
+    LLM_REGISTRY,
+    resolve_model_spec,
 )
 from src.llm_api_adapter.llm_registry.request_rules import (
     AnthropicRequestRuleRegistry,
@@ -27,6 +29,33 @@ from src.llm_api_adapter.llm_registry.request_rules import (
 
 
 SONNET_5_STANDARD_PRICING_DATE = date(2026, 9, 1)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("provider_name", "model_name", "expected_base_name"),
+    (
+        ("anthropic", "claude-sonnet-4-5-20250929", "claude-sonnet-4-5"),
+        ("openai", "gpt-5-2025-08-07", "gpt-5"),
+        ("openai", "gpt-4.1-2025-04-14", "gpt-4.1"),
+        ("google", "gemini-2.5-flash-preview-04-17", None),
+        ("anthropic", "claude-sonnet-4-5-20251301", None),
+        ("openai", "gpt-5-2025-13-01", None),
+        ("openai", "ft:gpt-5:example:custom-2025-08-07", None),
+    ),
+)
+def test_resolve_model_spec_supports_only_verified_provider_snapshots(
+    provider_name,
+    model_name,
+    expected_base_name,
+):
+    model_spec = resolve_model_spec(LLM_REGISTRY, provider_name, model_name)
+
+    if expected_base_name is None:
+        assert model_spec is None
+    else:
+        assert model_spec is not None
+        assert model_spec.name == expected_base_name
 
 
 def _model_data(*, tiers=None):

--- a/tests/unit/llm_registry/test_llm_registry.py
+++ b/tests/unit/llm_registry/test_llm_registry.py
@@ -15,6 +15,15 @@ from src.llm_api_adapter.llm_registry.llm_registry import (
     ProviderSpec,
     RegistrySpec,
 )
+from src.llm_api_adapter.llm_registry.request_rules import (
+    AnthropicRequestRuleRegistry,
+    GoogleRequestRuleRegistry,
+    OpenAIRequestRuleRegistry,
+    RequestRule,
+    RequestRuleRegistry,
+    RequestRules,
+    SamplingRequestRuleRegistry,
+)
 
 
 SONNET_5_STANDARD_PRICING_DATE = date(2026, 9, 1)
@@ -130,6 +139,216 @@ def test_model_and_provider_from_dict():
     assert "gpt-test" in provider.models
     assert isinstance(provider.models["gpt-test"], ModelSpec)
     assert provider.models["gpt-test"].pricing_tiers.currency == "EUR"
+
+
+@pytest.mark.unit
+def test_model_request_rules_load_as_validated_metadata():
+    model_data = _model_data()
+    model_data["request_rules"] = [
+        {
+            "handler": "select_api_variant",
+            "arguments": {"variant": "responses"},
+        },
+        {
+            "handler": "drop_parameter",
+            "arguments": {"path": "top_p", "default": 1.0},
+        },
+    ]
+
+    model = ModelSpec.from_dict(
+        "gpt-test",
+        model_data,
+        request_rule_registry=OpenAIRequestRuleRegistry(),
+    )
+
+    assert model.request_rules == RequestRules(
+        rules=(
+            RequestRule(
+                handler="select_api_variant",
+                arguments={"variant": "responses"},
+            ),
+            RequestRule(
+                handler="drop_parameter",
+                arguments={"path": "top_p", "default": 1.0},
+            ),
+        )
+    )
+    assert model.request_rules.api_variant == "responses"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("request_rules", "message"),
+    [
+        (None, "must be an array"),
+        (
+            [{"handler": "custom", "arguments": {}}],
+            "unknown request rule handler",
+        ),
+        (
+            [{"handler": "select_api_variant", "arguments": {"variant": "other"}}],
+            "must be one of: chat_completions, responses",
+        ),
+        (
+            [{"handler": "rename_parameter", "arguments": {"from": "top_p", "to": "topP"}}],
+            "unsupported request parameter rename",
+        ),
+        (
+            [{"handler": "drop_parameter", "arguments": {"path": "messages[0]"}}],
+            "unsupported request parameter path",
+        ),
+        (
+            [
+                {
+                    "handler": "drop_parameter",
+                    "arguments": {"path": "top_p", "default": 0.5},
+                }
+            ],
+            "default for 'top_p' must be 1.0",
+        ),
+        (
+            [
+                {
+                    "handler": "drop_parameter",
+                    "arguments": {"path": "top_p", "default": True},
+                }
+            ],
+            "default for 'top_p' must be 1.0",
+        ),
+        (
+            [
+                {
+                    "handler": "drop_parameter",
+                    "arguments": {"path": "top_p", "custom": {}},
+                }
+            ],
+            "must contain path and optional default",
+        ),
+    ],
+)
+def test_invalid_request_rule_metadata_is_rejected(request_rules, message):
+    model_data = _model_data()
+    model_data["request_rules"] = request_rules
+
+    with pytest.raises(ValueError, match=message):
+        ModelSpec.from_dict(
+            "invalid-model",
+            model_data,
+            request_rule_registry=OpenAIRequestRuleRegistry(),
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("request_rules", "message"),
+    [
+        (
+            [
+                {
+                    "handler": "drop_parameter",
+                    "arguments": {"path": "top_p"},
+                },
+                {
+                    "handler": "select_api_variant",
+                    "arguments": {"variant": "responses"},
+                },
+            ],
+            "conflicting execution order",
+        ),
+        (
+            [
+                {
+                    "handler": "select_api_variant",
+                    "arguments": {"variant": "responses"},
+                },
+                {
+                    "handler": "select_api_variant",
+                    "arguments": {"variant": "chat_completions"},
+                },
+            ],
+            "more than one API variant",
+        ),
+        (
+            [
+                {
+                    "handler": "drop_parameter",
+                    "arguments": {"path": "top_p"},
+                },
+                {
+                    "handler": "drop_parameter",
+                    "arguments": {"path": "top_p", "default": 1.0},
+                },
+            ],
+            "conflict on parameter path",
+        ),
+    ],
+)
+def test_conflicting_request_rule_order_is_rejected(request_rules, message):
+    model_data = _model_data()
+    model_data["request_rules"] = request_rules
+
+    with pytest.raises(ValueError, match=message):
+        ModelSpec.from_dict(
+            "invalid-model",
+            model_data,
+            request_rule_registry=OpenAIRequestRuleRegistry(),
+        )
+
+
+@pytest.mark.unit
+def test_request_rule_schemas_are_scoped_to_their_provider():
+    model_data = _model_data()
+    model_data["request_rules"] = [
+        {
+            "handler": "select_api_variant",
+            "arguments": {"variant": "responses"},
+        }
+    ]
+
+    with pytest.raises(ValueError, match="not supported for provider 'anthropic'"):
+        ModelSpec.from_dict(
+            "claude-test",
+            model_data,
+            request_rule_registry=AnthropicRequestRuleRegistry(),
+        )
+
+    model_data["request_rules"] = [
+        {
+            "handler": "drop_parameter",
+            "arguments": {"path": "top_p", "default": 1.0},
+        }
+    ]
+    with pytest.raises(ValueError, match="unsupported request parameter path"):
+        ModelSpec.from_dict(
+            "gemini-test",
+            model_data,
+            request_rule_registry=GoogleRequestRuleRegistry(),
+        )
+
+
+@pytest.mark.unit
+def test_sampling_rule_schema_is_shared_by_openai_and_anthropic():
+    assert AnthropicRequestRuleRegistry.droppable_parameter_defaults == {
+        "top_p": 1.0
+    }
+    assert OpenAIRequestRuleRegistry.droppable_parameter_defaults["top_p"] == 1.0
+    assert SamplingRequestRuleRegistry.DROP_PARAMETER == (
+        RequestRuleRegistry.DROP_PARAMETER
+    )
+
+
+@pytest.mark.unit
+def test_request_rules_need_a_provider_schema_when_present():
+    model_data = _model_data()
+    model_data["request_rules"] = [
+        {
+            "handler": "drop_parameter",
+            "arguments": {"path": "top_p", "default": 1.0},
+        }
+    ]
+
+    with pytest.raises(ValueError, match="without a provider schema"):
+        ModelSpec.from_dict("model-with-rules", model_data)
 
 
 @pytest.mark.unit
@@ -360,7 +579,7 @@ def test_default_registry_json_exists_and_uses_tiered_schema():
         assert (DEFAULT_REGISTRY_PATH.parent / relative_path).is_file()
 
     registry = RegistrySpec(path=str(DEFAULT_REGISTRY_PATH))
-    assert registry.schema_version == 10
+    assert registry.schema_version == 11
     for provider in registry.providers.values():
         for model in provider.models.values():
             assert model.limits.context_window_tokens > 0
@@ -370,6 +589,80 @@ def test_default_registry_json_exists_and_uses_tiered_schema():
                 assert model.reasoning_capability is not None
             else:
                 assert model.reasoning_capability is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("provider", "model_name", "expected_rules"),
+    [
+        (
+            "openai",
+            "gpt-5",
+            (
+                ("select_api_variant", {"variant": "responses"}),
+                (
+                    "drop_parameter",
+                    {"path": "top_p", "default": 1.0},
+                ),
+            ),
+        ),
+        (
+            "openai",
+            "gpt-5-nano",
+            (
+                ("select_api_variant", {"variant": "responses"}),
+                (
+                    "drop_parameter",
+                    {"path": "top_p", "default": 1.0},
+                ),
+                (
+                    "drop_parameter",
+                    {"path": "temperature", "default": 1.0},
+                ),
+            ),
+        ),
+        (
+            "openai",
+            "gpt-4.1-mini",
+            (
+                (
+                    "rename_parameter",
+                    {"from": "max_tokens", "to": "max_completion_tokens"},
+                ),
+            ),
+        ),
+        (
+            "anthropic",
+            "claude-sonnet-4-5",
+            (
+                (
+                    "drop_parameter",
+                    {"path": "top_p", "default": 1.0},
+                ),
+            ),
+        ),
+        (
+            "google",
+            "gemini-2.5-flash",
+            (
+                (
+                    "drop_parameter",
+                    {"path": "generationConfig.maxOutputTokens", "default": None},
+                ),
+            ),
+        ),
+    ],
+)
+def test_default_registry_contains_current_request_rules(
+    provider,
+    model_name,
+    expected_rules,
+):
+    registry = RegistrySpec(path=str(DEFAULT_REGISTRY_PATH))
+
+    rules = registry.providers[provider].models[model_name].request_rules.rules
+
+    assert tuple((rule.handler, rule.arguments) for rule in rules) == expected_rules
 
 
 @pytest.mark.unit

--- a/tests/unit/llm_registry/test_request_rule_runner.py
+++ b/tests/unit/llm_registry/test_request_rule_runner.py
@@ -1,0 +1,183 @@
+"""Unit tests for execution of validated registry request rules."""
+
+from __future__ import annotations
+
+import logging
+import warnings
+
+import pytest
+
+from src.llm_api_adapter.llm_registry.request_rules import (
+    AppliedRequestRule,
+    RequestRule,
+    RequestRuleRegistry,
+    RequestRules,
+    apply_request_rules,
+)
+
+
+@pytest.mark.unit
+def test_runner_renames_parameters_without_mutating_the_source_payload():
+    payload = {"max_tokens": 256, "messages": []}
+    request_rules = RequestRules(
+        rules=(
+            RequestRule(
+                handler=RequestRuleRegistry.RENAME_PARAMETER,
+                arguments={"from": "max_tokens", "to": "max_completion_tokens"},
+            ),
+        )
+    )
+
+    transformed, diagnostics = apply_request_rules(
+        payload,
+        request_rules,
+        model="gpt-4.1-mini",
+    )
+
+    assert transformed == {"max_completion_tokens": 256, "messages": []}
+    assert payload == {"max_tokens": 256, "messages": []}
+    assert diagnostics == (
+        AppliedRequestRule(
+            handler="rename_parameter",
+            path="max_tokens",
+            target_path="max_completion_tokens",
+        ),
+    )
+
+
+@pytest.mark.unit
+def test_runner_quietly_omits_default_values(caplog):
+    payload = {"top_p": 1.0}
+    request_rules = RequestRules(
+        rules=(
+            RequestRule(
+                handler=RequestRuleRegistry.DROP_PARAMETER,
+                arguments={"path": "top_p", "default": 1.0},
+            ),
+        )
+    )
+
+    with caplog.at_level(
+        logging.WARNING,
+        logger="src.llm_api_adapter.llm_registry.request_rules",
+    ):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            transformed, diagnostics = apply_request_rules(
+                payload,
+                request_rules,
+                model="gpt-5",
+            )
+
+    assert transformed == {}
+    assert payload == {"top_p": 1.0}
+    assert caught == []
+    assert caplog.records == []
+    assert diagnostics == (
+        AppliedRequestRule(
+            handler="drop_parameter",
+            path="top_p",
+        ),
+    )
+
+
+@pytest.mark.unit
+def test_runner_warns_and_logs_once_for_non_default_values(caplog):
+    request_rules = RequestRules(
+        rules=(
+            RequestRule(
+                handler=RequestRuleRegistry.DROP_PARAMETER,
+                arguments={"path": "top_p", "default": 1.0},
+            ),
+        )
+    )
+
+    with caplog.at_level(
+        logging.WARNING,
+        logger="src.llm_api_adapter.llm_registry.request_rules",
+    ):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            transformed, diagnostics = apply_request_rules(
+                {"top_p": 0.2},
+                request_rules,
+                model="gpt-5",
+            )
+
+    assert transformed == {}
+    assert len(caught) == 1
+    assert caught[0].category is UserWarning
+    assert "top_p" in str(caught[0].message)
+    assert "gpt-5" in str(caught[0].message)
+    assert [record.message for record in caplog.records] == [
+        "Parameter 'top_p' is not supported for model 'gpt-5' and will be ignored."
+    ]
+    assert diagnostics == (
+        AppliedRequestRule(
+            handler="drop_parameter",
+            path="top_p",
+            warning_emitted=True,
+        ),
+    )
+
+
+@pytest.mark.unit
+def test_runner_uses_a_deep_copy_for_nested_parameter_paths():
+    payload = {
+        "generationConfig": {
+            "maxOutputTokens": None,
+            "temperature": 1.0,
+        }
+    }
+    request_rules = RequestRules(
+        rules=(
+            RequestRule(
+                handler=RequestRuleRegistry.DROP_PARAMETER,
+                arguments={
+                    "path": "generationConfig.maxOutputTokens",
+                    "default": None,
+                },
+            ),
+        )
+    )
+
+    transformed, diagnostics = apply_request_rules(
+        payload,
+        request_rules,
+        model="gemini-2.5-flash",
+    )
+
+    assert transformed == {"generationConfig": {"temperature": 1.0}}
+    assert payload == {
+        "generationConfig": {
+            "maxOutputTokens": None,
+            "temperature": 1.0,
+        }
+    }
+    assert diagnostics == (
+        AppliedRequestRule(
+            handler="drop_parameter",
+            path="generationConfig.maxOutputTokens",
+        ),
+    )
+
+
+@pytest.mark.unit
+def test_api_variant_rules_are_not_payload_transformations():
+    request_rules = RequestRules(
+        rules=(
+            RequestRule(
+                handler=RequestRuleRegistry.SELECT_API_VARIANT,
+                arguments={"variant": "responses"},
+            ),
+        )
+    )
+
+    transformed, diagnostics = apply_request_rules(
+        {"model": "gpt-5"},
+        request_rules,
+        model="gpt-5",
+    )
+
+    assert transformed == {"model": "gpt-5"}
+    assert diagnostics == ()

--- a/tests/unit/llms/anthropic/test_sync_client.py
+++ b/tests/unit/llms/anthropic/test_sync_client.py
@@ -52,7 +52,7 @@ def mock_post_success():
 def test_chat_completion_success(client, mock_post_success):
     mock_post, _ = mock_post_success
     result = client.chat_completion(
-        "claude-v1", messages=[{"role": "user", "content": "Hi"}]
+        "claude-sonnet-4-5", messages=[{"role": "user", "content": "Hi"}]
     )
     assert isinstance(result, dict)
     assert "completion" in result

--- a/tests/unit/llms/google/test_async_client.py
+++ b/tests/unit/llms/google/test_async_client.py
@@ -21,7 +21,7 @@ async def test_chat_completion_uses_async_transport_and_payload_normalization(cl
         request,
     ):
         result = await client.chat_completion(
-            "gemini-2.5-flash-lite",
+            "gemini-2.5-flash",
             contents=[],
             generationConfig={"thinkingConfig": {"thinkingBudget": 1}},
         )
@@ -29,14 +29,14 @@ async def test_chat_completion_uses_async_transport_and_payload_normalization(cl
     assert result == {"candidates": [{"content": "Hello"}]}
     request.assert_awaited_once()
     assert request.await_args.args[0].endswith(
-        "/models/gemini-2.5-flash-lite:generateContent"
+        "/models/gemini-2.5-flash:generateContent"
     )
     assert request.await_args.kwargs["headers"] == {
         "x-goog-api-key": "test_api_key",
         "Content-Type": "application/json",
     }
     assert request.await_args.kwargs["payload"] == {
-        "model": "gemini-2.5-flash-lite",
+        "model": "gemini-2.5-flash",
         "contents": [],
         "generationConfig": {"thinkingConfig": {"thinkingBudget": 1}},
     }

--- a/tests/unit/llms/google/test_sync_client.py
+++ b/tests/unit/llms/google/test_sync_client.py
@@ -122,11 +122,15 @@ def test_stream_uses_stream_generate_content_and_yields_raw_chunks(mock_post, cl
     ])
     mock_post.return_value = response
 
-    events = list(client.stream(
-        "gemini-2.5-flash",
-        contents=[{"role": "user", "parts": [{"text": "Hi"}]}],
-        generationConfig={"maxOutputTokens": 64},
-    ))
+    with pytest.warns(
+        UserWarning,
+        match="Parameter 'generationConfig.maxOutputTokens' is not supported",
+    ):
+        events = list(client.stream(
+            "gemini-2.5-flash",
+            contents=[{"role": "user", "parts": [{"text": "Hi"}]}],
+            generationConfig={"maxOutputTokens": 64},
+        ))
 
     assert events == [
         SSEEvent(

--- a/tests/unit/llms/google/test_sync_client.py
+++ b/tests/unit/llms/google/test_sync_client.py
@@ -52,7 +52,7 @@ def mock_post_success():
 def test_chat_completion_success(client, mock_post_success):
     mock_post, _ = mock_post_success
     result = client.chat_completion(
-        "gemini-1", prompt={"messages":[{"author":"user","content":"Hi"}]}
+        "gemini-2.5-flash", prompt={"messages":[{"author":"user","content":"Hi"}]}
     )
     assert isinstance(result, dict)
     assert "candidates" in result
@@ -60,7 +60,7 @@ def test_chat_completion_success(client, mock_post_success):
     assert candidate_content == "Hello"
     mock_post.assert_called_once()
     assert mock_post.call_args.args[0] == (
-        "https://generativelanguage.googleapis.com/v1beta/models/gemini-1:generateContent"
+        "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent"
     )
     headers = mock_post.call_args[1]["headers"]
     assert headers["x-goog-api-key"] == "test_api_key"
@@ -170,13 +170,13 @@ def test_stream_preserves_adapter_resolved_thinking_payload(mock_post, client):
     mock_post.return_value = response
 
     assert list(client.stream(
-        "gemini-2.5-flash-lite",
+        "gemini-2.5-flash",
         contents=[],
         generationConfig={"thinkingConfig": {"thinkingBudget": 1}},
     )) == []
 
     assert mock_post.call_args.kwargs["json"] == {
-        "model": "gemini-2.5-flash-lite",
+        "model": "gemini-2.5-flash",
         "contents": [],
         "generationConfig": {"thinkingConfig": {"thinkingBudget": 1}},
     }

--- a/tests/unit/llms/openai/test_sync_client.py
+++ b/tests/unit/llms/openai/test_sync_client.py
@@ -52,7 +52,7 @@ def mock_post_success():
 def test_chat_completion_success(client, mock_post_success):
     mock_post, _ = mock_post_success
     result = client.chat_completion(
-        "gpt-4", messages=[{"role": "user", "content": "Hi"}]
+        "gpt-4o", messages=[{"role": "user", "content": "Hi"}]
     )
     assert isinstance(result, dict)
     assert "choices" in result

--- a/tests/unit/llms/test_request_rule_characterization.py
+++ b/tests/unit/llms/test_request_rule_characterization.py
@@ -1,0 +1,210 @@
+"""Characterize model-specific request rules before moving them to the registry."""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from src.llm_api_adapter.llms.anthropic.async_client import ClaudeAsyncClient
+from src.llm_api_adapter.llms.anthropic.sync_client import ClaudeSyncClient
+from src.llm_api_adapter.llms.google.async_client import GeminiAsyncClient
+from src.llm_api_adapter.llms.google.sync_client import GeminiSyncClient
+from src.llm_api_adapter.llms.openai.async_client import OpenAIAsyncClient
+from src.llm_api_adapter.llms.openai.sync_client import OpenAISyncClient
+
+
+OPENAI_CLIENTS = (OpenAISyncClient, OpenAIAsyncClient)
+ANTHROPIC_CLIENTS = (ClaudeSyncClient, ClaudeAsyncClient)
+GOOGLE_CLIENTS = (GeminiSyncClient, GeminiAsyncClient)
+
+
+def _captured_warnings():
+    return warnings.catch_warnings(record=True)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("client_class", OPENAI_CLIENTS, ids=("sync", "async"))
+def test_openai_selects_the_api_variant_for_each_model_family(client_class):
+    client = client_class(api_key="test_api_key")
+
+    assert client._should_use_responses_api("gpt-5") is True
+    assert client._should_use_responses_api("gpt-4o") is False
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("client_class", OPENAI_CLIENTS, ids=("sync", "async"))
+def test_openai_renames_max_tokens_for_chat_completions_models(client_class):
+    client = client_class(api_key="test_api_key")
+
+    payload = client._prepare_chat_payload_for_model(
+        "gpt-4.1-mini",
+        {"messages": [], "max_tokens": 256},
+    )
+
+    assert payload["max_completion_tokens"] == 256
+    assert "max_tokens" not in payload
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("client_class", OPENAI_CLIENTS, ids=("sync", "async"))
+def test_openai_converts_the_legacy_gpt5_reasoning_default(client_class):
+    client = client_class(api_key="test_api_key")
+
+    with _captured_warnings() as caught:
+        warnings.simplefilter("always")
+        payload = client._prepare_responses_payload_for_model(
+            "gpt-5",
+            {"reasoning_effort": "none"},
+        )
+
+    assert payload["reasoning"] == {"effort": "minimal"}
+    assert caught == []
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("client_class", OPENAI_CLIENTS, ids=("sync", "async"))
+def test_openai_silently_omits_default_top_p_for_gpt5(client_class):
+    client = client_class(api_key="test_api_key")
+
+    with _captured_warnings() as caught:
+        warnings.simplefilter("always")
+        payload = client._prepare_responses_payload_for_model(
+            "gpt-5",
+            {"top_p": 1.0},
+        )
+
+    assert "top_p" not in payload
+    assert caught == []
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("client_class", OPENAI_CLIENTS, ids=("sync", "async"))
+def test_openai_warns_once_when_omitting_non_default_top_p_for_gpt5(client_class):
+    client = client_class(api_key="test_api_key")
+
+    with _captured_warnings() as caught:
+        warnings.simplefilter("always")
+        payload = client._prepare_responses_payload_for_model(
+            "gpt-5",
+            {"top_p": 0.2},
+        )
+
+    assert "top_p" not in payload
+    assert len(caught) == 1
+    assert caught[0].category is UserWarning
+    assert "top_p" in str(caught[0].message)
+    assert "gpt-5" in str(caught[0].message)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("client_class", OPENAI_CLIENTS, ids=("sync", "async"))
+def test_openai_silently_omits_default_temperature_for_gpt5_nano(client_class):
+    client = client_class(api_key="test_api_key")
+
+    with _captured_warnings() as caught:
+        warnings.simplefilter("always")
+        payload = client._prepare_responses_payload_for_model(
+            "gpt-5-nano",
+            {"temperature": 1.0},
+        )
+
+    assert "temperature" not in payload
+    assert caught == []
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("client_class", OPENAI_CLIENTS, ids=("sync", "async"))
+def test_openai_warns_once_when_omitting_non_default_temperature_for_gpt5_nano(
+    client_class,
+):
+    client = client_class(api_key="test_api_key")
+
+    with _captured_warnings() as caught:
+        warnings.simplefilter("always")
+        payload = client._prepare_responses_payload_for_model(
+            "gpt-5-nano",
+            {"temperature": 0.2},
+        )
+
+    assert "temperature" not in payload
+    assert len(caught) == 1
+    assert caught[0].category is UserWarning
+    assert "temperature" in str(caught[0].message)
+    assert "gpt-5-nano" in str(caught[0].message)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("client_class", ANTHROPIC_CLIENTS, ids=("sync", "async"))
+def test_anthropic_silently_omits_default_top_p_for_claude_4_5(client_class):
+    client = client_class(api_key="test_api_key")
+
+    with _captured_warnings() as caught:
+        warnings.simplefilter("always")
+        payload = client._prepare_chat_payload_for_model(
+            "claude-sonnet-4-5",
+            {"messages": [], "top_p": 1.0},
+        )
+
+    assert "top_p" not in payload
+    assert caught == []
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("client_class", ANTHROPIC_CLIENTS, ids=("sync", "async"))
+def test_anthropic_warns_once_when_omitting_non_default_top_p_for_claude_4_5(
+    client_class,
+):
+    client = client_class(api_key="test_api_key")
+
+    with _captured_warnings() as caught:
+        warnings.simplefilter("always")
+        payload = client._prepare_chat_payload_for_model(
+            "claude-sonnet-4-5",
+            {"messages": [], "top_p": 0.2},
+        )
+
+    assert "top_p" not in payload
+    assert len(caught) == 1
+    assert caught[0].category is UserWarning
+    assert "top_p" in str(caught[0].message)
+    assert "claude-sonnet-4-5" in str(caught[0].message)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("client_class", GOOGLE_CLIENTS, ids=("sync", "async"))
+def test_google_silently_omits_default_max_output_tokens_for_gemini_2_5(
+    client_class,
+):
+    client = client_class(api_key="test_api_key")
+
+    with _captured_warnings() as caught:
+        warnings.simplefilter("always")
+        payload = client._prepare_chat_payload_for_model(
+            "gemini-2.5-flash",
+            {"generationConfig": {"maxOutputTokens": None}},
+        )
+
+    assert "maxOutputTokens" not in payload["generationConfig"]
+    assert caught == []
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("client_class", GOOGLE_CLIENTS, ids=("sync", "async"))
+def test_google_warns_once_when_omitting_non_default_max_output_tokens_for_gemini_2_5(
+    client_class,
+):
+    client = client_class(api_key="test_api_key")
+
+    with _captured_warnings() as caught:
+        warnings.simplefilter("always")
+        payload = client._prepare_chat_payload_for_model(
+            "gemini-2.5-flash",
+            {"generationConfig": {"maxOutputTokens": 256}},
+        )
+
+    assert "maxOutputTokens" not in payload["generationConfig"]
+    assert len(caught) == 1
+    assert caught[0].category is UserWarning
+    assert "maxOutputTokens" in str(caught[0].message)
+    assert "gemini-2.5-flash" in str(caught[0].message)

--- a/tests/unit/llms/test_request_rule_characterization.py
+++ b/tests/unit/llms/test_request_rule_characterization.py
@@ -34,6 +34,14 @@ def test_openai_selects_the_api_variant_for_each_model_family(client_class):
 
 @pytest.mark.unit
 @pytest.mark.parametrize("client_class", OPENAI_CLIENTS, ids=("sync", "async"))
+def test_openai_does_not_assume_an_api_variant_for_unregistered_models(client_class):
+    client = client_class(api_key="test_api_key")
+
+    assert client._should_use_responses_api("gpt-5-unregistered") is False
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("client_class", OPENAI_CLIENTS, ids=("sync", "async"))
 def test_openai_renames_max_tokens_for_chat_completions_models(client_class):
     client = client_class(api_key="test_api_key")
 
@@ -60,6 +68,19 @@ def test_openai_converts_the_legacy_gpt5_reasoning_default(client_class):
 
     assert payload["reasoning"] == {"effort": "minimal"}
     assert caught == []
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("client_class", OPENAI_CLIENTS, ids=("sync", "async"))
+def test_openai_preserves_native_none_when_registry_allows_it(client_class):
+    client = client_class(api_key="test_api_key")
+
+    payload = client._prepare_responses_payload_for_model(
+        "gpt-5.6-sol",
+        {"reasoning_effort": "none"},
+    )
+
+    assert payload["reasoning"] == {"effort": "none"}
 
 
 @pytest.mark.unit

--- a/tests/unit/llms/test_request_rule_characterization.py
+++ b/tests/unit/llms/test_request_rule_characterization.py
@@ -34,6 +34,14 @@ def test_openai_selects_the_api_variant_for_each_model_family(client_class):
 
 @pytest.mark.unit
 @pytest.mark.parametrize("client_class", OPENAI_CLIENTS, ids=("sync", "async"))
+def test_openai_snapshot_uses_its_registered_base_api_variant(client_class):
+    client = client_class(api_key="test_api_key")
+
+    assert client._should_use_responses_api("gpt-5-2025-08-07") is True
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("client_class", OPENAI_CLIENTS, ids=("sync", "async"))
 def test_openai_does_not_assume_an_api_variant_for_unregistered_models(client_class):
     client = client_class(api_key="test_api_key")
 
@@ -47,6 +55,20 @@ def test_openai_renames_max_tokens_for_chat_completions_models(client_class):
 
     payload = client._prepare_chat_payload_for_model(
         "gpt-4.1-mini",
+        {"messages": [], "max_tokens": 256},
+    )
+
+    assert payload["max_completion_tokens"] == 256
+    assert "max_tokens" not in payload
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("client_class", OPENAI_CLIENTS, ids=("sync", "async"))
+def test_openai_snapshot_uses_its_registered_base_payload_rules(client_class):
+    client = client_class(api_key="test_api_key")
+
+    payload = client._prepare_chat_payload_for_model(
+        "gpt-4.1-2025-04-14",
         {"messages": [], "max_tokens": 256},
     )
 
@@ -164,6 +186,22 @@ def test_anthropic_silently_omits_default_top_p_for_claude_4_5(client_class):
         warnings.simplefilter("always")
         payload = client._prepare_chat_payload_for_model(
             "claude-sonnet-4-5",
+            {"messages": [], "top_p": 1.0},
+        )
+
+    assert "top_p" not in payload
+    assert caught == []
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("client_class", ANTHROPIC_CLIENTS, ids=("sync", "async"))
+def test_anthropic_snapshot_uses_its_registered_base_payload_rules(client_class):
+    client = client_class(api_key="test_api_key")
+
+    with _captured_warnings() as caught:
+        warnings.simplefilter("always")
+        payload = client._prepare_chat_payload_for_model(
+            "claude-sonnet-4-5-20250929",
             {"messages": [], "top_p": 1.0},
         )
 

--- a/tests/unit/models/responses/test_chat_response.py
+++ b/tests/unit/models/responses/test_chat_response.py
@@ -12,7 +12,7 @@ from src.llm_api_adapter.models.tools import ToolCall
 @pytest.mark.unit
 def test_from_openai_response():
     api_response = {
-        "model": "gpt-4",
+        "model": "gpt-4o",
         "id": "response123",
         "created": 1234567890,
         "usage": {
@@ -28,7 +28,7 @@ def test_from_openai_response():
         ],
     }
     response = ChatResponse.from_openai_response(api_response)
-    assert response.model == "gpt-4"
+    assert response.model == "gpt-4o"
     assert response.response_id == "response123"
     assert response.timestamp == 1234567890
     assert response.usage.input_tokens == 30
@@ -46,7 +46,7 @@ def test_from_openai_response():
         (
             ChatResponse.from_openai_response,
             {
-                "model": "gpt-4",
+                "model": "gpt-4o",
                 "choices": [{"message": {"content": "Hello"}}],
             },
         ),
@@ -89,7 +89,7 @@ def test_provider_response_without_usage_leaves_usage_unset(parser, api_response
 @pytest.mark.unit
 def test_from_openai_response_parses_tool_calls_json_string():
     api_response = {
-        "model": "gpt-4",
+        "model": "gpt-4o",
         "id": "resp_1",
         "created": 111,
         "usage": {},
@@ -552,13 +552,13 @@ def test_from_openai_responses_response_invalid_tool_arguments_raise():
 def test_from_anthropic_response():
     api_response = {
         "usage": {"input_tokens": 30, "output_tokens": 70},
-        "model": "claude-2",
+        "model": "claude-sonnet-4-5",
         "id": "anthropic123",
         "content": [{"type": "text", "text": "Hello from Anthropic!"}],
         "stop_reason": "end",
     }
     response = ChatResponse.from_anthropic_response(api_response)
-    assert response.model == "claude-2"
+    assert response.model == "claude-sonnet-4-5"
     assert response.response_id == "anthropic123"
     assert response.usage.input_tokens == 30
     assert response.usage.output_tokens == 70
@@ -600,7 +600,7 @@ def test_from_anthropic_response_captures_thinking_only_when_opted_in():
 def test_from_anthropic_response_parses_tool_use_blocks():
     api_response = {
         "usage": {"input_tokens": 5, "output_tokens": 7},
-        "model": "claude-3",
+        "model": "claude-sonnet-4-5",
         "id": "a1",
         "content": [
             {"type": "text", "text": "first text"},

--- a/tests/unit/test_universal_adapter.py
+++ b/tests/unit/test_universal_adapter.py
@@ -59,7 +59,7 @@ def test_unsupported_organization_raises(monkeypatch):
     )
     with pytest.raises(ValueError, match="Unsupported organization: UnknownCorp"):
         UniversalLLMAPIAdapter(
-            organization="UnknownCorp", model="gpt", api_key="k"
+            organization="UnknownCorp", model="test-model", api_key="k"
         )
 
 @pytest.mark.unit


### PR DESCRIPTION
- Added provider-scoped request rules to the model registry.
- OpenAI, Anthropic, and Google now apply payload compatibility rules from the registry in both sync and async paths.
- Added support for validated snapshot model IDs:
  - Anthropic: `claude-...-YYYYMMDD`
  - OpenAI: `gpt-...-YYYY-MM-DD`
- The original snapshot ID is preserved in provider requests, while pricing, reasoning, request rules, and API selection inherit from the registered base model.
- Unknown aliases, Google preview/alias IDs, and OpenAI fine-tuned IDs do not automatically inherit base-model rules.
- Replaced obsolete model fixtures that were absent from the registry.
- Added integration coverage for OpenAI and Anthropic snapshot IDs.
