### PR TITLE
Structured output portability

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,9 +103,9 @@ paid `chat()` request plus one paid `achat()` request for that selected model
 per configured provider. The HTTPX requests reserve 512 generated tokens so
 models that think by default still have room for visible text.
 
-For a release candidate, open a pull request to `main` first. After review and deterministic CI pass, the maintainer promotes that exact candidate commit through a staging pull request to `dev`. The `dev` branch is protected by an active repository ruleset: direct updates are restricted, pull requests are required, and only repository administrators are on the bypass list. The [dev workflow](.github/workflows/ci-dev.yml) runs deterministic core tests with coverage, while the [Mistral dev workflow](.github/workflows/ci-mistral-dev.yml) and [Mistral main workflow](.github/workflows/ci-mistral-main.yml) run Mistral's unit and mocked-integration suites on Python 3.10–3.14 when that package or code it uses changes.
+For a release candidate, open a pull request to `main` first. After review and deterministic CI pass, the maintainer promotes that exact candidate commit through a staging pull request to `dev`. The `dev` branch is protected by an active repository ruleset: direct updates are restricted, pull requests are required, and only repository administrators are on the bypass list. The [dev workflow](.github/workflows/ci-dev.yml) runs deterministic core tests with coverage. The Mistral and xAI package workflows run their respective unit and mocked-integration suites on Python 3.10–3.14 when that package or code it uses changes.
 
-Only after the staging pull request is merged does the [dev release workflow](.github/workflows/ci-dev-release.yml) publish changed distributions to TestPyPI and run paid E2E tests. A core change publishes the core package and runs both the built-in and Mistral E2E lanes. A Mistral package change publishes only `llm-api-adapter-mistral` and runs the Mistral lane. That lane installs the exact TestPyPI versions through `llm-api-adapter[mistral]`, then verifies plugin discovery before making a provider call. Every changed distribution needs a new version because TestPyPI artifacts are immutable; do not raise the version of an unchanged package. The installer retries twice with two-minute waits for TestPyPI propagation and never falls back to an older candidate. After the workflow passes, the maintainer manually installs the TestPyPI packages and verifies the changed behavior and critical flows before merging the pull request to `main`. Do not push directly to `dev`, and do not run these paid provider calls as part of a deterministic PR matrix or multiply them across Python versions.
+Only after the staging pull request is merged does the [dev release workflow](.github/workflows/ci-dev-release.yml) publish changed distributions to TestPyPI and run paid E2E tests. A core change publishes the core package and runs the built-in, Mistral, and xAI E2E lanes. A Mistral or xAI package change publishes only that organization package and runs its corresponding lane. Each lane installs the exact TestPyPI versions through the matching optional extra, verifies plugin discovery, then makes provider calls. Every changed distribution needs a new version because TestPyPI artifacts are immutable; do not raise the version of an unchanged package. The installer retries twice with two-minute waits for TestPyPI propagation and never falls back to an older candidate. After the workflow passes, the maintainer manually installs the TestPyPI packages and verifies the changed behavior and critical flows before merging the pull request to `main`. Do not push directly to `dev`, and do not run these paid provider calls as part of a deterministic PR matrix or multiply them across Python versions.
 
 ## Provider-key safety
 
@@ -170,6 +170,7 @@ Use `--prompt` to test another task. The script prints reasoning summaries and v
    python tests/tests_runner.py
    python -m pytest -v -m unit packages/organizations/mistral/tests
    python -m pytest -v -m integration packages/organizations/mistral/tests
+   python -m pytest -v -m unit packages/organizations/xai/tests
    ```
 
    The dev workflow collects coverage separately while running its unit and integration jobs.
@@ -179,8 +180,9 @@ Use `--prompt` to test another task. The script prints reasoning summaries and v
    ```bash
    python -m pip install build
    python -m build
-   # Run when the Mistral package changed:
+   # Run for each changed organization package:
    python -m build packages/organizations/mistral
+   python -m build packages/organizations/xai
    ```
 
 4. Open or update the pull request to `main`. Wait for review and the deterministic main CI to pass.
@@ -194,9 +196,18 @@ Use `--prompt` to test another task. The script prints reasoning summaries and v
      "llm-api-adapter-mistral==<mistral-version>"
    ```
 
+   For xAI, include the transports used by the release candidate:
+
+   ```bash
+   pip install --index-url https://test.pypi.org/simple/ \\
+     --extra-index-url https://pypi.org/simple \\
+     "llm-api-adapter[async,httpx]==<core-version>" \\
+     "llm-api-adapter-xai==<xai-version>"
+   ```
+
    Then verify the changed behavior, critical flows, and absence of regressions.
 7. Merge the already verified pull request into `main`.
-8. After the pull request is merged, create one final tag for each changed distribution: `v<core-version>` for the core package and `mistral-v<mistral-version>` for Mistral. The tags may point to the same commit. The main workflow publishes only the distribution selected by its tag.
+8. After the pull request is merged, create one final tag for each changed distribution: `v<core-version>` for the core package, `mistral-v<mistral-version>` for Mistral, and `xai-v<xai-version>` for xAI. The tags may point to the same commit. The main workflow publishes only the distribution selected by its tag.
 
 The post-publish E2E job is a release-candidate gate, not a general development check. Keep it out of pull-request jobs and Python-version matrices so paid provider calls remain bounded.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ python -m coverage report --show-missing --fail-under=90
 
 E2E tests make real provider requests and may incur charges. Run them only deliberately, outside pull-request and Python-version matrix jobs.
 
-The full E2E marker runs the scenarios under `tests/e2e/`; many scenarios iterate over the models registered for each provider, so this command can make more than one request per provider:
+The full E2E marker runs the scenarios under `tests/e2e/`. The synchronous feature and structured-output scenarios traverse the models registered for each organization profile, so this command can make more than one request per provider:
 
 ```bash
 python -m pytest -v -m e2e
@@ -90,14 +90,18 @@ The required environment variables are:
 - `OPENAI_API_KEY`
 - `ANTHROPIC_API_KEY`
 - `GOOGLE_API_KEY`
+- `MISTRAL_API_KEY` (with the independently installed Mistral package)
+- `XAI_API_KEY` (with the independently installed xAI package)
 
-Async E2E checks use the latest registered model for each provider by default; providers without configured API keys are skipped. Override a provider's model only when needed with `ASYNC_E2E_OPENAI_MODEL`, `ASYNC_E2E_ANTHROPIC_MODEL`, or `ASYNC_E2E_GOOGLE_MODEL`.
+`test_json_schema.py` makes one portable structured-output request for every configured registered model. It must return the exact expected JSON without a refusal or incomplete state; advertised structured-output support is not skipped after the request.
 
-The sync HTTPX pilot has one paid `chat()` check per configured provider and
-also selects the latest registered model by default. Its request reserves 512
-generated tokens so models that think by default still have room for visible
-text. Override a provider model only when needed with `SYNC_HTTPX_E2E_OPENAI_MODEL`,
-`SYNC_HTTPX_E2E_ANTHROPIC_MODEL`, or `SYNC_HTTPX_E2E_GOOGLE_MODEL`.
+The heavyweight async suite uses one latest registered model for each provider
+by default; override it only when needed with
+`ASYNC_E2E_<ORGANIZATION>_MODEL`. The synchronous HTTPX suite uses the same
+bounded selection through `SYNC_HTTPX_E2E_<ORGANIZATION>_MODEL`, and makes one
+paid `chat()` request plus one paid `achat()` request for that selected model
+per configured provider. The HTTPX requests reserve 512 generated tokens so
+models that think by default still have room for visible text.
 
 For a release candidate, open a pull request to `main` first. After review and deterministic CI pass, the maintainer promotes that exact candidate commit through a staging pull request to `dev`. The `dev` branch is protected by an active repository ruleset: direct updates are restricted, pull requests are required, and only repository administrators are on the bypass list. The [dev workflow](.github/workflows/ci-dev.yml) runs deterministic core tests with coverage, while the [Mistral dev workflow](.github/workflows/ci-mistral-dev.yml) and [Mistral main workflow](.github/workflows/ci-mistral-main.yml) run Mistral's unit and mocked-integration suites on Python 3.10–3.14 when that package or code it uses changes.
 
@@ -153,6 +157,7 @@ Use `--prompt` to test another task. The script prints reasoning summaries and v
 - Keep README focused on the public package contract, installation, and user-facing examples.
 - Keep contributor setup, test commands, provider-key rules, CI details, and release procedures in this guide.
 - Update the relevant documentation when public behavior, provider mappings, or test workflows change. Keep `docs/architecture.json` minimal and place topical details in its linked detail files.
+- When structured-output behavior changes, update the README's portable-profile contract, the organization-package READMEs, and deterministic conformance tests together. Do not claim arbitrary JSON Schema compatibility.
 - Examples must not require credentials merely to import. Live calls should be explicit and documented.
 - When code or project artifacts change, run `graphify update .` and review the resulting diff.
 

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ This table is a positioning snapshot. Provider capabilities change independently
 - **Vision Input**: Send images alongside text via `ImagePart` — URL or raw bytes, all providers handled automatically.
 - **PDF Documents**: Send PDF URLs or bytes via `DocumentPart`; provider-specific file/document payloads are generated automatically.
 - **Tool / Function Calling**: Provider-agnostic tool definitions and normalized tool calls in `ChatResponse.tool_calls`.
-- **Strict JSON Mode**: Pass one JSON Schema to `chat()` and get a parsed object in `ChatResponse.parsed_json` — provider-specific schema formats and restrictions are handled automatically.
-- **Pydantic Integration**: Pass a Pydantic model as `response_model` and get a typed instance back in `ChatResponse.parsed_model` — no manual schema writing required.
+- **Portable Structured Output**: Pass a documented portable JSON Schema to `chat()` and get a parsed object in `ChatResponse.parsed_json` across all supported organizations.
+- **Pydantic Integration**: Pass a portable Pydantic model as `response_model` and get a typed instance back in `ChatResponse.parsed_model` — no manual schema writing required.
 - **Request Timeouts**: Per-request timeout control via `timeout_s`; raises `LLMAPITimeoutError` on expiry.
 - **Flexible Configuration**: `temperature`, `max_tokens`, `top_p`, and other parameters are translated to a verified provider payload; known unsupported fields are omitted predictably.
 - **Pricing Registry**: Model prices stored in a bundled JSON registry with per-model input/output rates; overridable per instance.
@@ -338,7 +338,7 @@ The SDK provides a set of standardized errors for easier debugging and integrati
 
 - **ToolChoiceError**: Raised when `tool_choice` is invalid or references an unknown tool.
 
-- **JSONSchemaError**: Raised when `json_schema` or `response_model` is used incorrectly (combined with each other or with `tools`), when `response_model` is not a Pydantic `BaseModel` subclass, when Pydantic is not installed, or when the model response is not valid JSON.
+- **JSONSchemaError**: Raised for incompatible structured-output arguments, a non-portable or non-recursive schema, an invalid Pydantic response model, invalid JSON, or failed Pydantic response validation.
 
 ### Config Errors
 
@@ -471,9 +471,11 @@ The `ChatResponse` object returned by `chat` includes:
 7. **cost\_output**: Cost of output tokens.
 8. **cost\_total**: Total combined cost.
 9. **content**: The generated text response.
-10. **finish\_reason**: Reason why generation stopped (e.g., `"stop"`, `"length"`).
-11. **parsed\_json**: Parsed JSON object when `json_schema` or `response_model` was provided, otherwise `None`.
-12. **parsed\_model**: Typed Pydantic instance when `response_model` was provided, otherwise `None`.
+10. **finish\_reason**: Provider-native reason why generation stopped (for example, `"stop"` or `"length"`).
+11. **refusal**: Provider-normalized refusal detail, or `None` when the response was not a refusal.
+12. **incomplete\_reason**: Provider-normalized incomplete-generation reason, or `None` when generation completed.
+13. **parsed\_json**: Parsed JSON object for a valid completed structured result, otherwise `None`.
+14. **parsed\_model**: Typed Pydantic instance for a valid completed `response_model` result, otherwise `None`.
 
 ## Timeout Support
 
@@ -735,23 +737,58 @@ If you omit `previous_response`, the call works normally; you just won't get the
 
 ## Structured Output
 
-The SDK supports two ways to get structured output from `chat()`, `achat()`,
-`stream_chat()`, and `astream_chat()`: a raw `json_schema` dict, or a Pydantic
-model via `response_model`. Both use the same application-level contract
-across supported providers; provider-specific availability and schema
-restrictions are handled by the adapter. For streaming methods, parsed fields
-are available on the finalized `ChatResponse` passed to `on_done`.
+The SDK supports structured output from `chat()`, `achat()`, `stream_chat()`,
+and `astream_chat()` through a raw `json_schema` dict or a Pydantic model passed
+as `response_model`. The documented Core portable profile below is guaranteed
+across OpenAI, Anthropic, Google, Mistral, and xAI. Its explicit boundaries
+define the schema vocabulary that remains portable between organizations.
+
+For streaming methods, parsed fields and terminal structured-output state are
+available on the finalized `ChatResponse` passed to `on_done`.
+
+### Core portable JSON Schema profile
+
+The profile is the provider-neutral intersection enforced before an HTTP
+request. A portable schema has:
+
+- an object as its root;
+- only `string`, `number`, `integer`, `boolean`, `object`, and `array` types;
+  nullable fields are expressed only as `[<one type>, "null"]`;
+- `additionalProperties: false` on every object, and a `required` list that
+  contains every object property exactly once; use a nullable property instead
+  of an optional one;
+- a single object schema in `items` for every array;
+- a non-empty `enum` when `enum` is used; and
+- only the profile's structural and metadata keywords: `type`, `properties`,
+  `required`, `additionalProperties`, `items`, `enum`, `title`, `description`,
+  `$id`, and `$schema`.
+
+Direct local references of the form `#/$defs/<name>` (including
+Pydantic-generated references) are inlined locally before this profile is
+checked. External, unresolved, recursive, or
+semantically combined `$ref` values are rejected with `JSONSchemaError` before
+a provider request. Other JSON Schema composition, validation, and conditional
+keywords are intentionally outside the portable profile.
+
+OpenAI, Anthropic, and Google enforce this Core profile. The Mistral and xAI
+organization packages require core `>=0.9.2,<1.0.0` and enforce the same
+boundary; xAI additionally rejects the documented xAI-only invalid constructs
+before sending its request.
 
 ### Pydantic Integration (`response_model`)
 
-Pass a Pydantic `BaseModel` subclass as `response_model` — the adapter extracts the JSON Schema automatically and returns a typed instance in `ChatResponse.parsed_model`.
+Pass a Pydantic `BaseModel` subclass as `response_model` — the adapter extracts
+the JSON Schema automatically and returns a typed instance in
+`ChatResponse.parsed_model`.
 
 ```python
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from llm_api_adapter.models.messages.chat_message import Prompt, UserMessage
 from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
 
 class Person(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     name: str
     age: int
 
@@ -774,16 +811,16 @@ print(response.parsed_model)  # Person(name='Alice', age=30)
 print(response.parsed_json)   # {"name": "Alice", "age": 30}
 ```
 
-> **Note:** Pydantic is not a required dependency of this package. Install it separately: `pip install pydantic`.
+> **Note:** Pydantic is not a required dependency of this package. Install it separately: `pip install pydantic`. Every nested Pydantic model must also use `ConfigDict(extra="forbid")` so its generated object schema satisfies the portable profile.
 
 `response_model` cannot be combined with `json_schema` or `tools` — passing both raises `JSONSchemaError`.
 
 ### Raw JSON Schema (`json_schema`)
 
-The SDK also supports structured JSON output via a `json_schema` parameter in
-`chat()`, `achat()`, `stream_chat()`, and `astream_chat()`. Pass any JSON
-Schema object — the adapter normalizes it for each provider automatically and
-returns the parsed result in `ChatResponse.parsed_json`.
+The SDK also supports portable structured JSON output via a `json_schema`
+parameter in `chat()`, `achat()`, `stream_chat()`, and `astream_chat()`. The
+adapter preserves the schema's semantics: it validates the profile rather than
+silently adding required fields or changing `additionalProperties`.
 
 ```python
 from llm_api_adapter.models.messages.chat_message import Prompt, UserMessage
@@ -796,6 +833,7 @@ schema = {
         "age": {"type": "integer"},
     },
     "required": ["name", "age"],
+    "additionalProperties": False,
 }
 
 adapter = UniversalLLMAPIAdapter(
@@ -821,11 +859,15 @@ print(response.parsed_json)  # {"name": "Alice", "age": 30}
 
 - Accepts a `dict` containing a JSON Schema object.
 - Cannot be combined with `tools` or `response_model` — passing both raises `JSONSchemaError`.
-- If the model returns a response that is not valid JSON, `JSONSchemaError` is raised.
+- Must satisfy the Core portable profile; unsupported, external, or recursive references raise `JSONSchemaError` before the request.
+- Raw schemas are parsed as JSON only. The SDK does not run a local JSON Schema validator against the response.
+- If a completed, non-refusal response is not valid JSON, `JSONSchemaError` is raised.
 
 ### `parsed_json` field
 
-`ChatResponse.parsed_json` contains the parsed `dict` when `json_schema` or `response_model` was provided, or `None` otherwise.
+`ChatResponse.parsed_json` contains the parsed `dict` for a valid completed
+structured result. It remains `None` for a refusal or incomplete generation,
+and `parsed_model` remains `None` in those cases as well.
 
 ### Provider behavior
 
@@ -835,8 +877,35 @@ print(response.parsed_json)  # {"name": "Alice", "age": 30}
 | **OpenAI** (Responses API / o-series) | Native `text.format.type=json_schema` with `strict=true` |
 | **Anthropic** | Native `output_config.format.type=json_schema` |
 | **Google** | `generationConfig.responseMimeType="application/json"` + `responseSchema` |
+| **Mistral** | Native `response_format.type=json_schema` with `strict=true` (optional organization package) |
+| **xAI** | Responses `text.format.type=json_schema` with `strict=true` plus xAI's additive local overlay (optional organization package) |
 
-The adapter automatically handles provider-specific schema constraints, so the same schema can be reused across supported providers without provider-specific request code.
+The same **portable** schema can be reused across these organizations without
+provider-specific request code. Google drops only `$id` and `$schema`, which
+are non-semantic metadata that its endpoint does not accept; no transformer
+silently drops a semantic constraint.
+
+### Refusal, incomplete, and invalid results
+
+A provider refusal is exposed as `response.refusal`; an incomplete generation
+is exposed as `response.incomplete_reason`. Neither is parsed or Pydantic
+validated, so both parsed fields remain `None`. A completed non-refusal result
+that is invalid JSON, or fails `response_model.model_validate()`, raises
+`JSONSchemaError`. Check the terminal fields before using structured output:
+
+```python
+response = adapter.chat(
+    messages=[UserMessage("Give me the data.")],
+    json_schema=schema,
+    max_tokens=200,
+)
+if response.refusal is not None:
+    handle_refusal(response.refusal)
+elif response.incomplete_reason is not None:
+    handle_incomplete(response.incomplete_reason)
+else:
+    data = response.parsed_json
+```
 
 ### Error handling
 

--- a/README.md
+++ b/README.md
@@ -876,14 +876,14 @@ and `parsed_model` remains `None` in those cases as well.
 | **OpenAI** (standard) | Native `response_format.type=json_schema` with `strict=true` |
 | **OpenAI** (Responses API / o-series) | Native `text.format.type=json_schema` with `strict=true` |
 | **Anthropic** | Native `output_config.format.type=json_schema` |
-| **Google** | `generationConfig.responseMimeType="application/json"` + `responseSchema` |
+| **Google** | `generationConfig.responseMimeType="application/json"` + `responseJsonSchema` |
 | **Mistral** | Native `response_format.type=json_schema` with `strict=true` (optional organization package) |
 | **xAI** | Responses `text.format.type=json_schema` with `strict=true` plus xAI's additive local overlay (optional organization package) |
 
 The same **portable** schema can be reused across these organizations without
-provider-specific request code. Google drops only `$id` and `$schema`, which
-are non-semantic metadata that its endpoint does not accept; no transformer
-silently drops a semantic constraint.
+provider-specific request code. Google sends the portable JSON Schema through
+`responseJsonSchema` and drops only `$id` and `$schema`, which are
+non-semantic metadata; no transformer silently drops a semantic constraint.
 
 ### Refusal, incomplete, and invalid results
 

--- a/packages/organizations/mistral/README.md
+++ b/packages/organizations/mistral/README.md
@@ -49,6 +49,25 @@ print(response.content)
 See the main [llm-api-adapter README](https://github.com/Inozem/llm_api_adapter/#readme)
 for the shared API contract and examples.
 
+## Structured-output portability
+
+This package requires `llm-api-adapter>=0.9.2,<1.0.0` and enforces the same
+Core portable JSON Schema profile as OpenAI, Anthropic, Google, and xAI. The
+profile guarantees that every object is strict, every property is required,
+optional values are nullable, and only direct,
+non-recursive local `#/$defs/...` references are resolved before the request.
+
+Use `json_schema` for parsed JSON only. Use a Pydantic `response_model` when
+the final result must also be locally validated and returned as
+`ChatResponse.parsed_model`; each nested Pydantic model must use
+`ConfigDict(extra="forbid")`. Refusal and incomplete terminal responses set
+`ChatResponse.refusal` or `ChatResponse.incomplete_reason` and leave parsed
+fields unset. Invalid completed JSON or failed Pydantic validation raises
+`JSONSchemaError`.
+
+The complete schema vocabulary and examples are in the main
+[Structured Output guide](https://github.com/Inozem/llm_api_adapter/#structured-output).
+
 ## Supported models
 
 - `mistral-small-2603`

--- a/packages/organizations/mistral/pyproject.toml
+++ b/packages/organizations/mistral/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-api-adapter-mistral"
-version = "0.1.0"
+version = "0.1.1"
 description = "Official Mistral API package for llm-api-adapter"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/organizations/mistral/pyproject.toml
+++ b/packages/organizations/mistral/pyproject.toml
@@ -22,11 +22,11 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
 ]
-dependencies = ["llm-api-adapter>=0.9.0,<1.0.0"]
+dependencies = ["llm-api-adapter>=0.9.2,<1.0.0"]
 
 [project.optional-dependencies]
-async = ["llm-api-adapter[async]>=0.9.0,<1.0.0"]
-httpx = ["llm-api-adapter[httpx]>=0.9.0,<1.0.0"]
+async = ["llm-api-adapter[async]>=0.9.2,<1.0.0"]
+httpx = ["llm-api-adapter[httpx]>=0.9.2,<1.0.0"]
 
 [project.entry-points."llm_api_adapter.organizations"]
 mistral = "llm_api_adapter_mistral.plugin:PLUGIN"

--- a/packages/organizations/mistral/src/llm_api_adapter_mistral/adapter.py
+++ b/packages/organizations/mistral/src/llm_api_adapter_mistral/adapter.py
@@ -872,6 +872,7 @@ class MistralAdapter(LLMAdapterBase):
         if content is None and not tool_calls:
             warnings.warn("Mistral returned empty content and no tool calls.", UserWarning)
 
+        finish_reason = _as_optional_str(choice.get("finish_reason"))
         return ChatResponse(
             model=_as_optional_str(response.get("model")),
             response_id=_as_optional_str(response.get("id")),
@@ -879,7 +880,10 @@ class MistralAdapter(LLMAdapterBase):
             usage=cls._parse_usage(response.get("usage")),
             content=content,
             tool_calls=tool_calls,
-            finish_reason=_as_optional_str(choice.get("finish_reason")),
+            finish_reason=finish_reason,
+            incomplete_reason=(
+                finish_reason if finish_reason == "length" else None
+            ),
             reasoning_events=reasoning_events,
         )
 

--- a/packages/organizations/mistral/src/llm_api_adapter_mistral/adapter.py
+++ b/packages/organizations/mistral/src/llm_api_adapter_mistral/adapter.py
@@ -21,6 +21,9 @@ from llm_api_adapter.adapters.base_adapter import (
     OnToolCall,
     _StreamState,
 )
+from llm_api_adapter.adapters.structured_output import (
+    validate_core_portable_schema,
+)
 from llm_api_adapter.errors.llm_api_error import (
     InvalidToolArgumentsError,
     LLMAPIAuthorizationError,
@@ -737,7 +740,10 @@ class MistralAdapter(LLMAdapterBase):
                 "json_schema": {
                     "name": "response",
                     "strict": True,
-                    "schema": self._enforce_strict_schema(json_schema),
+                    "schema": validate_core_portable_schema(
+                        json_schema,
+                        provider="mistral",
+                    ),
                 },
             }
         return {key: value for key, value in payload.items() if value is not None}

--- a/packages/organizations/mistral/tests/test_mistral_adapter.py
+++ b/packages/organizations/mistral/tests/test_mistral_adapter.py
@@ -10,9 +10,10 @@ import pytest
 
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[1]
-CORE_SOURCE = PACKAGE_ROOT.parents[2] / "src"
+REPOSITORY_ROOT = PACKAGE_ROOT.parents[2]
+CORE_SOURCE = REPOSITORY_ROOT / "src"
 PACKAGE_SOURCE = PACKAGE_ROOT / "src"
-for source in (str(PACKAGE_SOURCE), str(CORE_SOURCE)):
+for source in (str(PACKAGE_SOURCE), str(CORE_SOURCE), str(REPOSITORY_ROOT)):
     if source not in sys.path:
         sys.path.insert(0, source)
 

--- a/packages/organizations/mistral/tests/test_mistral_adapter.py
+++ b/packages/organizations/mistral/tests/test_mistral_adapter.py
@@ -31,6 +31,7 @@ from llm_api_adapter.service_provider_registry import ServiceProviderRegistry
 from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
 from llm_api_adapter_mistral.adapter import MistralAdapter
 from llm_api_adapter_mistral.plugin import PLUGIN
+from tests.fixtures.structured_output import FLAT_OBJECT_SCHEMA
 
 
 class FakeSyncTransport:
@@ -394,14 +395,9 @@ def test_mistral_uses_official_json_schema_payload_shape(mistral_runtime):
         }
     )
     adapter.adapter._sync_transport = transport
-    schema = {
-        "type": "object",
-        "properties": {"answer": {"type": "string"}},
-    }
-
     response = adapter.chat(
         [{"role": "user", "content": "Reply as JSON."}],
-        json_schema=schema,
+        json_schema=FLAT_OBJECT_SCHEMA,
     )
 
     assert response.parsed_json == {"answer": "Bonjour"}
@@ -410,11 +406,12 @@ def test_mistral_uses_official_json_schema_payload_shape(mistral_runtime):
         "json_schema": {
             "name": "response",
             "strict": True,
-            "schema": {
-                "type": "object",
-                "properties": {"answer": {"type": "string"}},
-                "additionalProperties": False,
-            },
+                "schema": {
+                    "type": "object",
+                    "properties": {"answer": {"type": "string"}},
+                    "required": ["answer"],
+                    "additionalProperties": False,
+                },
         },
     }
 

--- a/packages/organizations/xai/README.md
+++ b/packages/organizations/xai/README.md
@@ -61,10 +61,30 @@ The package deliberately exposes fixed model IDs, not moving aliases:
 For `grok-4.5` and `grok-4.6`, xAI cannot disable reasoning: a requested
 `"none"` is mapped to the documented minimum and produces a warning.
 
-The JSON Schema subset is limited by xAI. The adapter rejects unsupported
-schemas before sending a request. See xAI's
+## Structured-output portability
+
+This package requires `llm-api-adapter>=0.9.2,<1.0.0` and enforces the same
+Core portable JSON Schema profile as OpenAI, Anthropic, Google, and Mistral.
+The profile guarantees that every object is strict, every property is required,
+optional values are nullable, and only
+direct, non-recursive local `#/$defs/...` references are resolved before the
+request.
+
+xAI's documented immediate schema failures are an additive local overlay, not
+a replacement for the Core boundary. The adapter rejects boolean property
+schemas, empty `enum` or `anyOf`, `minContains`/`maxContains`, tuple `items`
+arrays, and unsupported regular expressions before the request. See xAI's
 [structured-output documentation](https://docs.x.ai/developers/model-capabilities/text/structured-outputs)
-for the supported schema vocabulary.
+for xAI-specific details.
+
+Use `json_schema` for parsed JSON only. Use a Pydantic `response_model` when
+the final result must also be locally validated and returned as
+`ChatResponse.parsed_model`; each nested Pydantic model must use
+`ConfigDict(extra="forbid")`. Refusal and incomplete terminal responses set
+`ChatResponse.refusal` or `ChatResponse.incomplete_reason` and leave parsed
+fields unset. Invalid completed JSON or failed Pydantic validation raises
+`JSONSchemaError`. The complete portable vocabulary and examples are in the
+main [Structured Output guide](https://github.com/Inozem/llm_api_adapter/#structured-output).
 
 ## Conversations, files, and costs
 

--- a/packages/organizations/xai/pyproject.toml
+++ b/packages/organizations/xai/pyproject.toml
@@ -22,11 +22,11 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
 ]
-dependencies = ["llm-api-adapter>=0.9.1,<1.0.0"]
+dependencies = ["llm-api-adapter>=0.9.2,<1.0.0"]
 
 [project.optional-dependencies]
-async = ["llm-api-adapter[async]>=0.9.1,<1.0.0"]
-httpx = ["llm-api-adapter[httpx]>=0.9.1,<1.0.0"]
+async = ["llm-api-adapter[async]>=0.9.2,<1.0.0"]
+httpx = ["llm-api-adapter[httpx]>=0.9.2,<1.0.0"]
 
 [project.entry-points."llm_api_adapter.organizations"]
 xai = "llm_api_adapter_xai.plugin:PLUGIN"

--- a/packages/organizations/xai/pyproject.toml
+++ b/packages/organizations/xai/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-api-adapter-xai"
-version = "0.1.0"
+version = "0.1.1"
 description = "Official xAI Responses API package for llm-api-adapter"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/organizations/xai/src/llm_api_adapter_xai/adapter.py
+++ b/packages/organizations/xai/src/llm_api_adapter_xai/adapter.py
@@ -22,6 +22,9 @@ from llm_api_adapter.adapters.base_adapter import (
     OnReasoning,
     OnToolCall,
 )
+from llm_api_adapter.adapters.structured_output import (
+    validate_core_portable_schema,
+)
 from llm_api_adapter.errors.llm_api_error import (
     InvalidToolSchemaError,
     JSONSchemaError,
@@ -378,6 +381,7 @@ class XAIAdapter(LLMAdapterBase):
             schema = self._validate_xai_structured_schema(
                 request_context.effective_schema,
             )
+            schema = validate_core_portable_schema(schema, provider="xai")
             parameters["text"] = {
                 "format": {
                     "type": "json_schema",

--- a/packages/organizations/xai/src/llm_api_adapter_xai/streaming.py
+++ b/packages/organizations/xai/src/llm_api_adapter_xai/streaming.py
@@ -84,7 +84,10 @@ class XAIResponsesStreamParser:
                 cls._record_output_item(payload, item, state)
             return None
 
-        if event_type == "response.completed" and isinstance(response_data, Mapping):
+        if event_type in (
+            "response.completed",
+            "response.incomplete",
+        ) and isinstance(response_data, Mapping):
             state.final_response = dict(response_data)
         return None
 

--- a/packages/organizations/xai/tests/test_xai_adapter.py
+++ b/packages/organizations/xai/tests/test_xai_adapter.py
@@ -11,7 +11,7 @@ from typing import Any, Iterator, Mapping
 import warnings
 
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[1]
 CORE_SOURCE = PACKAGE_ROOT.parents[2] / "src"
@@ -65,6 +65,8 @@ from llm_api_adapter_xai.registry import MODEL_METADATA
 
 
 class StructuredAnswer(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     answer: str
 
 
@@ -656,7 +658,7 @@ def test_chat_rejects_documented_invalid_structured_schemas(xai_runtime, schema)
 
 
 @pytest.mark.unit
-def test_chat_accepts_explicit_additional_properties_in_structured_schema(
+def test_chat_accepts_explicit_portable_structured_schema(
     xai_runtime,
 ):
     adapter = XAIAdapter(api_key="test-key", model="grok-4.6")
@@ -666,6 +668,7 @@ def test_chat_accepts_explicit_additional_properties_in_structured_schema(
     schema = {
         "type": "object",
         "properties": {"answer": {"type": "string"}},
+        "required": ["answer"],
         "additionalProperties": False,
     }
 

--- a/packages/organizations/xai/tests/test_xai_adapter.py
+++ b/packages/organizations/xai/tests/test_xai_adapter.py
@@ -14,9 +14,10 @@ import pytest
 from pydantic import BaseModel, ConfigDict
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[1]
-CORE_SOURCE = PACKAGE_ROOT.parents[2] / "src"
+REPOSITORY_ROOT = PACKAGE_ROOT.parents[2]
+CORE_SOURCE = REPOSITORY_ROOT / "src"
 PACKAGE_SOURCE = PACKAGE_ROOT / "src"
-for source in (str(PACKAGE_SOURCE), str(CORE_SOURCE)):
+for source in (str(PACKAGE_SOURCE), str(CORE_SOURCE), str(REPOSITORY_ROOT)):
     if source not in sys.path:
         sys.path.insert(0, source)
 

--- a/packages/organizations/xai/tests/test_xai_adapter.py
+++ b/packages/organizations/xai/tests/test_xai_adapter.py
@@ -53,6 +53,7 @@ from llm_api_adapter.organization_registry import (
     ORGANIZATION_PLUGIN_ENTRY_POINT_GROUP,
     OrganizationPluginDiscovery,
 )
+from tests.fixtures.structured_output import FLAT_OBJECT_SCHEMA
 from llm_api_adapter.service_provider_registry import ServiceProviderRegistry
 from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
 
@@ -615,6 +616,23 @@ def test_chat_maps_structured_pydantic_output_and_reasoning(xai_runtime):
         }
     }
     assert transport.requests[0].payload["reasoning"] == {"effort": "xhigh"}
+
+
+@pytest.mark.unit
+def test_chat_preserves_the_shared_flat_portable_schema(xai_runtime):
+    adapter = XAIAdapter(api_key="test-key", model="grok-4.6")
+    transport = FakeSyncTransport(_structured_response(model="grok-4.6"))
+    adapter._client._sync_transport = transport
+
+    response = adapter.chat(
+        messages=[UserMessage("Return an answer.")],
+        json_schema=FLAT_OBJECT_SCHEMA,
+    )
+
+    assert response.parsed_json == {"answer": "ok"}
+    assert transport.requests[0].payload["text"]["format"]["schema"] == (
+        FLAT_OBJECT_SCHEMA
+    )
 
 
 @pytest.mark.unit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-api-adapter"
-version = "0.9.1"
+version = "0.9.2"
 description = "Lightweight multi-provider LLM API adapter for Python — OpenAI, Anthropic, Google, Mistral, and xAI."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -27,8 +27,8 @@ dependencies = ["requests>=2.32"]
 [project.optional-dependencies]
 async = ["httpx>=0.28"]
 httpx = ["httpx>=0.28"]
-mistral = ["llm-api-adapter-mistral>=0.1.0,<0.2.0"]
-xai = ["llm-api-adapter-xai>=0.1.0,<0.2.0"]
+mistral = ["llm-api-adapter-mistral>=0.1.1,<0.2.0"]
+xai = ["llm-api-adapter-xai>=0.1.1,<0.2.0"]
 
 [project.urls]
 Repository = "https://github.com/Inozem/llm_api_adapter/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-api-adapter"
-version = "0.9.2.post1"
+version = "0.9.2"
 description = "Lightweight multi-provider LLM API adapter for Python — OpenAI, Anthropic, Google, Mistral, and xAI."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-api-adapter"
-version = "0.9.2"
+version = "0.9.2.post1"
 description = "Lightweight multi-provider LLM API adapter for Python — OpenAI, Anthropic, Google, Mistral, and xAI."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/llm_api_adapter/adapters/anthropic/payloads.py
+++ b/src/llm_api_adapter/adapters/anthropic/payloads.py
@@ -8,6 +8,7 @@ from ...errors.config_errors import LLMReasoningLevelError
 from ...models.messages.chat_message import Messages
 from ...models.responses.chat_response import ChatResponse
 from ...models.tools.tool_spec import ToolSpec
+from ..structured_output import validate_core_portable_schema
 
 class _AnthropicPayloadMixin:
     """Build Anthropic payloads while keeping adapter options normalized."""
@@ -110,7 +111,7 @@ class _AnthropicPayloadMixin:
             params["output_config"] = {
                 "format": {
                     "type": "json_schema",
-                    "schema": self._enforce_strict_schema(effective_schema),
+                    "schema": self._to_anthropic_structured_output_schema(effective_schema),
                 }
             }
         if reasoning_level is not None:
@@ -150,6 +151,11 @@ class _AnthropicPayloadMixin:
         if tool.description:
             payload["description"] = tool.description
         return payload
+
+    @staticmethod
+    def _to_anthropic_structured_output_schema(schema: dict) -> dict:
+        """Validate the Core profile without changing schema semantics."""
+        return validate_core_portable_schema(schema, provider="anthropic")
 
     def _to_anthropic_tool_choice(
         self,

--- a/src/llm_api_adapter/adapters/base_adapter.py
+++ b/src/llm_api_adapter/adapters/base_adapter.py
@@ -41,6 +41,7 @@ from ..models.responses.reasoning_event import (
     ReasoningEventKind,
 )
 from ..models.responses.stream_chunk import StreamChunk
+from .structured_output import prepare_structured_output
 from ..llms.streaming import (
     StreamChunkBuffer,
     StreamReasoningCollector,
@@ -57,7 +58,9 @@ TOOL_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
 @dataclass(frozen=True)
 class _ChatRequestContext:
     normalized_messages: Messages
+    source_schema: Optional[dict]
     effective_schema: Optional[dict]
+    response_model: Optional[Any]
     normalized_tool_choice: Optional[str]
 
 
@@ -295,10 +298,11 @@ class LLMAdapterBase(ABC):
     ) -> _ChatRequestContext:
         """Validate and normalize provider-neutral chat inputs."""
         self._validate_tools(tools)
-        effective_schema = self._resolve_json_schema(
+        structured_output = prepare_structured_output(
             json_schema,
             response_model,
             tools,
+            provider=self.company,
         )
         normalized_tool_choice = self._normalize_tool_choice(
             tool_choice,
@@ -307,7 +311,9 @@ class LLMAdapterBase(ABC):
         normalized_messages = self._normalize_messages(messages)
         return _ChatRequestContext(
             normalized_messages=normalized_messages,
-            effective_schema=effective_schema,
+            source_schema=structured_output.source_schema,
+            effective_schema=structured_output.provider_schema,
+            response_model=structured_output.response_model,
             normalized_tool_choice=normalized_tool_choice,
         )
 
@@ -471,26 +477,13 @@ class LLMAdapterBase(ABC):
         response_model: Optional[Any],
         tools: Optional[List[ToolSpec]],
     ) -> Optional[dict]:
-        if json_schema is not None and response_model is not None:
-            raise JSONSchemaError(detail="json_schema and response_model cannot be used together")
-        if response_model is not None and tools is not None:
-            raise JSONSchemaError(detail="response_model and tools cannot be used together")
-        if json_schema is not None and tools is not None:
-            raise JSONSchemaError(detail="json_schema and tools cannot be used together")
-        if response_model is not None:
-            try:
-                return response_model.model_json_schema()
-            except AttributeError:
-                try:
-                    import pydantic  # noqa
-                except ImportError:
-                    raise JSONSchemaError(
-                        detail="pydantic is required for response_model; install it with: pip install pydantic"
-                    )
-                raise JSONSchemaError(detail="response_model must be a Pydantic BaseModel subclass")
-        if json_schema is not None and not isinstance(json_schema, dict):
-            raise JSONSchemaError(detail="json_schema must be a dict")
-        return json_schema
+        """Compatibility wrapper for the provider-ready schema preparation path."""
+        return prepare_structured_output(
+            json_schema,
+            response_model,
+            tools,
+            provider=self.company,
+        ).provider_schema
 
     def _strip_json_fences(self, content: str) -> str:
         text = content.strip()

--- a/src/llm_api_adapter/adapters/base_adapter.py
+++ b/src/llm_api_adapter/adapters/base_adapter.py
@@ -679,6 +679,25 @@ class LLMAdapterBase(ABC):
         response_model: Optional[Any],
     ) -> ChatResponse:
         """Apply common structured-output parsing and pricing to a response."""
+        self._prepare_structured_output_response(
+            chat_response,
+            effective_schema,
+            response_model,
+        )
+        self._apply_response_pricing(chat_response)
+        return chat_response
+
+    def _prepare_structured_output_response(
+        self,
+        chat_response: ChatResponse,
+        effective_schema: Optional[dict],
+        response_model: Optional[Any],
+    ) -> None:
+        """Parse a completed structured result unless its terminal state forbids it."""
+        if chat_response.refusal is not None or chat_response.incomplete_reason is not None:
+            chat_response.parsed_json = None
+            chat_response.parsed_model = None
+            return
         chat_response.parsed_json = self._parse_json_response(
             chat_response.content,
             effective_schema,
@@ -687,8 +706,6 @@ class LLMAdapterBase(ABC):
             chat_response.parsed_json,
             response_model,
         )
-        self._apply_response_pricing(chat_response)
-        return chat_response
 
     def _prepare_stream_response(
         self,
@@ -698,12 +715,9 @@ class LLMAdapterBase(ABC):
     ) -> None:
         """Apply final response processing before delivering stream callbacks."""
         try:
-            chat_response.parsed_json = self._parse_json_response(
-                chat_response.content,
+            self._prepare_structured_output_response(
+                chat_response,
                 effective_schema,
-            )
-            chat_response.parsed_model = self._parse_response_model(
-                chat_response.parsed_json,
                 response_model,
             )
             self._apply_response_pricing(chat_response)

--- a/src/llm_api_adapter/adapters/google/payloads.py
+++ b/src/llm_api_adapter/adapters/google/payloads.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional
 from ...models.messages.chat_message import Messages
 from ...models.responses.chat_response import ChatResponse
 from ...models.tools import ToolSpec
+from ..structured_output import validate_core_portable_schema
 
 class _GooglePayloadMixin:
     """Build Gemini payloads while keeping adapter options normalized."""
@@ -146,27 +147,35 @@ class _GooglePayloadMixin:
         parser_kwargs = {"capture_reasoning": True} if capture_reasoning else {}
         return ChatResponse.from_google_response(response, **parser_kwargs)
 
-    # Fields not supported by Google's responseSchema subset of JSON Schema.
-    _GOOGLE_SCHEMA_UNSUPPORTED = frozenset(
-        {"additionalProperties", "$schema", "$id", "$ref"}
-    )
+    # These annotations do not affect the Core portable-profile meaning and
+    # are not accepted by Google's responseSchema wire representation.
+    _GOOGLE_SCHEMA_METADATA_TO_REMOVE = frozenset({"$schema", "$id"})
 
     def _to_google_schema(self, schema: dict) -> dict:
-        """Convert JSON Schema to Google's format and strip unsupported fields."""
+        """Convert a validated Core schema to Google's wire representation."""
+        return self._convert_core_schema_to_google(
+            validate_core_portable_schema(schema, provider="google"),
+        )
+
+    def _convert_core_schema_to_google(self, schema: dict) -> dict:
         schema = {
             key: value
             for key, value in schema.items()
-            if key not in self._GOOGLE_SCHEMA_UNSUPPORTED
+            if key not in self._GOOGLE_SCHEMA_METADATA_TO_REMOVE
         }
         if "type" in schema and isinstance(schema["type"], str):
             schema["type"] = schema["type"].upper()
+        elif "type" in schema and isinstance(schema["type"], list):
+            schema["type"] = [value.upper() for value in schema["type"]]
         if "properties" in schema:
             schema["properties"] = {
-                key: self._to_google_schema(value) if isinstance(value, dict) else value
+                key: self._convert_core_schema_to_google(value)
+                if isinstance(value, dict)
+                else value
                 for key, value in schema["properties"].items()
             }
         if "items" in schema and isinstance(schema["items"], dict):
-            schema["items"] = self._to_google_schema(schema["items"])
+            schema["items"] = self._convert_core_schema_to_google(schema["items"])
         return schema
 
     def _to_google_function_declaration(self, tool: ToolSpec) -> Dict[str, Any]:

--- a/src/llm_api_adapter/adapters/google/payloads.py
+++ b/src/llm_api_adapter/adapters/google/payloads.py
@@ -108,7 +108,9 @@ class _GooglePayloadMixin:
         }
         if effective_schema is not None:
             generation_config["responseMimeType"] = "application/json"
-            generation_config["responseSchema"] = self._to_google_schema(effective_schema)
+            generation_config["responseJsonSchema"] = self._to_google_schema(
+                effective_schema,
+            )
         thinking_config = self._build_thinking_config(
             reasoning_level=reasoning_level,
             capture_reasoning=capture_reasoning,
@@ -147,12 +149,12 @@ class _GooglePayloadMixin:
         parser_kwargs = {"capture_reasoning": True} if capture_reasoning else {}
         return ChatResponse.from_google_response(response, **parser_kwargs)
 
-    # These annotations do not affect the Core portable-profile meaning and
-    # are not accepted by Google's responseSchema wire representation.
+    # These annotations do not affect the Core portable-profile meaning, so
+    # the Google wire schema deliberately omits them.
     _GOOGLE_SCHEMA_METADATA_TO_REMOVE = frozenset({"$schema", "$id"})
 
     def _to_google_schema(self, schema: dict) -> dict:
-        """Convert a validated Core schema to Google's wire representation."""
+        """Convert a validated Core schema to Google's JSON Schema wire form."""
         return self._convert_core_schema_to_google(
             validate_core_portable_schema(schema, provider="google"),
         )
@@ -163,10 +165,6 @@ class _GooglePayloadMixin:
             for key, value in schema.items()
             if key not in self._GOOGLE_SCHEMA_METADATA_TO_REMOVE
         }
-        if "type" in schema and isinstance(schema["type"], str):
-            schema["type"] = schema["type"].upper()
-        elif "type" in schema and isinstance(schema["type"], list):
-            schema["type"] = [value.upper() for value in schema["type"]]
         if "properties" in schema:
             schema["properties"] = {
                 key: self._convert_core_schema_to_google(value)

--- a/src/llm_api_adapter/adapters/google/streaming.py
+++ b/src/llm_api_adapter/adapters/google/streaming.py
@@ -31,6 +31,7 @@ class _GoogleStreamState(_StreamState):
     text_parts: List[str] = field(default_factory=list)
     function_parts: List[Dict[str, Any]] = field(default_factory=list)
     finish_reason: Optional[str] = None
+    finish_message: Optional[str] = None
     usage_metadata: Dict[str, Any] = field(default_factory=dict)
     response_metadata: Dict[str, Any] = field(default_factory=dict)
 
@@ -101,6 +102,8 @@ class _GoogleStreamingMixin:
             return
         if candidate.get("finishReason") is not None:
             state.finish_reason = str(candidate["finishReason"])
+        if isinstance(candidate.get("finishMessage"), str):
+            state.finish_message = candidate["finishMessage"]
         content = candidate.get("content")
         parts = content.get("parts") if isinstance(content, Mapping) else []
         if not isinstance(parts, list):
@@ -201,6 +204,8 @@ class _GoogleStreamingMixin:
             return
         if candidate.get("finishReason") is not None:
             state.finish_reason = str(candidate["finishReason"])
+        if isinstance(candidate.get("finishMessage"), str):
+            state.finish_message = candidate["finishMessage"]
         content = candidate.get("content")
         parts = content.get("parts") if isinstance(content, Mapping) else []
         if not isinstance(parts, list):
@@ -297,6 +302,8 @@ class _GoogleStreamingMixin:
         final_candidate: Dict[str, Any] = {"content": {"parts": final_parts}}
         if state.finish_reason is not None:
             final_candidate["finishReason"] = state.finish_reason
+        if state.finish_message is not None:
+            final_candidate["finishMessage"] = state.finish_message
         final_response: Dict[str, Any] = {
             **state.response_metadata,
             "candidates": [final_candidate],

--- a/src/llm_api_adapter/adapters/openai/payloads.py
+++ b/src/llm_api_adapter/adapters/openai/payloads.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional
 from ...models.messages.chat_message import Messages
 from ...models.responses.chat_response import ChatResponse
 from ...models.tools import ToolSpec
+from ..structured_output import validate_core_portable_schema
 
 class _OpenAIPayloadMixin:
     """Build provider payloads while keeping adapter-level options normalized."""
@@ -92,7 +93,7 @@ class _OpenAIPayloadMixin:
                     "type": "json_schema",
                     "name": "response",
                     "strict": True,
-                    "schema": self._enforce_strict_schema(effective_schema),
+                    "schema": self._to_openai_structured_output_schema(effective_schema),
                 }
             }
         return params
@@ -120,7 +121,7 @@ class _OpenAIPayloadMixin:
                 "json_schema": {
                     "name": "response",
                     "strict": True,
-                    "schema": self._enforce_strict_schema(effective_schema),
+                    "schema": self._to_openai_structured_output_schema(effective_schema),
                 },
             }
         return params
@@ -182,7 +183,7 @@ class _OpenAIPayloadMixin:
                         "type": "json_schema",
                         "name": "response",
                         "strict": True,
-                        "schema": self._enforce_strict_schema(effective_schema),
+                        "schema": self._to_openai_structured_output_schema(effective_schema),
                     }
                 }
             if capture_reasoning:
@@ -200,7 +201,7 @@ class _OpenAIPayloadMixin:
                     "json_schema": {
                         "name": "response",
                         "strict": True,
-                        "schema": self._enforce_strict_schema(effective_schema),
+                        "schema": self._to_openai_structured_output_schema(effective_schema),
                     },
                 }
         return {key: value for key, value in params.items() if value is not None}
@@ -226,6 +227,11 @@ class _OpenAIPayloadMixin:
                 }
             )
         return mapped
+
+    @staticmethod
+    def _to_openai_structured_output_schema(schema: dict) -> dict:
+        """Validate the Core profile without changing schema semantics."""
+        return validate_core_portable_schema(schema, provider="openai")
 
     def _map_tool_choice_to_openai(self, tool_choice: Optional[str]) -> Any:
         if tool_choice is None:

--- a/src/llm_api_adapter/adapters/openai/streaming.py
+++ b/src/llm_api_adapter/adapters/openai/streaming.py
@@ -211,7 +211,10 @@ class _OpenAIStreamingMixin:
                 event_type,
                 state,
             )
-        elif event_type == "response.completed" and isinstance(response_data, Mapping):
+        elif event_type in (
+            "response.completed",
+            "response.incomplete",
+        ) and isinstance(response_data, Mapping):
             state.final_response = dict(response_data)
 
     async def _handle_responses_reasoning_delta_async(
@@ -327,7 +330,10 @@ class _OpenAIStreamingMixin:
                 event_type,
                 state,
             )
-        elif event_type == "response.completed" and isinstance(response_data, Mapping):
+        elif event_type in (
+            "response.completed",
+            "response.incomplete",
+        ) and isinstance(response_data, Mapping):
             state.final_response = dict(response_data)
 
     def _handle_responses_reasoning_delta(
@@ -457,6 +463,7 @@ class _OpenAIStreamingMixin:
         on_chunk: Optional[AsyncOnChunk],
     ) -> AsyncIterator[str]:
         text_parts: List[str] = []
+        refusal_parts: List[str] = []
         tool_calls: Dict[int, Dict[str, Any]] = {}
         legacy_response: Dict[str, Any] = {"model": self.model, "choices": []}
         finish_reason: Optional[str] = None
@@ -480,6 +487,7 @@ class _OpenAIStreamingMixin:
                 text, choice_finish_reason = self._consume_legacy_stream_choice(
                     choice,
                     text_parts,
+                    refusal_parts,
                     tool_calls,
                 )
                 if text is not None:
@@ -494,6 +502,7 @@ class _OpenAIStreamingMixin:
         chat_response = self._build_legacy_stream_response(
             legacy_response,
             text_parts,
+            refusal_parts,
             tool_calls,
             finish_reason,
         )
@@ -524,6 +533,7 @@ class _OpenAIStreamingMixin:
         on_chunk: Optional[OnChunk],
     ) -> Iterator[str]:
         text_parts: List[str] = []
+        refusal_parts: List[str] = []
         tool_calls: Dict[int, Dict[str, Any]] = {}
         legacy_response: Dict[str, Any] = {"model": self.model, "choices": []}
         finish_reason: Optional[str] = None
@@ -547,6 +557,7 @@ class _OpenAIStreamingMixin:
                 text, choice_finish_reason = self._consume_legacy_stream_choice(
                     choice,
                     text_parts,
+                    refusal_parts,
                     tool_calls,
                 )
                 if text is not None:
@@ -560,6 +571,7 @@ class _OpenAIStreamingMixin:
         chat_response = self._build_legacy_stream_response(
             legacy_response,
             text_parts,
+            refusal_parts,
             tool_calls,
             finish_reason,
         )
@@ -628,6 +640,7 @@ class _OpenAIStreamingMixin:
         self,
         choice: Any,
         text_parts: List[str],
+        refusal_parts: List[str],
         tool_calls: Dict[int, Dict[str, Any]],
     ) -> tuple[Optional[str], Optional[str]]:
         if not isinstance(choice, Mapping) or choice.get("index", 0) != 0:
@@ -640,6 +653,10 @@ class _OpenAIStreamingMixin:
         text = content if isinstance(content, str) and content else None
         if text is not None:
             text_parts.append(text)
+
+        refusal = delta.get("refusal")
+        if isinstance(refusal, str) and refusal:
+            refusal_parts.append(refusal)
 
         raw_tool_calls = delta.get("tool_calls")
         if isinstance(raw_tool_calls, list):
@@ -679,10 +696,13 @@ class _OpenAIStreamingMixin:
     def _build_legacy_stream_response(
         legacy_response: Dict[str, Any],
         text_parts: List[str],
+        refusal_parts: List[str],
         tool_calls: Dict[int, Dict[str, Any]],
         finish_reason: Optional[str],
     ) -> ChatResponse:
         message: Dict[str, Any] = {"content": "".join(text_parts) or None}
+        if refusal_parts:
+            message["refusal"] = "".join(refusal_parts)
         if tool_calls:
             message["tool_calls"] = [tool_calls[index] for index in sorted(tool_calls)]
         legacy_response["choices"] = [{"message": message, "finish_reason": finish_reason}]

--- a/src/llm_api_adapter/adapters/structured_output.py
+++ b/src/llm_api_adapter/adapters/structured_output.py
@@ -1,0 +1,264 @@
+"""Internal preparation of provider-neutral structured-output schemas."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from ..errors.llm_api_error import JSONSchemaError
+
+
+_REFERENCE_METADATA_KEYS = frozenset(
+    {"title", "description", "default", "examples", "$comment"},
+)
+
+
+@dataclass(frozen=True)
+class PreparedStructuredOutput:
+    """Keep source validation inputs distinct from the provider-ready schema."""
+
+    source_schema: Optional[dict]
+    provider_schema: Optional[dict]
+    response_model: Optional[Any]
+
+
+def prepare_structured_output(
+    json_schema: Optional[dict],
+    response_model: Optional[Any],
+    tools: Optional[Any],
+    *,
+    provider: str,
+) -> PreparedStructuredOutput:
+    """Validate structured-output inputs and prepare a provider schema.
+
+    ``response_model`` remains untouched for response validation.  The source
+    schema is a deep copy of the caller-supplied JSON Schema or Pydantic's
+    generated schema, while ``provider_schema`` has local references inlined.
+    """
+    if json_schema is not None and response_model is not None:
+        raise JSONSchemaError(
+            detail="json_schema and response_model cannot be used together",
+        )
+    if response_model is not None and tools is not None:
+        raise JSONSchemaError(
+            detail="response_model and tools cannot be used together",
+        )
+    if json_schema is not None and tools is not None:
+        raise JSONSchemaError(
+            detail="json_schema and tools cannot be used together",
+        )
+
+    if response_model is not None:
+        source_schema = _schema_from_response_model(response_model)
+    else:
+        if json_schema is not None and not isinstance(json_schema, dict):
+            raise JSONSchemaError(detail="json_schema must be a dict")
+        source_schema = json_schema
+
+    copied_source_schema = deepcopy(source_schema) if source_schema is not None else None
+    provider_schema = (
+        normalize_local_references(copied_source_schema, provider=provider)
+        if copied_source_schema is not None
+        else None
+    )
+    return PreparedStructuredOutput(
+        source_schema=copied_source_schema,
+        provider_schema=provider_schema,
+        response_model=response_model,
+    )
+
+
+def normalize_local_references(schema: dict, *, provider: str) -> dict:
+    """Inline supported ``#/$defs/...`` references without mutating ``schema``.
+
+    The portable profile permits only direct, local references into the root
+    ``$defs`` mapping.  External, unresolved, recursive, and semantically
+    ambiguous references are rejected before a provider request is made.
+    """
+    source = deepcopy(schema)
+    definitions = source.get("$defs", {})
+    if definitions is not None and not isinstance(definitions, dict):
+        raise _reference_error(
+            provider,
+            "#/$defs",
+            "must be an object when local references are used",
+        )
+
+    normalized = _normalize_schema_node(
+        source,
+        provider=provider,
+        path="#",
+        definitions=definitions or {},
+        active_references=frozenset(),
+        is_root=True,
+    )
+    if not isinstance(normalized, dict):
+        raise _reference_error(provider, "#", "must resolve to an object schema")
+    return normalized
+
+
+def _schema_from_response_model(response_model: Any) -> dict:
+    try:
+        schema = response_model.model_json_schema()
+    except AttributeError:
+        try:
+            import pydantic  # noqa: F401
+        except ImportError:
+            raise JSONSchemaError(
+                detail=(
+                    "pydantic is required for response_model; install it with: "
+                    "pip install pydantic"
+                ),
+            )
+        raise JSONSchemaError(
+            detail="response_model must be a Pydantic BaseModel subclass",
+        )
+    if not isinstance(schema, dict):
+        raise JSONSchemaError(detail="response_model.model_json_schema() must return a dict")
+    return schema
+
+
+def _normalize_schema_node(
+    node: Any,
+    *,
+    provider: str,
+    path: str,
+    definitions: dict[str, Any],
+    active_references: frozenset[str],
+    is_root: bool = False,
+) -> Any:
+    if isinstance(node, list):
+        return [
+            _normalize_schema_node(
+                item,
+                provider=provider,
+                path=_pointer_path(path, str(index)),
+                definitions=definitions,
+                active_references=active_references,
+            )
+            for index, item in enumerate(node)
+        ]
+    if not isinstance(node, dict):
+        return deepcopy(node)
+
+    if "$ref" in node:
+        return _resolve_reference_node(
+            node,
+            provider=provider,
+            path=path,
+            definitions=definitions,
+            active_references=active_references,
+        )
+
+    return {
+        key: _normalize_schema_node(
+            value,
+            provider=provider,
+            path=_pointer_path(path, key),
+            definitions=definitions,
+            active_references=active_references,
+        )
+        for key, value in node.items()
+        if not (is_root and key == "$defs")
+    }
+
+
+def _resolve_reference_node(
+    node: dict[str, Any],
+    *,
+    provider: str,
+    path: str,
+    definitions: dict[str, Any],
+    active_references: frozenset[str],
+) -> Any:
+    reference = node["$ref"]
+    if not isinstance(reference, str):
+        raise _reference_error(provider, path, "$ref must be a string")
+    definition_name = _local_definition_name(reference, provider=provider, path=path)
+    if definition_name in active_references:
+        raise _reference_error(
+            provider,
+            path,
+            f"contains recursive local reference {reference!r}",
+        )
+    if definition_name not in definitions:
+        raise _reference_error(
+            provider,
+            path,
+            f"cannot resolve local reference {reference!r}",
+        )
+
+    # A root Pydantic schema can declare ``$defs`` beside a root ``$ref``.
+    # The definitions mapping is the resolution table, not an additional
+    # constraint to merge into the inlined schema.
+    sibling_keys = set(node) - {"$ref", "$defs"}
+    unsupported_siblings = sibling_keys - _REFERENCE_METADATA_KEYS
+    if unsupported_siblings:
+        names = ", ".join(sorted(unsupported_siblings))
+        raise _reference_error(
+            provider,
+            path,
+            f"cannot combine local reference {reference!r} with {names}",
+        )
+
+    resolved = _normalize_schema_node(
+        definitions[definition_name],
+        provider=provider,
+        path=_pointer_path(_pointer_path("#", "$defs"), definition_name),
+        definitions=definitions,
+        active_references=active_references | {definition_name},
+    )
+    if not sibling_keys:
+        return resolved
+    if not isinstance(resolved, dict):
+        raise _reference_error(
+            provider,
+            path,
+            f"cannot attach metadata to non-object local reference {reference!r}",
+        )
+    return {
+        **resolved,
+        **{
+            key: _normalize_schema_node(
+                node[key],
+                provider=provider,
+                path=_pointer_path(path, key),
+                definitions=definitions,
+                active_references=active_references,
+            )
+            for key in sibling_keys
+        },
+    }
+
+
+def _local_definition_name(reference: str, *, provider: str, path: str) -> str:
+    prefix = "#/$defs/"
+    if not reference.startswith(prefix):
+        raise _reference_error(
+            provider,
+            path,
+            f"supports only local #/$defs/... references, got {reference!r}",
+        )
+    escaped_name = reference[len(prefix):]
+    if not escaped_name or "/" in escaped_name:
+        raise _reference_error(
+            provider,
+            path,
+            f"supports only direct local $defs references, got {reference!r}",
+        )
+    return escaped_name.replace("~1", "/").replace("~0", "~")
+
+
+def _pointer_path(parent: str, token: str) -> str:
+    escaped_token = str(token).replace("~", "~0").replace("/", "~1")
+    return f"{parent}/{escaped_token}"
+
+
+def _reference_error(provider: str, path: str, detail: str) -> JSONSchemaError:
+    return JSONSchemaError(
+        detail=f"{provider} structured-output schema at {path}: {detail}",
+    )
+
+
+__all__ = ["PreparedStructuredOutput", "normalize_local_references", "prepare_structured_output"]

--- a/src/llm_api_adapter/adapters/structured_output.py
+++ b/src/llm_api_adapter/adapters/structured_output.py
@@ -13,6 +13,24 @@ _REFERENCE_METADATA_KEYS = frozenset(
     {"title", "description", "default", "examples", "$comment"},
 )
 
+_PORTABLE_SCHEMA_TYPES = frozenset(
+    {"string", "number", "integer", "boolean", "object", "array"},
+)
+_PORTABLE_SCHEMA_KEYWORDS = frozenset(
+    {
+        "$id",
+        "$schema",
+        "additionalProperties",
+        "description",
+        "enum",
+        "items",
+        "properties",
+        "required",
+        "title",
+        "type",
+    },
+)
+
 
 @dataclass(frozen=True)
 class PreparedStructuredOutput:
@@ -96,6 +114,158 @@ def normalize_local_references(schema: dict, *, provider: str) -> dict:
     if not isinstance(normalized, dict):
         raise _reference_error(provider, "#", "must resolve to an object schema")
     return normalized
+
+
+def validate_core_portable_schema(schema: dict, *, provider: str) -> dict:
+    """Validate the schema profile shared by the built-in organizations.
+
+    The Core profile is intentionally narrower than JSON Schema: it is the
+    documented intersection used by OpenAI, Anthropic, and Google.  It never
+    rewrites semantic constraints.  A caller must make strict-object and
+    required-field intent explicit rather than relying on a provider-specific
+    repair step.
+    """
+    portable_schema = deepcopy(schema)
+    _validate_core_schema_node(
+        portable_schema,
+        provider=provider,
+        path="#",
+        is_root=True,
+    )
+    return portable_schema
+
+
+def _validate_core_schema_node(
+    node: Any,
+    *,
+    provider: str,
+    path: str,
+    is_root: bool = False,
+) -> None:
+    if not isinstance(node, dict):
+        raise _core_profile_error(provider, path, "must be an object schema")
+
+    unsupported_keywords = set(node) - _PORTABLE_SCHEMA_KEYWORDS
+    if unsupported_keywords:
+        names = ", ".join(sorted(unsupported_keywords))
+        raise _core_profile_error(provider, path, f"does not support {names}")
+
+    schema_types = _portable_schema_types(node.get("type"), provider=provider, path=path)
+    if is_root and schema_types != {"object"}:
+        raise _core_profile_error(provider, path, "requires a root object schema")
+
+    if "enum" in node:
+        enum = node["enum"]
+        if not isinstance(enum, list) or not enum:
+            raise _core_profile_error(provider, _pointer_path(path, "enum"), "requires a non-empty array")
+
+    if "object" in schema_types:
+        _validate_core_object_schema(node, provider=provider, path=path)
+    elif any(key in node for key in ("properties", "required", "additionalProperties")):
+        raise _core_profile_error(
+            provider,
+            path,
+            "allows object keywords only on an object schema",
+        )
+
+    if "array" in schema_types:
+        items = node.get("items")
+        if not isinstance(items, dict):
+            raise _core_profile_error(
+                provider,
+                _pointer_path(path, "items"),
+                "requires one object item schema",
+            )
+        _validate_core_schema_node(
+            items,
+            provider=provider,
+            path=_pointer_path(path, "items"),
+        )
+    elif "items" in node:
+        raise _core_profile_error(
+            provider,
+            path,
+            "allows items only on an array schema",
+        )
+
+
+def _portable_schema_types(value: Any, *, provider: str, path: str) -> set[str]:
+    if isinstance(value, str):
+        schema_types = {value}
+    elif isinstance(value, list):
+        if len(value) != 2 or len(set(value)) != 2 or "null" not in value:
+            raise _core_profile_error(
+                provider,
+                _pointer_path(path, "type"),
+                "permits nullable fields only as [<type>, \"null\"]",
+            )
+        schema_types = set(value)
+    else:
+        raise _core_profile_error(
+            provider,
+            _pointer_path(path, "type"),
+            "requires an explicit type",
+        )
+
+    non_null_types = schema_types - {"null"}
+    if not non_null_types or not non_null_types <= _PORTABLE_SCHEMA_TYPES:
+        raise _core_profile_error(
+            provider,
+            _pointer_path(path, "type"),
+            "uses a type outside the Core portable profile",
+        )
+    return schema_types
+
+
+def _validate_core_object_schema(
+    node: dict[str, Any],
+    *,
+    provider: str,
+    path: str,
+) -> None:
+    if node.get("additionalProperties") is not False:
+        raise _core_profile_error(
+            provider,
+            _pointer_path(path, "additionalProperties"),
+            "requires additionalProperties to be false",
+        )
+
+    properties = node.get("properties")
+    if properties is None:
+        if "required" in node:
+            raise _core_profile_error(
+                provider,
+                _pointer_path(path, "required"),
+                "requires properties when required is present",
+            )
+        return
+    if not isinstance(properties, dict):
+        raise _core_profile_error(
+            provider,
+            _pointer_path(path, "properties"),
+            "must be an object",
+        )
+
+    required = node.get("required")
+    if not isinstance(required, list) or not all(isinstance(name, str) for name in required):
+        raise _core_profile_error(
+            provider,
+            _pointer_path(path, "required"),
+            "must list every property name",
+        )
+    if len(set(required)) != len(required) or set(required) != set(properties):
+        raise _core_profile_error(
+            provider,
+            _pointer_path(path, "required"),
+            "must contain every property exactly once",
+        )
+
+    for name, property_schema in properties.items():
+        _validate_core_schema_node(
+            property_schema,
+            provider=provider,
+            path=_pointer_path(_pointer_path(path, "properties"), name),
+        )
 
 
 def _schema_from_response_model(response_model: Any) -> dict:
@@ -261,4 +431,18 @@ def _reference_error(provider: str, path: str, detail: str) -> JSONSchemaError:
     )
 
 
-__all__ = ["PreparedStructuredOutput", "normalize_local_references", "prepare_structured_output"]
+def _core_profile_error(provider: str, path: str, detail: str) -> JSONSchemaError:
+    return JSONSchemaError(
+        detail=(
+            f"{provider} structured-output schema at {path}: "
+            f"Core portable profile {detail}"
+        ),
+    )
+
+
+__all__ = [
+    "PreparedStructuredOutput",
+    "normalize_local_references",
+    "prepare_structured_output",
+    "validate_core_portable_schema",
+]

--- a/src/llm_api_adapter/models/responses/chat_response.py
+++ b/src/llm_api_adapter/models/responses/chat_response.py
@@ -19,6 +19,7 @@ class Usage:
 class _ParsedResponsesOutput:
     text_parts: List[str] = field(default_factory=list)
     tool_calls: Optional[List[ToolCall]] = None
+    refusal: Optional[str] = None
     reasoning_events: List[ReasoningEvent] = field(default_factory=list)
 
 
@@ -34,6 +35,8 @@ class _ParsedGoogleContent:
     text: Optional[str] = None
     tool_calls: Optional[List[ToolCall]] = None
     finish_reason: Optional[str] = None
+    refusal: Optional[str] = None
+    incomplete_reason: Optional[str] = None
     reasoning_events: List[ReasoningEvent] = field(default_factory=list)
 
 
@@ -50,6 +53,8 @@ class ChatResponse:
     content: Optional[str] = None
     tool_calls: Optional[List[ToolCall]] = None
     finish_reason: Optional[str] = None
+    refusal: Optional[str] = None
+    incomplete_reason: Optional[str] = None
     parsed_json: Optional[dict] = None
     parsed_model: Optional[Any] = None
     reasoning_events: List[ReasoningEvent] = field(default_factory=list)
@@ -69,6 +74,11 @@ class ChatResponse:
         choice0 = (api_response.get("choices") or [None])[0] or {}
         message = choice0.get("message") or {}
         text = message.get("content")
+        finish_reason = cls._optional_string(choice0.get("finish_reason"))
+        refusal = cls._optional_string(message.get("refusal"))
+        if refusal is None and finish_reason == "content_filter":
+            refusal = finish_reason
+        incomplete_reason = finish_reason if finish_reason == "length" else None
         parsed_tool_calls: Optional[List[ToolCall]] = None
         raw_tool_calls = message.get("tool_calls")
         if isinstance(raw_tool_calls, list) and raw_tool_calls:
@@ -115,7 +125,7 @@ class ChatResponse:
                 )
             parsed_tool_calls = [ToolCall(name=name, arguments=arguments, call_id=None)]
 
-        if not parsed_tool_calls:
+        if not parsed_tool_calls and refusal is None:
             if not text or not str(text).strip():
                 warnings.warn(
                     "OpenAI returned empty content. "
@@ -130,7 +140,9 @@ class ChatResponse:
             usage=usage,
             content=text,
             tool_calls=parsed_tool_calls,
-            finish_reason=choice0.get("finish_reason"),
+            finish_reason=finish_reason,
+            refusal=refusal,
+            incomplete_reason=incomplete_reason,
         )
 
     @classmethod
@@ -155,9 +167,12 @@ class ChatResponse:
             capture_reasoning=capture_reasoning,
         )
         text = "\n".join(parsed_output.text_parts) if parsed_output.text_parts else None
+        incomplete_reason = cls._responses_incomplete_reason(api_response)
         if (
             not parsed_output.tool_calls
             and not parsed_output.reasoning_events
+            and parsed_output.refusal is None
+            and incomplete_reason is None
             and (not text or not text.strip())
         ):
             warnings.warn(
@@ -172,6 +187,8 @@ class ChatResponse:
             content=text,
             tool_calls=parsed_output.tool_calls,
             finish_reason=api_response.get("status"),
+            refusal=parsed_output.refusal,
+            incomplete_reason=incomplete_reason,
             reasoning_events=parsed_output.reasoning_events,
         )
 
@@ -191,7 +208,7 @@ class ChatResponse:
                 continue
             item_type = item.get("type")
             if item_type == "message":
-                cls._append_responses_message_text(item, parsed_output.text_parts)
+                cls._append_responses_message_content(item, parsed_output)
             elif item_type == "reasoning" and capture_reasoning:
                 cls._append_responses_reasoning_events(
                     item,
@@ -204,9 +221,9 @@ class ChatResponse:
         return parsed_output
 
     @staticmethod
-    def _append_responses_message_text(
+    def _append_responses_message_content(
         item: dict,
-        text_parts: List[str],
+        parsed_output: _ParsedResponsesOutput,
     ) -> None:
         content_items = item.get("content") or []
         if not isinstance(content_items, list):
@@ -215,11 +232,29 @@ class ChatResponse:
             if not isinstance(content_item, dict):
                 continue
             content_type = content_item.get("type")
-            if content_type not in ("output_text", "text"):
-                continue
-            text_value = content_item.get("text")
-            if isinstance(text_value, str) and text_value.strip():
-                text_parts.append(text_value)
+            if content_type in ("output_text", "text"):
+                text_value = content_item.get("text")
+                if isinstance(text_value, str) and text_value.strip():
+                    parsed_output.text_parts.append(text_value)
+            elif content_type == "refusal" and parsed_output.refusal is None:
+                parsed_output.refusal = ChatResponse._optional_string(
+                    content_item.get("refusal"),
+                )
+
+    @staticmethod
+    def _optional_string(value: Any) -> Optional[str]:
+        return value if isinstance(value, str) and value else None
+
+    @classmethod
+    def _responses_incomplete_reason(cls, api_response: dict) -> Optional[str]:
+        if api_response.get("status") != "incomplete":
+            return None
+        details = api_response.get("incomplete_details")
+        if isinstance(details, dict):
+            reason = cls._optional_string(details.get("reason"))
+            if reason is not None:
+                return reason
+        return "incomplete"
 
     @staticmethod
     def _append_responses_reasoning_events(
@@ -309,15 +344,41 @@ class ChatResponse:
             api_response.get("content", []) or [],
             capture_reasoning=capture_reasoning,
         )
+        finish_reason = cls._optional_string(api_response.get("stop_reason"))
         return cls(
             model=api_response.get("model"),
             response_id=api_response.get("id"),
             usage=usage,
             content=parsed_content.text,
             tool_calls=parsed_content.tool_calls,
-            finish_reason=api_response.get("stop_reason"),
+            finish_reason=finish_reason,
+            refusal=cls._anthropic_refusal(api_response, finish_reason),
+            incomplete_reason=(
+                finish_reason
+                if finish_reason in {
+                    "max_tokens",
+                    "model_context_window_exceeded",
+                }
+                else None
+            ),
             reasoning_events=parsed_content.reasoning_events,
         )
+
+    @classmethod
+    def _anthropic_refusal(
+        cls,
+        api_response: dict,
+        finish_reason: Optional[str],
+    ) -> Optional[str]:
+        if finish_reason != "refusal":
+            return None
+        stop_details = api_response.get("stop_details")
+        if isinstance(stop_details, dict):
+            for field in ("reason", "category", "explanation"):
+                value = cls._optional_string(stop_details.get(field))
+                if value is not None:
+                    return value
+        return finish_reason
 
     @classmethod
     def _parse_anthropic_content_blocks(
@@ -391,6 +452,7 @@ class ChatResponse:
         usage = cls._parse_google_usage(api_response)
         first_candidate = (api_response.get("candidates") or [None])[0] or {}
         parsed_content = cls._parse_google_content(
+            api_response,
             first_candidate,
             capture_reasoning=capture_reasoning,
         )
@@ -400,6 +462,8 @@ class ChatResponse:
             content=parsed_content.text,
             tool_calls=parsed_content.tool_calls,
             finish_reason=parsed_content.finish_reason,
+            refusal=parsed_content.refusal,
+            incomplete_reason=parsed_content.incomplete_reason,
             reasoning_events=parsed_content.reasoning_events,
         )
 
@@ -418,15 +482,23 @@ class ChatResponse:
     @classmethod
     def _parse_google_content(
         cls,
+        api_response: dict,
         candidate: dict,
         *,
         capture_reasoning: bool,
     ) -> _ParsedGoogleContent:
         finish_reason = candidate.get("finishReason")
+        normalized_finish_reason = (
+            str(finish_reason) if finish_reason is not None else None
+        )
         parsed_content = _ParsedGoogleContent(
-            finish_reason=(
-                str(finish_reason) if finish_reason is not None else None
-            )
+            finish_reason=normalized_finish_reason,
+            refusal=cls._google_refusal(api_response, candidate, normalized_finish_reason),
+            incomplete_reason=(
+                normalized_finish_reason
+                if normalized_finish_reason in {"MAX_TOKENS", "length"}
+                else None
+            ),
         )
         content_obj = candidate.get("content") or {}
         parts = content_obj.get("parts") or []
@@ -442,6 +514,30 @@ class ChatResponse:
                 capture_reasoning=capture_reasoning,
             )
         return parsed_content
+
+    @classmethod
+    def _google_refusal(
+        cls,
+        api_response: dict,
+        candidate: dict,
+        finish_reason: Optional[str],
+    ) -> Optional[str]:
+        if finish_reason in {
+            "SAFETY",
+            "RECITATION",
+            "BLOCKLIST",
+            "PROHIBITED_CONTENT",
+            "SPII",
+            "IMAGE_SAFETY",
+            "IMAGE_PROHIBITED_CONTENT",
+            "IMAGE_RECITATION",
+            "ESCALATION",
+        }:
+            return cls._optional_string(candidate.get("finishMessage")) or finish_reason
+        prompt_feedback = api_response.get("promptFeedback")
+        if isinstance(prompt_feedback, dict):
+            return cls._optional_string(prompt_feedback.get("blockReason"))
+        return None
 
     @classmethod
     def _parse_google_part(

--- a/tests/e2e/test_json_schema.py
+++ b/tests/e2e/test_json_schema.py
@@ -1,52 +1,59 @@
+"""Live structured-output smoke test for every registered model."""
+
 import pytest
 
-from llm_api_adapter.errors import JSONSchemaError
 from llm_api_adapter.models.messages.chat_message import UserMessage
 from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
 
 
-SIMPLE_SCHEMA = {
+_EXPECTED_JSON = {"contact": {"name": "Ada"}}
+_PORTABLE_NESTED_OBJECT_SCHEMA = {
     "type": "object",
     "properties": {
-        "name": {"type": "string"},
-        "age": {"type": "integer"},
+        "contact": {
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "required": ["name"],
+            "additionalProperties": False,
+        },
     },
-    "required": ["name", "age"],
+    "required": ["contact"],
+    "additionalProperties": False,
 }
 
 
 @pytest.mark.e2e
-def test_json_schema_returns_parsed_json_for_all_organizations(subtests, iter_organization_models, chat_with_retry):
-    for p, model in iter_organization_models():
-        with subtests.test(provider=p["name"], model=model):
+def test_json_schema_returns_structured_output_for_every_configured_model(
+    subtests,
+    iter_organization_models,
+    chat_with_retry,
+):
+    """Make one portable structured-output request for every configured model."""
+    configured_models = 0
+    for organization, model in iter_organization_models():
+        if not organization["api_key"]:
+            continue
+        configured_models += 1
+
+        with subtests.test(organization=organization["name"], model=model):
             adapter = UniversalLLMAPIAdapter(
-                organization=p["name"],
+                organization=organization["name"],
                 model=model,
-                api_key=p["api_key"],
+                api_key=organization["api_key"],
+            )
+            response = chat_with_retry(
+                adapter,
+                messages=[
+                    UserMessage('Return exactly {"contact":{"name":"Ada"}}.')
+                ],
+                max_tokens=512,
+                json_schema=_PORTABLE_NESTED_OBJECT_SCHEMA,
+                timeout_s=60,
             )
 
-            try:
-                resp = chat_with_retry(
-                    adapter,
-                    messages=[
-                        UserMessage(
-                            'Return a JSON object with fields "name" (string) '
-                            'and "age" (integer). Use name="Alice" and age=30.'
-                        )
-                    ],
-                    max_tokens=500,
-                    json_schema=SIMPLE_SCHEMA,
-                    timeout_s=60,
-                )
-            except JSONSchemaError as e:
-                pytest.skip(f"Model returned non-JSON despite json_schema mode: {e}")
+            assert response.refusal is None
+            assert response.incomplete_reason is None
+            assert response.parsed_json == _EXPECTED_JSON
 
-            if resp.content is None:
-                pytest.skip("Model returned no content — likely exhausted token budget in reasoning")
-
-            assert resp.parsed_json is not None
-            assert isinstance(resp.parsed_json, dict)
-            assert "name" in resp.parsed_json
-            assert "age" in resp.parsed_json
-            assert isinstance(resp.parsed_json["name"], str)
-            assert isinstance(resp.parsed_json["age"], int)
+    if not configured_models:
+        pytest.skip("No provider API keys are configured")

--- a/tests/e2e/test_sync_httpx.py
+++ b/tests/e2e/test_sync_httpx.py
@@ -1,4 +1,4 @@
-"""Bounded live verification for the opt-in synchronous HTTPX transport."""
+"""Bounded HTTPX sync and async contract checks for every provider."""
 
 import pytest
 
@@ -9,44 +9,81 @@ from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
 pytest.importorskip("httpx")
 
 
+def _assert_usage_and_pricing(response):
+    assert isinstance(response.content, str)
+    assert response.content.strip()
+    assert isinstance(response.finish_reason, str)
+    assert response.usage is not None
+    assert response.usage.input_tokens >= 0
+    assert response.usage.output_tokens >= 0
+    assert response.usage.total_tokens >= response.usage.input_tokens
+    assert response.currency
+    assert response.cost_total is not None and response.cost_total >= 0
+    if response.cost_input is None or response.cost_output is None:
+        assert response.cost_input is response.cost_output is None
+    else:
+        assert response.cost_input >= 0
+        assert response.cost_output >= 0
+
+
+def _adapter(organization, model: str, *, transport: str) -> UniversalLLMAPIAdapter:
+    return UniversalLLMAPIAdapter(
+        organization=organization["name"],
+        model=model,
+        api_key=organization["api_key"],
+        transport=transport,
+    )
+
+
+def _chat_kwargs():
+    return {
+        "messages": [UserMessage("Reply with exactly: OK")],
+        # Gemini 3.x may spend part of this shared output budget on default
+        # thinking before returning visible text.
+        "max_tokens": 512,
+        "timeout_s": 60,
+    }
+
+
 @pytest.mark.e2e
 def test_sync_httpx_chat_returns_contract_for_latest_provider_models(
     subtests,
     configured_sync_httpx_e2e_models,
     chat_with_retry,
 ):
-    """Make one paid HTTPX sync request for each configured provider."""
+    """Make one HTTPX-backed sync request for each configured provider."""
     if not configured_sync_httpx_e2e_models:
         pytest.skip("No provider API keys are configured")
 
-    for provider, model in configured_sync_httpx_e2e_models:
-        with subtests.test(provider=provider["name"], model=model):
-            adapter = UniversalLLMAPIAdapter(
-                organization=provider["name"],
-                model=model,
-                api_key=provider["api_key"],
-                transport="httpx",
-            )
+    for organization, model in configured_sync_httpx_e2e_models:
+        with subtests.test(organization=organization["name"], model=model):
             response = chat_with_retry(
-                adapter,
-                messages=[UserMessage("Reply with exactly: OK")],
-                # Gemini 3.x may spend part of this shared output budget on
-                # default thinking before returning visible text.
-                max_tokens=512,
-                timeout_s=60,
+                _adapter(organization, model, transport="httpx"),
+                **_chat_kwargs(),
             )
+            _assert_usage_and_pricing(response)
 
-            assert isinstance(response.content, str)
-            assert response.content.strip()
-            assert isinstance(response.finish_reason, str)
-            assert response.usage is not None
-            assert response.usage.input_tokens >= 0
-            assert response.usage.output_tokens >= 0
-            assert response.usage.total_tokens >= response.usage.input_tokens
-            assert response.currency
-            assert response.cost_total is not None and response.cost_total >= 0
-            if response.cost_input is None or response.cost_output is None:
-                assert response.cost_input is response.cost_output is None
-            else:
-                assert response.cost_input >= 0
-                assert response.cost_output >= 0
+
+@pytest.mark.asyncio
+@pytest.mark.e2e
+async def test_async_httpx_chat_returns_contract_for_latest_provider_models(
+    subtests,
+    configured_sync_httpx_e2e_models,
+    async_chat_with_retry,
+):
+    """Make one async HTTPX request for each configured provider.
+
+    ``achat()`` always uses the shared asynchronous HTTPX transport.  Passing
+    ``transport='httpx'`` also verifies that the opt-in sync transport setting
+    remains compatible with an async facade instance.
+    """
+    if not configured_sync_httpx_e2e_models:
+        pytest.skip("No provider API keys are configured")
+
+    for organization, model in configured_sync_httpx_e2e_models:
+        with subtests.test(organization=organization["name"], model=model):
+            response = await async_chat_with_retry(
+                _adapter(organization, model, transport="httpx"),
+                **_chat_kwargs(),
+            )
+            _assert_usage_and_pricing(response)

--- a/tests/fixtures/structured_output.py
+++ b/tests/fixtures/structured_output.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Final
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 FLAT_OBJECT_SCHEMA: Final = {
@@ -61,10 +61,14 @@ INLINE_NESTED_OBJECT_SCHEMA: Final = {
 
 
 class PortableContact(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     name: str
 
 
 class NestedPydanticResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     contact: PortableContact
 
 

--- a/tests/fixtures/structured_output.py
+++ b/tests/fixtures/structured_output.py
@@ -1,0 +1,98 @@
+"""Provider-neutral structured-output fixtures for deterministic tests.
+
+The fixtures describe the v0.9.2 portable-profile acceptance vocabulary.  They
+intentionally contain no provider payload shapes, so core and organization
+package suites can use the same inputs and expected terminal outcomes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from pydantic import BaseModel
+
+
+FLAT_OBJECT_SCHEMA: Final = {
+    "type": "object",
+    "properties": {"answer": {"type": "string"}},
+    "required": ["answer"],
+    "additionalProperties": False,
+}
+
+NULLABLE_REQUIRED_FIELD_SCHEMA: Final = {
+    "type": "object",
+    "properties": {"nickname": {"type": ["string", "null"]}},
+    "required": ["nickname"],
+    "additionalProperties": False,
+}
+
+ENUM_SCHEMA: Final = {
+    "type": "object",
+    "properties": {
+        "priority": {"type": "string", "enum": ["low", "medium", "high"]},
+    },
+    "required": ["priority"],
+    "additionalProperties": False,
+}
+
+ARRAY_SCHEMA: Final = {
+    "type": "object",
+    "properties": {
+        "tags": {"type": "array", "items": {"type": "string"}},
+    },
+    "required": ["tags"],
+    "additionalProperties": False,
+}
+
+INLINE_NESTED_OBJECT_SCHEMA: Final = {
+    "type": "object",
+    "properties": {
+        "contact": {
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "required": ["name"],
+            "additionalProperties": False,
+        },
+    },
+    "required": ["contact"],
+    "additionalProperties": False,
+}
+
+
+class PortableContact(BaseModel):
+    name: str
+
+
+class NestedPydanticResponse(BaseModel):
+    contact: PortableContact
+
+
+NESTED_PYDANTIC_RESPONSE_JSON: Final = '{"contact": {"name": "Ada"}}'
+INVALID_JSON_CONTENT: Final = '{"contact": '
+
+
+@dataclass(frozen=True)
+class StructuredOutputOutcomeFixture:
+    """Named terminal outcome used by the portable-profile conformance suite."""
+
+    name: str
+    content: str | None
+
+
+STRUCTURED_OUTPUT_OUTCOMES: Final = (
+    StructuredOutputOutcomeFixture("valid_structured_result", '{"answer": "ok"}'),
+    StructuredOutputOutcomeFixture("refusal", None),
+    StructuredOutputOutcomeFixture("incomplete_result", None),
+    StructuredOutputOutcomeFixture("invalid_json", INVALID_JSON_CONTENT),
+    StructuredOutputOutcomeFixture("pydantic_validation_error", '{"contact": {}}'),
+    StructuredOutputOutcomeFixture("unsupported_schema", None),
+)
+
+PORTABLE_PROFILE_SCHEMAS: Final = {
+    "flat_object": FLAT_OBJECT_SCHEMA,
+    "nullable_required_field": NULLABLE_REQUIRED_FIELD_SCHEMA,
+    "enum": ENUM_SCHEMA,
+    "array": ARRAY_SCHEMA,
+    "inline_nested_object": INLINE_NESTED_OBJECT_SCHEMA,
+}

--- a/tests/integration/test_json_schema.py
+++ b/tests/integration/test_json_schema.py
@@ -249,11 +249,12 @@ def test_google_sends_response_mime_type_and_schema(google_json_mock):
     payload = google_json_mock.request_history[0].json()
     gen_cfg = payload["generationConfig"]
     assert gen_cfg["responseMimeType"] == "application/json"
-    assert "responseSchema" in gen_cfg
-    assert gen_cfg["responseSchema"]["type"] == "OBJECT"
-    assert "name" in gen_cfg["responseSchema"]["properties"]
-    assert "age" in gen_cfg["responseSchema"]["properties"]
-    assert gen_cfg["responseSchema"]["additionalProperties"] is False
+    assert "responseSchema" not in gen_cfg
+    assert "responseJsonSchema" in gen_cfg
+    assert gen_cfg["responseJsonSchema"]["type"] == "object"
+    assert "name" in gen_cfg["responseJsonSchema"]["properties"]
+    assert "age" in gen_cfg["responseJsonSchema"]["properties"]
+    assert gen_cfg["responseJsonSchema"]["additionalProperties"] is False
 
     assert resp.content == JSON_CONTENT
     assert resp.parsed_json == {"name": "Alice", "age": 30}
@@ -270,8 +271,8 @@ def test_google_sends_schema_and_returns_parsed_model_for_response_model(google_
     payload = google_json_mock.request_history[0].json()
     gen_cfg = payload["generationConfig"]
     assert gen_cfg["responseMimeType"] == "application/json"
-    assert "name" in gen_cfg["responseSchema"]["properties"]
-    assert "age" in gen_cfg["responseSchema"]["properties"]
+    assert "name" in gen_cfg["responseJsonSchema"]["properties"]
+    assert "age" in gen_cfg["responseJsonSchema"]["properties"]
 
     assert resp.parsed_json == {"name": "Alice", "age": 30}
     assert isinstance(resp.parsed_model, Person)

--- a/tests/integration/test_json_schema.py
+++ b/tests/integration/test_json_schema.py
@@ -1,6 +1,6 @@
 import pytest
 import requests_mock as requests_mock_module
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from src.llm_api_adapter.models.messages.chat_message import UserMessage
 from src.llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
@@ -15,10 +15,13 @@ SCHEMA = {
         "age": {"type": "integer"},
     },
     "required": ["name", "age"],
+    "additionalProperties": False,
 }
 
 
 class Person(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     name: str
     age: int
 
@@ -136,7 +139,7 @@ def test_openai_responses_api_sends_schema_and_returns_parsed_model(openai_respo
     payload = openai_responses_json_mock.request_history[0].json()
     fmt = payload["text"]["format"]
     assert fmt["type"] == "json_schema"
-    assert fmt["schema"] == {**Person.model_json_schema(), "additionalProperties": False}
+    assert fmt["schema"] == Person.model_json_schema()
 
     assert resp.parsed_json == {"name": "Alice", "age": 30}
     assert isinstance(resp.parsed_model, Person)
@@ -179,7 +182,7 @@ def test_openai_legacy_api_sends_schema_and_returns_parsed_model(openai_legacy_j
 
     payload = openai_legacy_json_mock.request_history[0].json()
     js = payload["response_format"]["json_schema"]
-    assert js["schema"] == {**Person.model_json_schema(), "additionalProperties": False}
+    assert js["schema"] == Person.model_json_schema()
 
     assert resp.parsed_json == {"name": "Alice", "age": 30}
     assert isinstance(resp.parsed_model, Person)
@@ -250,7 +253,7 @@ def test_google_sends_response_mime_type_and_schema(google_json_mock):
     assert gen_cfg["responseSchema"]["type"] == "OBJECT"
     assert "name" in gen_cfg["responseSchema"]["properties"]
     assert "age" in gen_cfg["responseSchema"]["properties"]
-    assert "additionalProperties" not in gen_cfg["responseSchema"]
+    assert gen_cfg["responseSchema"]["additionalProperties"] is False
 
     assert resp.content == JSON_CONTENT
     assert resp.parsed_json == {"name": "Alice", "age": 30}

--- a/tests/integration/test_streaming.py
+++ b/tests/integration/test_streaming.py
@@ -6,7 +6,7 @@ import pytest
 import respx
 import requests
 import requests_mock
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from src.llm_api_adapter.errors.llm_api_error import (
     JSONSchemaError,
@@ -34,10 +34,13 @@ STRUCTURED_SCHEMA = {
     "type": "object",
     "properties": {"answer": {"type": "string"}},
     "required": ["answer"],
+    "additionalProperties": False,
 }
 
 
 class StreamAnswer(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     answer: str
 
 

--- a/tests/unit/adapters/test_anthropic_adapter.py
+++ b/tests/unit/adapters/test_anthropic_adapter.py
@@ -155,7 +155,12 @@ def test_chat_skips_validation_for_adaptive_thinking_model(adapter):
 
 @pytest.mark.unit
 def test_chat_passes_output_config_when_json_schema_provided(adapter):
-    schema = {"type": "object", "properties": {"name": {"type": "string"}}}
+    schema = {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+        "required": ["name"],
+        "additionalProperties": False,
+    }
     fake_response = {"some": "anthropic response"}
     fake_chat_response = ChatResponse(content='{"name": "test"}')
 

--- a/tests/unit/adapters/test_async_parity.py
+++ b/tests/unit/adapters/test_async_parity.py
@@ -27,6 +27,7 @@ RESPONSE_SCHEMA = {
     "type": "object",
     "properties": {"answer": {"type": "string"}},
     "required": ["answer"],
+    "additionalProperties": False,
 }
 
 LOOKUP_TOOL = ToolSpec(

--- a/tests/unit/adapters/test_base_adapter.py
+++ b/tests/unit/adapters/test_base_adapter.py
@@ -27,6 +27,7 @@ from src.llm_api_adapter.llms.streaming import (
     StreamReasoningCollector,
 )
 from src.llm_api_adapter.models.tools import ToolCall, ToolSpec
+from tests.fixtures.structured_output import NestedPydanticResponse
 
 
 class DummyClient:
@@ -748,6 +749,22 @@ def test_resolve_json_schema_dict_returns_dict(adapter):
 def test_resolve_json_schema_response_model_returns_schema(adapter):
     result = adapter._resolve_json_schema(None, _Person, None)
     assert result == _Person.model_json_schema()
+
+
+@pytest.mark.unit
+def test_prepare_chat_request_keeps_source_model_and_provider_schema_separate(adapter):
+    context = adapter._prepare_chat_request(
+        [UserMessage("hi")],
+        None,
+        None,
+        None,
+        NestedPydanticResponse,
+    )
+
+    assert context.response_model is NestedPydanticResponse
+    assert "$defs" in context.source_schema
+    assert "$defs" not in context.effective_schema
+    assert context.effective_schema["properties"]["contact"]["type"] == "object"
 
 
 @pytest.mark.unit

--- a/tests/unit/adapters/test_google_adapter.py
+++ b/tests/unit/adapters/test_google_adapter.py
@@ -182,7 +182,8 @@ def test_chat_passes_json_schema_in_generation_config(adapter):
     kwargs = mock_client.call_args[1]
     gen_cfg = kwargs["generationConfig"]
     assert gen_cfg["responseMimeType"] == "application/json"
-    assert "responseSchema" in gen_cfg
+    assert "responseSchema" not in gen_cfg
+    assert "responseJsonSchema" in gen_cfg
     assert result.parsed_json == {"name": "test"}
 
 
@@ -198,8 +199,8 @@ def test_to_google_schema_preserves_semantics_and_removes_metadata(adapter):
     result = adapter._to_google_schema(schema)
     assert result["additionalProperties"] is False
     assert "$schema" not in result
-    assert result["type"] == "OBJECT"
-    assert result["properties"]["name"]["type"] == "STRING"
+    assert result["type"] == "object"
+    assert result["properties"]["name"]["type"] == "string"
 
 
 @pytest.mark.unit
@@ -217,6 +218,7 @@ def test_chat_omits_json_schema_fields_when_not_provided(adapter):
     gen_cfg = kwargs["generationConfig"]
     assert "responseMimeType" not in gen_cfg
     assert "responseSchema" not in gen_cfg
+    assert "responseJsonSchema" not in gen_cfg
 
 
 @pytest.mark.unit

--- a/tests/unit/adapters/test_google_adapter.py
+++ b/tests/unit/adapters/test_google_adapter.py
@@ -164,7 +164,12 @@ def test_chat_captures_google_thought_summaries_when_opted_in(adapter):
 
 @pytest.mark.unit
 def test_chat_passes_json_schema_in_generation_config(adapter):
-    schema = {"type": "object", "properties": {"name": {"type": "string"}}}
+    schema = {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+        "required": ["name"],
+        "additionalProperties": False,
+    }
     fake_response = {"some": "google response"}
     fake_chat_response = ChatResponse(content='{"name": "test"}')
 
@@ -182,15 +187,16 @@ def test_chat_passes_json_schema_in_generation_config(adapter):
 
 
 @pytest.mark.unit
-def test_to_google_schema_strips_unsupported_fields(adapter):
+def test_to_google_schema_preserves_semantics_and_removes_metadata(adapter):
     schema = {
         "type": "object",
         "properties": {"name": {"type": "string"}},
+        "required": ["name"],
         "additionalProperties": False,
         "$schema": "http://json-schema.org/draft-07/schema#",
     }
     result = adapter._to_google_schema(schema)
-    assert "additionalProperties" not in result
+    assert result["additionalProperties"] is False
     assert "$schema" not in result
     assert result["type"] == "OBJECT"
     assert result["properties"]["name"]["type"] == "STRING"

--- a/tests/unit/adapters/test_openai_adapter.py
+++ b/tests/unit/adapters/test_openai_adapter.py
@@ -553,7 +553,12 @@ def test_map_tool_choice_to_openai_responses_passthrough_non_string(adapter):
 
 @pytest.mark.unit
 def test_chat_responses_api_passes_json_schema_in_text_param(adapter):
-    schema = {"type": "object", "properties": {"name": {"type": "string"}}}
+    schema = {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+        "required": ["name"],
+        "additionalProperties": False,
+    }
     fake_response = {"id": "resp_123"}
     fake_chat_response = ChatResponse(content='{"name": "test"}')
 
@@ -578,7 +583,12 @@ def test_chat_responses_api_passes_json_schema_in_text_param(adapter):
 
 @pytest.mark.unit
 def test_chat_legacy_api_passes_json_schema_in_response_format(legacy_adapter):
-    schema = {"type": "object", "properties": {"name": {"type": "string"}}}
+    schema = {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+        "required": ["name"],
+        "additionalProperties": False,
+    }
     fake_response = {"id": "chatcmpl_123"}
     fake_chat_response = ChatResponse(content='{"name": "test"}')
 

--- a/tests/unit/conformance/test_facade_contract.py
+++ b/tests/unit/conformance/test_facade_contract.py
@@ -27,6 +27,13 @@ from src.llm_api_adapter.models.messages.file_parts import ImagePart
 from src.llm_api_adapter.models.responses.chat_response import Usage
 from src.llm_api_adapter.models.tools import ToolSpec
 from src.llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
+from tests.fixtures.structured_output import (
+    FLAT_OBJECT_SCHEMA,
+    NESTED_PYDANTIC_RESPONSE_JSON,
+    NestedPydanticResponse,
+    PORTABLE_PROFILE_SCHEMAS,
+    STRUCTURED_OUTPUT_OUTCOMES,
+)
 
 
 @dataclass(frozen=True)
@@ -290,6 +297,28 @@ def _chat_kwargs(case: OrganizationConformanceCase) -> dict[str, Any]:
     }
 
 
+def _structured_schema_from_payload(
+    case: OrganizationConformanceCase,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    """Return the effective schema from each built-in organization's payload."""
+    if case.organization == "openai":
+        return payload["text"]["format"]["schema"]
+    if case.organization == "anthropic":
+        return payload["output_config"]["format"]["schema"]
+    if case.organization == "google":
+        return payload["generationConfig"]["responseSchema"]
+    raise AssertionError(f"No structured-output payload path for {case.organization!r}")
+
+
+def _contains_reference(node: Any) -> bool:
+    if isinstance(node, dict):
+        return "$ref" in node or any(_contains_reference(value) for value in node.values())
+    if isinstance(node, list):
+        return any(_contains_reference(value) for value in node)
+    return False
+
+
 async def _as_async_iter(events: list[SSEEvent]) -> AsyncIterator[SSEEvent]:
     for event in events:
         yield event
@@ -372,6 +401,76 @@ def test_facade_preserves_tool_structured_output_file_and_reasoning_contracts(ca
         )
 
     assert [event.text for event in reasoning_response.reasoning_events] == ["Plan"]
+
+
+@pytest.mark.unit
+def test_portable_profile_fixture_covers_the_v092_acceptance_vocabulary():
+    assert set(PORTABLE_PROFILE_SCHEMAS) == {
+        "flat_object",
+        "nullable_required_field",
+        "enum",
+        "array",
+        "inline_nested_object",
+    }
+    assert {fixture.name for fixture in STRUCTURED_OUTPUT_OUTCOMES} == {
+        "valid_structured_result",
+        "refusal",
+        "incomplete_result",
+        "invalid_json",
+        "pydantic_validation_error",
+        "unsupported_schema",
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("case", CASES)
+def test_facade_preserves_flat_portable_schema_baseline(case):
+    transport = Mock(
+        return_value=_JSONResponse(case.response_factory('{"answer": "ok"}')),
+    )
+
+    with patch.object(case.sync_client_class, "_send_request", new=transport):
+        response = _facade(case).chat(
+            **_chat_kwargs(case),
+            json_schema=FLAT_OBJECT_SCHEMA,
+        )
+
+    schema = _structured_schema_from_payload(case, transport.call_args.args[1])
+    assert response.parsed_json == {"answer": "ok"}
+    assert schema["properties"]["answer"]["type"] in {"string", "STRING"}
+    if case.organization == "google":
+        assert "additionalProperties" not in schema
+    else:
+        assert schema["additionalProperties"] is False
+
+
+@pytest.mark.unit
+@pytest.mark.xfail(
+    reason=(
+        "v0.9.2 will normalize local Pydantic $defs/$ref before provider "
+        "conversion; the current adapters still pass or discard references."
+    ),
+    strict=True,
+)
+@pytest.mark.parametrize("case", CASES)
+def test_nested_pydantic_schema_is_not_yet_portable_across_builtin_adapters(case):
+    transport = Mock(
+        return_value=_JSONResponse(case.response_factory(NESTED_PYDANTIC_RESPONSE_JSON)),
+    )
+
+    with patch.object(case.sync_client_class, "_send_request", new=transport):
+        response = _facade(case).chat(
+            **_chat_kwargs(case),
+            response_model=NestedPydanticResponse,
+        )
+
+    schema = _structured_schema_from_payload(case, transport.call_args.args[1])
+    assert response.parsed_model == NestedPydanticResponse(
+        contact={"name": "Ada"},
+    )
+    assert "$defs" not in schema
+    assert not _contains_reference(schema)
+    assert schema["properties"]["contact"]["type"] in {"object", "OBJECT"}
 
 
 @pytest.mark.unit

--- a/tests/unit/conformance/test_facade_contract.py
+++ b/tests/unit/conformance/test_facade_contract.py
@@ -7,12 +7,13 @@ contract without credentials or live API calls.
 
 from __future__ import annotations
 
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any, AsyncIterator, Callable
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from src.llm_api_adapter.errors.llm_api_error import (
     JSONSchemaError,
@@ -282,6 +283,8 @@ CASES = (
 
 
 class _StructuredAnswer(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     answer: str
 
 
@@ -320,6 +323,29 @@ def _contains_reference(node: Any) -> bool:
     if isinstance(node, list):
         return any(_contains_reference(value) for value in node)
     return False
+
+
+def _google_wire_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Apply only Google's type-value casing to a portable source schema."""
+    converted = deepcopy(schema)
+
+    def convert(node: Any) -> None:
+        if isinstance(node, list):
+            for item in node:
+                convert(item)
+            return
+        if not isinstance(node, dict):
+            return
+        schema_type = node.get("type")
+        if isinstance(schema_type, str):
+            node["type"] = schema_type.upper()
+        elif isinstance(schema_type, list):
+            node["type"] = [value.upper() for value in schema_type]
+        for value in node.values():
+            convert(value)
+
+    convert(converted)
+    return converted
 
 
 async def _as_async_iter(events: list[SSEEvent]) -> AsyncIterator[SSEEvent]:
@@ -441,10 +467,51 @@ def test_facade_preserves_flat_portable_schema_baseline(case):
     schema = _structured_schema_from_payload(case, transport.call_args.args[1])
     assert response.parsed_json == {"answer": "ok"}
     assert schema["properties"]["answer"]["type"] in {"string", "STRING"}
-    if case.organization == "google":
-        assert "additionalProperties" not in schema
-    else:
-        assert schema["additionalProperties"] is False
+    assert schema["additionalProperties"] is False
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("case", CASES)
+@pytest.mark.parametrize("fixture_name", sorted(PORTABLE_PROFILE_SCHEMAS))
+def test_core_portable_profile_has_exact_provider_payloads(case, fixture_name):
+    source_schema = PORTABLE_PROFILE_SCHEMAS[fixture_name]
+    transport = Mock(
+        return_value=_JSONResponse(case.response_factory('{"answer": "ok"}')),
+    )
+
+    with patch.object(case.sync_client_class, "_send_request", new=transport):
+        _facade(case).chat(
+            **_chat_kwargs(case),
+            json_schema=source_schema,
+        )
+
+    schema = _structured_schema_from_payload(case, transport.call_args.args[1])
+    expected = (
+        _google_wire_schema(source_schema)
+        if case.organization == "google"
+        else source_schema
+    )
+    assert schema == expected
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("case", CASES)
+def test_facade_rejects_nonportable_core_schema_before_sending_request(case):
+    transport = Mock()
+    schema = {
+        "type": "object",
+        "properties": {"answer": {"type": "string"}},
+        "required": [],
+        "additionalProperties": False,
+    }
+
+    with (
+        patch.object(case.sync_client_class, "_send_request", new=transport),
+        pytest.raises(JSONSchemaError, match=r"#/required"),
+    ):
+        _facade(case).chat(**_chat_kwargs(case), json_schema=schema)
+
+    transport.assert_not_called()
 
 
 @pytest.mark.unit

--- a/tests/unit/conformance/test_facade_contract.py
+++ b/tests/unit/conformance/test_facade_contract.py
@@ -14,7 +14,10 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 from pydantic import BaseModel
 
-from src.llm_api_adapter.errors.llm_api_error import LLMAPIRateLimitError
+from src.llm_api_adapter.errors.llm_api_error import (
+    JSONSchemaError,
+    LLMAPIRateLimitError,
+)
 from src.llm_api_adapter.llms.anthropic.async_client import ClaudeAsyncClient
 from src.llm_api_adapter.llms.anthropic.sync_client import ClaudeSyncClient
 from src.llm_api_adapter.llms.google.async_client import GeminiAsyncClient
@@ -445,15 +448,8 @@ def test_facade_preserves_flat_portable_schema_baseline(case):
 
 
 @pytest.mark.unit
-@pytest.mark.xfail(
-    reason=(
-        "v0.9.2 will normalize local Pydantic $defs/$ref before provider "
-        "conversion; the current adapters still pass or discard references."
-    ),
-    strict=True,
-)
 @pytest.mark.parametrize("case", CASES)
-def test_nested_pydantic_schema_is_not_yet_portable_across_builtin_adapters(case):
+def test_nested_pydantic_schema_is_portable_across_builtin_adapters(case):
     transport = Mock(
         return_value=_JSONResponse(case.response_factory(NESTED_PYDANTIC_RESPONSE_JSON)),
     )
@@ -471,6 +467,24 @@ def test_nested_pydantic_schema_is_not_yet_portable_across_builtin_adapters(case
     assert "$defs" not in schema
     assert not _contains_reference(schema)
     assert schema["properties"]["contact"]["type"] in {"object", "OBJECT"}
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("case", CASES)
+def test_facade_rejects_external_schema_references_before_sending_request(case):
+    transport = Mock()
+    schema = {
+        "type": "object",
+        "properties": {"contact": {"$ref": "https://example.com/contact.json"}},
+    }
+
+    with (
+        patch.object(case.sync_client_class, "_send_request", new=transport),
+        pytest.raises(JSONSchemaError, match=r"#?/properties/contact"),
+    ):
+        _facade(case).chat(**_chat_kwargs(case), json_schema=schema)
+
+    transport.assert_not_called()
 
 
 @pytest.mark.unit

--- a/tests/unit/conformance/test_facade_contract.py
+++ b/tests/unit/conformance/test_facade_contract.py
@@ -353,6 +353,301 @@ async def _as_async_iter(events: list[SSEEvent]) -> AsyncIterator[SSEEvent]:
         yield event
 
 
+_TERMINAL_OUTCOME_FIXTURES = tuple(
+    outcome
+    for outcome in STRUCTURED_OUTPUT_OUTCOMES
+    if outcome.name != "unsupported_schema"
+)
+
+
+def _terminal_outcome_response(
+    case: OrganizationConformanceCase,
+    outcome_name: str,
+    content: str | None,
+) -> dict[str, Any]:
+    """Return the native terminal shape for one structured-output outcome."""
+    if case.organization == "openai":
+        if outcome_name == "refusal":
+            return {
+                "id": "resp_refusal",
+                "model": case.model,
+                "status": "completed",
+                "output": [{
+                    "type": "message",
+                    "content": [{
+                        "type": "refusal",
+                        "refusal": "I can't help with that.",
+                    }],
+                }],
+            }
+        if outcome_name == "incomplete_result":
+            return {
+                "id": "resp_incomplete",
+                "model": case.model,
+                "status": "incomplete",
+                "incomplete_details": {"reason": "max_output_tokens"},
+                "output": [],
+            }
+        return _openai_response(content or "")
+
+    if case.organization == "anthropic":
+        if outcome_name == "refusal":
+            return {
+                "id": "msg_refusal",
+                "model": case.model,
+                "stop_reason": "refusal",
+                "stop_details": {"reason": "safety"},
+                "content": [],
+                "usage": {"input_tokens": 2, "output_tokens": 0},
+            }
+        if outcome_name == "incomplete_result":
+            return {
+                "id": "msg_incomplete",
+                "model": case.model,
+                "stop_reason": "max_tokens",
+                "content": [{"type": "text", "text": '{"answer": '}],
+                "usage": {"input_tokens": 2, "output_tokens": 3},
+            }
+        return _anthropic_response(content or "")
+
+    if case.organization == "google":
+        if outcome_name == "refusal":
+            return {
+                "modelVersion": case.model,
+                "candidates": [{
+                    "content": {"parts": []},
+                    "finishReason": "SAFETY",
+                    "finishMessage": "Blocked by safety policy.",
+                }],
+            }
+        if outcome_name == "incomplete_result":
+            return {
+                "modelVersion": case.model,
+                "candidates": [{
+                    "content": {"parts": [{"text": '{"answer": '}]},
+                    "finishReason": "MAX_TOKENS",
+                }],
+            }
+        return _google_response(content or "")
+
+    raise AssertionError(f"No terminal-outcome fixture for {case.organization!r}")
+
+
+def _terminal_outcome_stream_events(
+    case: OrganizationConformanceCase,
+    outcome_name: str,
+    content: str | None,
+) -> list[SSEEvent]:
+    response = _terminal_outcome_response(case, outcome_name, content)
+    if case.organization == "openai":
+        return [
+            SSEEvent(
+                event=(
+                    "response.incomplete"
+                    if response["status"] == "incomplete"
+                    else "response.completed"
+                ),
+                data={"response": response},
+            ),
+        ]
+
+    if case.organization == "anthropic":
+        events = [
+            SSEEvent(
+                event="message_start",
+                data={
+                    "message": {
+                        "id": response["id"],
+                        "model": response["model"],
+                        "content": [],
+                        "usage": {"input_tokens": 2, "output_tokens": 0},
+                    },
+                },
+            ),
+        ]
+        if response["content"]:
+            events.extend([
+                SSEEvent(
+                    event="content_block_start",
+                    data={
+                        "index": 0,
+                        "content_block": {"type": "text", "text": ""},
+                    },
+                ),
+                SSEEvent(
+                    event="content_block_delta",
+                    data={
+                        "index": 0,
+                        "delta": {
+                            "type": "text_delta",
+                            "text": response["content"][0]["text"],
+                        },
+                    },
+                ),
+                SSEEvent(event="content_block_stop", data={"index": 0}),
+            ])
+        delta: dict[str, Any] = {"stop_reason": response["stop_reason"]}
+        if "stop_details" in response:
+            delta["stop_details"] = response["stop_details"]
+        events.extend([
+            SSEEvent(
+                event="message_delta",
+                data={"delta": delta, "usage": {"output_tokens": 3}},
+            ),
+            SSEEvent(event="message_stop", data={}),
+        ])
+        return events
+
+    if case.organization == "google":
+        return [SSEEvent(event=None, data=response)]
+
+    raise AssertionError(f"No terminal stream fixture for {case.organization!r}")
+
+
+def _structured_outcome_kwargs(
+    case: OrganizationConformanceCase,
+    outcome_name: str,
+) -> dict[str, Any]:
+    kwargs = _chat_kwargs(case)
+    if outcome_name == "pydantic_validation_error":
+        kwargs["response_model"] = NestedPydanticResponse
+    elif outcome_name in {"refusal", "incomplete_result"}:
+        kwargs["response_model"] = _StructuredAnswer
+    else:
+        kwargs["json_schema"] = FLAT_OBJECT_SCHEMA
+    return kwargs
+
+
+def _assert_structured_terminal_outcome(
+    response: Any,
+    case: OrganizationConformanceCase,
+    outcome_name: str,
+) -> None:
+    if outcome_name == "valid_structured_result":
+        assert response.parsed_json == {"answer": "ok"}
+        return
+    if outcome_name == "refusal":
+        expected_refusals = {
+            "openai": "I can't help with that.",
+            "anthropic": "safety",
+            "google": "Blocked by safety policy.",
+        }
+        assert response.refusal == expected_refusals[case.organization]
+        assert response.incomplete_reason is None
+    elif outcome_name == "incomplete_result":
+        expected_reasons = {
+            "openai": "max_output_tokens",
+            "anthropic": "max_tokens",
+            "google": "MAX_TOKENS",
+        }
+        assert response.incomplete_reason == expected_reasons[case.organization]
+        assert response.refusal is None
+    else:
+        raise AssertionError(f"Unexpected terminal outcome {outcome_name!r}")
+    assert response.parsed_json is None
+    assert response.parsed_model is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("case", CASES)
+@pytest.mark.parametrize("outcome", _TERMINAL_OUTCOME_FIXTURES)
+def test_facade_structured_terminal_outcomes_are_consistent_in_sync_chat(
+    case,
+    outcome,
+):
+    transport = Mock(
+        return_value=_JSONResponse(
+            _terminal_outcome_response(case, outcome.name, outcome.content),
+        ),
+    )
+    kwargs = _structured_outcome_kwargs(case, outcome.name)
+
+    with patch.object(case.sync_client_class, "_send_request", new=transport):
+        if outcome.name in {"invalid_json", "pydantic_validation_error"}:
+            with pytest.raises(JSONSchemaError):
+                _facade(case).chat(**kwargs)
+            return
+        response = _facade(case).chat(**kwargs)
+
+    _assert_structured_terminal_outcome(response, case, outcome.name)
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+@pytest.mark.parametrize("case", CASES)
+@pytest.mark.parametrize("outcome", _TERMINAL_OUTCOME_FIXTURES)
+async def test_facade_structured_terminal_outcomes_are_consistent_in_async_chat(
+    case,
+    outcome,
+):
+    transport = AsyncMock(
+        return_value=_terminal_outcome_response(case, outcome.name, outcome.content),
+    )
+    kwargs = _structured_outcome_kwargs(case, outcome.name)
+
+    with patch.object(case.async_client_class, "_send_request", new=transport):
+        if outcome.name in {"invalid_json", "pydantic_validation_error"}:
+            with pytest.raises(JSONSchemaError):
+                await _facade(case).achat(**kwargs)
+            return
+        response = await _facade(case).achat(**kwargs)
+
+    _assert_structured_terminal_outcome(response, case, outcome.name)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("case", CASES)
+@pytest.mark.parametrize("outcome", _TERMINAL_OUTCOME_FIXTURES)
+def test_facade_structured_terminal_outcomes_are_consistent_in_sync_streams(
+    case,
+    outcome,
+):
+    events = _terminal_outcome_stream_events(case, outcome.name, outcome.content)
+    completed = []
+    kwargs = _structured_outcome_kwargs(case, outcome.name)
+    kwargs["on_done"] = completed.append
+
+    with patch.object(case.sync_client_class, "stream", return_value=iter(events)):
+        if outcome.name in {"invalid_json", "pydantic_validation_error"}:
+            with pytest.raises(JSONSchemaError):
+                list(_facade(case).stream_chat(**kwargs))
+            return
+        list(_facade(case).stream_chat(**kwargs))
+
+    assert len(completed) == 1
+    _assert_structured_terminal_outcome(completed[0], case, outcome.name)
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+@pytest.mark.parametrize("case", CASES)
+@pytest.mark.parametrize("outcome", _TERMINAL_OUTCOME_FIXTURES)
+async def test_facade_structured_terminal_outcomes_are_consistent_in_async_streams(
+    case,
+    outcome,
+):
+    events = _terminal_outcome_stream_events(case, outcome.name, outcome.content)
+    completed = []
+    kwargs = _structured_outcome_kwargs(case, outcome.name)
+    kwargs["on_done"] = completed.append
+
+    with patch.object(
+        case.async_client_class,
+        "stream",
+        return_value=_as_async_iter(events),
+    ):
+        if outcome.name in {"invalid_json", "pydantic_validation_error"}:
+            with pytest.raises(JSONSchemaError):
+                async for _ in _facade(case).astream_chat(**kwargs):
+                    pass
+            return
+        async for _ in _facade(case).astream_chat(**kwargs):
+            pass
+
+    assert len(completed) == 1
+    _assert_structured_terminal_outcome(completed[0], case, outcome.name)
+
+
 @pytest.mark.unit
 @pytest.mark.parametrize("case", CASES)
 def test_facade_chat_normalizes_messages_response_usage_and_pricing(case):

--- a/tests/unit/conformance/test_facade_contract.py
+++ b/tests/unit/conformance/test_facade_contract.py
@@ -313,7 +313,7 @@ def _structured_schema_from_payload(
     if case.organization == "anthropic":
         return payload["output_config"]["format"]["schema"]
     if case.organization == "google":
-        return payload["generationConfig"]["responseSchema"]
+        return payload["generationConfig"]["responseJsonSchema"]
     raise AssertionError(f"No structured-output payload path for {case.organization!r}")
 
 
@@ -326,26 +326,8 @@ def _contains_reference(node: Any) -> bool:
 
 
 def _google_wire_schema(schema: dict[str, Any]) -> dict[str, Any]:
-    """Apply only Google's type-value casing to a portable source schema."""
-    converted = deepcopy(schema)
-
-    def convert(node: Any) -> None:
-        if isinstance(node, list):
-            for item in node:
-                convert(item)
-            return
-        if not isinstance(node, dict):
-            return
-        schema_type = node.get("type")
-        if isinstance(schema_type, str):
-            node["type"] = schema_type.upper()
-        elif isinstance(schema_type, list):
-            node["type"] = [value.upper() for value in schema_type]
-        for value in node.values():
-            convert(value)
-
-    convert(converted)
-    return converted
+    """Google responseJsonSchema uses the portable JSON Schema vocabulary."""
+    return deepcopy(schema)
 
 
 async def _as_async_iter(events: list[SSEEvent]) -> AsyncIterator[SSEEvent]:

--- a/tests/unit/conformance/test_portable_profile_matrix.py
+++ b/tests/unit/conformance/test_portable_profile_matrix.py
@@ -315,32 +315,15 @@ def _schema_from_payload(
     if organization == "anthropic":
         return payload["output_config"]["format"]["schema"]
     if organization == "google":
-        return payload["generationConfig"]["responseSchema"]
+        return payload["generationConfig"]["responseJsonSchema"]
     if organization == "mistral":
         return payload["response_format"]["json_schema"]["schema"]
     raise AssertionError(f"No schema path for {organization!r}")
 
 
 def _google_wire_schema(schema: dict[str, Any]) -> dict[str, Any]:
-    converted = deepcopy(schema)
-
-    def convert(node: Any) -> None:
-        if isinstance(node, list):
-            for item in node:
-                convert(item)
-            return
-        if not isinstance(node, dict):
-            return
-        schema_type = node.get("type")
-        if isinstance(schema_type, str):
-            node["type"] = schema_type.upper()
-        elif isinstance(schema_type, list):
-            node["type"] = [value.upper() for value in schema_type]
-        for value in node.values():
-            convert(value)
-
-    convert(converted)
-    return converted
+    """Google responseJsonSchema uses the portable JSON Schema vocabulary."""
+    return deepcopy(schema)
 
 
 def _assert_native_format(

--- a/tests/unit/conformance/test_portable_profile_matrix.py
+++ b/tests/unit/conformance/test_portable_profile_matrix.py
@@ -1,0 +1,791 @@
+"""Portable structured-output conformance through the public facade.
+
+The matrix deliberately uses the same ``UniversalLLMAPIAdapter`` entry point
+for built-in organizations and installed organization plugins.  HTTP/SSE
+clients are replaced at their network boundary, so this suite records native
+payloads without credentials or live API calls.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from copy import deepcopy
+from dataclasses import dataclass
+from pathlib import Path
+import sys
+from typing import Any, Final
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+for source in (
+    REPOSITORY_ROOT / "src",
+    REPOSITORY_ROOT / "packages" / "organizations" / "mistral" / "src",
+    REPOSITORY_ROOT / "packages" / "organizations" / "xai" / "src",
+):
+    source_path = str(source)
+    if source_path not in sys.path:
+        sys.path.insert(0, source_path)
+
+
+import llm_api_adapter.adapters.base_adapter as base_adapter_module
+import llm_api_adapter.universal_adapter as universal_adapter_module
+from llm_api_adapter.adapters.anthropic_adapter import AnthropicAdapter
+from llm_api_adapter.adapters.google_adapter import GoogleAdapter
+from llm_api_adapter.adapters.openai_adapter import OpenAIAdapter
+from llm_api_adapter.errors.llm_api_error import JSONSchemaError
+from llm_api_adapter.llm_registry.llm_registry import RegistrySpec
+from llm_api_adapter.llms.anthropic.async_client import ClaudeAsyncClient
+from llm_api_adapter.llms.anthropic.sync_client import ClaudeSyncClient
+from llm_api_adapter.llms.google.async_client import GeminiAsyncClient
+from llm_api_adapter.llms.google.sync_client import GeminiSyncClient
+from llm_api_adapter.llms.openai.async_client import OpenAIAsyncClient
+from llm_api_adapter.llms.openai.sync_client import OpenAISyncClient
+from llm_api_adapter.llms.transports import SSEEvent
+from llm_api_adapter.service_provider_registry import ServiceProviderRegistry
+from llm_api_adapter.universal_adapter import UniversalLLMAPIAdapter
+from llm_api_adapter_mistral.adapter import MistralAdapter
+from llm_api_adapter_mistral.plugin import PLUGIN as MISTRAL_PLUGIN
+from llm_api_adapter_xai.adapter import XAIAdapter
+from llm_api_adapter_xai.plugin import PLUGIN as XAI_PLUGIN
+from tests.fixtures.structured_output import (
+    FLAT_OBJECT_SCHEMA,
+    NESTED_PYDANTIC_RESPONSE_JSON,
+    NestedPydanticResponse,
+    PORTABLE_PROFILE_SCHEMAS,
+)
+
+
+@dataclass(frozen=True)
+class _JSONResponse:
+    data: dict[str, Any]
+
+    def json(self) -> dict[str, Any]:
+        return self.data
+
+
+@dataclass(frozen=True)
+class PortableProfileCase:
+    organization: str
+    model: str
+    max_tokens: int | None
+    sync_client_class: type[Any] | None
+    async_client_class: type[Any] | None
+
+
+def _openai_response(content: str) -> dict[str, Any]:
+    return {
+        "id": "resp_123",
+        "model": "gpt-5-nano",
+        "status": "completed",
+        "usage": {"input_tokens": 2, "output_tokens": 3, "total_tokens": 5},
+        "output": [{
+            "type": "message",
+            "content": [{"type": "output_text", "text": content}],
+        }],
+    }
+
+
+def _anthropic_response(content: str) -> dict[str, Any]:
+    return {
+        "id": "msg_123",
+        "model": "claude-sonnet-4-5",
+        "stop_reason": "end_turn",
+        "content": [{"type": "text", "text": content}],
+        "usage": {"input_tokens": 2, "output_tokens": 3},
+    }
+
+
+def _google_response(content: str) -> dict[str, Any]:
+    return {
+        "modelVersion": "gemini-2.5-flash",
+        "candidates": [{
+            "content": {"parts": [{"text": content}]},
+            "finishReason": "STOP",
+        }],
+        "usageMetadata": {
+            "promptTokenCount": 2,
+            "candidatesTokenCount": 3,
+            "totalTokenCount": 5,
+        },
+    }
+
+
+def _mistral_response(content: str) -> dict[str, Any]:
+    return {
+        "model": "mistral-small-2603",
+        "choices": [{"message": {"content": content}, "finish_reason": "stop"}],
+    }
+
+
+def _xai_response(content: str) -> dict[str, Any]:
+    return {
+        "object": "response",
+        "id": "resp_xai_123",
+        "model": "grok-4.6",
+        "created_at": 1_774_274_151,
+        "status": "completed",
+        "output": [{
+            "type": "message",
+            "role": "assistant",
+            "status": "completed",
+            "content": [{"type": "output_text", "text": content}],
+        }],
+        "usage": {"input_tokens": 2, "output_tokens": 3, "total_tokens": 5},
+    }
+
+
+CASES: Final = (
+    pytest.param(
+        PortableProfileCase(
+            "openai", "gpt-5-nano", 64, OpenAISyncClient, OpenAIAsyncClient,
+        ),
+        id="openai",
+    ),
+    pytest.param(
+        PortableProfileCase(
+            "anthropic", "claude-sonnet-4-5", 64,
+            ClaudeSyncClient, ClaudeAsyncClient,
+        ),
+        id="anthropic",
+    ),
+    pytest.param(
+        PortableProfileCase(
+            "google", "gemini-2.5-flash", None,
+            GeminiSyncClient, GeminiAsyncClient,
+        ),
+        id="google",
+    ),
+    pytest.param(
+        PortableProfileCase("mistral", "mistral-small-2603", 64, None, None),
+        id="mistral",
+    ),
+    pytest.param(
+        PortableProfileCase("xai", "grok-4.6", 64, None, None),
+        id="xai",
+    ),
+)
+
+
+# This matrix is intentionally exact at organization, model, and endpoint
+# granularity.  It is the only source of skips in the terminal-outcome tests:
+# Mistral Chat Completions exposes no documented distinct refusal terminal
+# signal, while every other case has a response shape that carries one.
+_TERMINAL_OUTCOME_CAPABILITIES: Final = {
+    ("openai", "gpt-5-nano", "responses"): frozenset({"refusal", "incomplete"}),
+    ("anthropic", "claude-sonnet-4-5", "messages"): frozenset({"refusal", "incomplete"}),
+    ("google", "gemini-2.5-flash", "generate_content"): frozenset({"refusal", "incomplete"}),
+    ("mistral", "mistral-small-2603", "chat_completions"): frozenset({"incomplete"}),
+    ("xai", "grok-4.6", "responses"): frozenset({"refusal", "incomplete"}),
+}
+
+_ENDPOINTS: Final = {
+    "openai": "responses",
+    "anthropic": "messages",
+    "google": "generate_content",
+    "mistral": "chat_completions",
+    "xai": "responses",
+}
+
+
+@pytest.fixture
+def installed_organization_plugins(monkeypatch):
+    """Register the two installed organization plugins beside Core adapters."""
+    registry = RegistrySpec()
+    service_providers = ServiceProviderRegistry({
+        AnthropicAdapter.company: AnthropicAdapter,
+        OpenAIAdapter.company: OpenAIAdapter,
+        GoogleAdapter.company: GoogleAdapter,
+    })
+    for plugin in (MISTRAL_PLUGIN, XAI_PLUGIN):
+        assert plugin.model_metadata is not None
+        assert registry.register_organization_metadata(plugin.model_metadata) is True
+        plugin.register(service_providers)
+
+    monkeypatch.setattr(base_adapter_module, "LLM_REGISTRY", registry)
+    monkeypatch.setattr(universal_adapter_module, "LLM_REGISTRY", registry)
+    monkeypatch.setattr(
+        universal_adapter_module,
+        "SERVICE_PROVIDER_REGISTRY",
+        service_providers,
+    )
+
+
+def _facade(case: PortableProfileCase) -> UniversalLLMAPIAdapter:
+    return UniversalLLMAPIAdapter(
+        organization=case.organization,
+        model=case.model,
+        api_key="test-api-key",
+    )
+
+
+def _chat_kwargs(case: PortableProfileCase) -> dict[str, Any]:
+    return {
+        "messages": [{"role": "user", "content": "Return JSON."}],
+        "max_tokens": case.max_tokens,
+    }
+
+
+def _response(case: PortableProfileCase, content: str) -> dict[str, Any]:
+    responses = {
+        "openai": _openai_response,
+        "anthropic": _anthropic_response,
+        "google": _google_response,
+        "mistral": _mistral_response,
+        "xai": _xai_response,
+    }
+    return responses[case.organization](content)
+
+
+def _sync_payload_mock(
+    case: PortableProfileCase,
+    facade: UniversalLLMAPIAdapter,
+    response: dict[str, Any],
+) -> tuple[Mock, Any]:
+    """Install one sync network mock and return a payload reader."""
+    if case.sync_client_class is not None:
+        transport = Mock(return_value=_JSONResponse(response))
+        return transport, patch.object(
+            case.sync_client_class,
+            "_send_request",
+            new=transport,
+        )
+    if case.organization == "mistral":
+        transport = Mock(return_value=response)
+        return transport, patch.object(
+            MistralAdapter,
+            "_post_payload",
+            new=transport,
+        )
+    transport = Mock(return_value=response)
+    facade.adapter._client.create = transport
+    return transport, None
+
+
+def _sync_payload(case: PortableProfileCase, transport: Mock) -> dict[str, Any]:
+    if case.sync_client_class is not None:
+        return transport.call_args.args[1]
+    if case.organization == "mistral":
+        return transport.call_args.args[0]
+    return {
+        "model": transport.call_args.kwargs["model"],
+        **transport.call_args.kwargs,
+    }
+
+
+def _async_payload_mock(
+    case: PortableProfileCase,
+    facade: UniversalLLMAPIAdapter,
+    response: dict[str, Any],
+) -> tuple[AsyncMock, Any]:
+    if case.async_client_class is not None:
+        transport = AsyncMock(return_value=response)
+        return transport, patch.object(
+            case.async_client_class,
+            "_send_request",
+            new=transport,
+        )
+    transport = AsyncMock(return_value=response)
+    if case.organization == "mistral":
+        facade.adapter._apost_payload = transport
+    else:
+        facade.adapter._async_client.create = transport
+    return transport, None
+
+
+def _async_payload(case: PortableProfileCase, transport: AsyncMock) -> dict[str, Any]:
+    if case.async_client_class is not None:
+        return transport.call_args.args[1]
+    if case.organization == "mistral":
+        return transport.call_args.args[0]
+    return {
+        "model": transport.call_args.kwargs["model"],
+        **transport.call_args.kwargs,
+    }
+
+
+def _schema_from_payload(
+    organization: str,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    if organization in {"openai", "xai"}:
+        return payload["text"]["format"]["schema"]
+    if organization == "anthropic":
+        return payload["output_config"]["format"]["schema"]
+    if organization == "google":
+        return payload["generationConfig"]["responseSchema"]
+    if organization == "mistral":
+        return payload["response_format"]["json_schema"]["schema"]
+    raise AssertionError(f"No schema path for {organization!r}")
+
+
+def _google_wire_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    converted = deepcopy(schema)
+
+    def convert(node: Any) -> None:
+        if isinstance(node, list):
+            for item in node:
+                convert(item)
+            return
+        if not isinstance(node, dict):
+            return
+        schema_type = node.get("type")
+        if isinstance(schema_type, str):
+            node["type"] = schema_type.upper()
+        elif isinstance(schema_type, list):
+            node["type"] = [value.upper() for value in schema_type]
+        for value in node.values():
+            convert(value)
+
+    convert(converted)
+    return converted
+
+
+def _assert_native_format(
+    organization: str,
+    payload: dict[str, Any],
+    expected_schema: dict[str, Any],
+) -> None:
+    assert _schema_from_payload(organization, payload) == expected_schema
+    if organization in {"openai", "xai"}:
+        fmt = payload["text"]["format"]
+        assert fmt["type"] == "json_schema"
+        assert fmt["name"] == "response"
+        assert fmt["strict"] is True
+    elif organization == "anthropic":
+        assert payload["output_config"]["format"]["type"] == "json_schema"
+    elif organization == "google":
+        assert payload["generationConfig"]["responseMimeType"] == "application/json"
+    else:
+        fmt = payload["response_format"]
+        assert fmt["type"] == "json_schema"
+        assert fmt["json_schema"]["name"] == "response"
+        assert fmt["json_schema"]["strict"] is True
+
+
+def _contains_reference(node: Any) -> bool:
+    if isinstance(node, dict):
+        return "$ref" in node or any(_contains_reference(value) for value in node.values())
+    if isinstance(node, list):
+        return any(_contains_reference(value) for value in node)
+    return False
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("case", CASES)
+@pytest.mark.parametrize("fixture_name", sorted(PORTABLE_PROFILE_SCHEMAS))
+def test_portable_profile_raw_schema_matrix_uses_exact_native_payloads(
+    case,
+    fixture_name,
+    installed_organization_plugins,
+):
+    """Every portable fixture reaches every organization unchanged in meaning."""
+    source_schema = deepcopy(PORTABLE_PROFILE_SCHEMAS[fixture_name])
+    facade = _facade(case)
+    transport, patcher = _sync_payload_mock(
+        case,
+        facade,
+        _response(case, '{"answer": "ok"}'),
+    )
+
+    if patcher is None:
+        response = facade.chat(**_chat_kwargs(case), json_schema=source_schema)
+    else:
+        with patcher:
+            response = facade.chat(**_chat_kwargs(case), json_schema=source_schema)
+
+    expected_schema = (
+        _google_wire_schema(source_schema)
+        if case.organization == "google"
+        else source_schema
+    )
+    assert response.parsed_json == {"answer": "ok"}
+    _assert_native_format(
+        case.organization,
+        _sync_payload(case, transport),
+        expected_schema,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+@pytest.mark.parametrize("case", CASES)
+async def test_portable_profile_response_model_has_sync_async_payload_parity(
+    case,
+    installed_organization_plugins,
+):
+    """Pydantic extraction and schema normalization agree in both API modes."""
+    sync_facade = _facade(case)
+    sync_transport, sync_patcher = _sync_payload_mock(
+        case,
+        sync_facade,
+        _response(case, NESTED_PYDANTIC_RESPONSE_JSON),
+    )
+    if sync_patcher is None:
+        sync_response = sync_facade.chat(
+            **_chat_kwargs(case),
+            response_model=NestedPydanticResponse,
+        )
+    else:
+        with sync_patcher:
+            sync_response = sync_facade.chat(
+                **_chat_kwargs(case),
+                response_model=NestedPydanticResponse,
+            )
+
+    async_facade = _facade(case)
+    async_transport, async_patcher = _async_payload_mock(
+        case,
+        async_facade,
+        _response(case, NESTED_PYDANTIC_RESPONSE_JSON),
+    )
+    if async_patcher is None:
+        async_response = await async_facade.achat(
+            **_chat_kwargs(case),
+            response_model=NestedPydanticResponse,
+        )
+    else:
+        with async_patcher:
+            async_response = await async_facade.achat(
+                **_chat_kwargs(case),
+                response_model=NestedPydanticResponse,
+            )
+
+    expected_model = NestedPydanticResponse(contact={"name": "Ada"})
+    assert sync_response.parsed_model == expected_model
+    assert async_response.parsed_model == expected_model
+    expected_schema = _schema_from_payload(
+        case.organization,
+        _sync_payload(case, sync_transport),
+    )
+    assert _schema_from_payload(
+        case.organization,
+        _async_payload(case, async_transport),
+    ) == expected_schema
+    assert "$defs" not in expected_schema
+    assert not _contains_reference(expected_schema)
+
+
+def _stream_events(case: PortableProfileCase, content: str) -> list[SSEEvent]:
+    if case.organization == "openai":
+        return [
+            SSEEvent(event="response.output_text.delta", data={"delta": content}),
+            SSEEvent(
+                event="response.completed",
+                data={"response": _openai_response(content)},
+            ),
+        ]
+    if case.organization == "anthropic":
+        return [
+            SSEEvent(
+                event="message_start",
+                data={"message": {
+                    "id": "msg_123",
+                    "model": case.model,
+                    "content": [],
+                    "usage": {"input_tokens": 2, "output_tokens": 0},
+                }},
+            ),
+            SSEEvent(
+                event="content_block_start",
+                data={"index": 0, "content_block": {"type": "text", "text": ""}},
+            ),
+            SSEEvent(
+                event="content_block_delta",
+                data={"index": 0, "delta": {"type": "text_delta", "text": content}},
+            ),
+            SSEEvent(
+                event="message_delta",
+                data={"delta": {"stop_reason": "end_turn"}, "usage": {"output_tokens": 3}},
+            ),
+            SSEEvent(event="message_stop", data={}),
+        ]
+    if case.organization == "google":
+        return [SSEEvent(
+            event=None,
+            data=_google_response(content),
+        )]
+    if case.organization == "mistral":
+        return [SSEEvent(
+            event=None,
+            data={"choices": [{
+                "index": 0,
+                "delta": {"content": content},
+                "finish_reason": "stop",
+            }]},
+        )]
+    return [
+        SSEEvent(event="response.output_text.delta", data={"delta": content}),
+        SSEEvent(
+            event="response.completed",
+            data={"response": _xai_response(content)},
+        ),
+    ]
+
+
+def _install_sync_stream(
+    case: PortableProfileCase,
+    facade: UniversalLLMAPIAdapter,
+    events: list[SSEEvent],
+) -> Any:
+    stream = Mock(return_value=iter(events))
+    if case.sync_client_class is not None:
+        return patch.object(case.sync_client_class, "stream", new=stream)
+    if case.organization == "mistral":
+        facade.adapter._stream_payload = stream
+    else:
+        facade.adapter._client.stream = stream
+    return None
+
+
+async def _as_async_iter(events: list[SSEEvent]) -> AsyncIterator[SSEEvent]:
+    for event in events:
+        yield event
+
+
+def _install_async_stream(
+    case: PortableProfileCase,
+    facade: UniversalLLMAPIAdapter,
+    events: list[SSEEvent],
+) -> Any:
+    stream = Mock(return_value=_as_async_iter(events))
+    if case.async_client_class is not None:
+        return patch.object(case.async_client_class, "stream", new=stream)
+    if case.organization == "mistral":
+        facade.adapter._astream_payload = stream
+    else:
+        facade.adapter._async_client.stream = stream
+    return None
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+@pytest.mark.parametrize("case", CASES)
+async def test_portable_profile_streams_finalize_through_on_done_in_both_modes(
+    case,
+    installed_organization_plugins,
+):
+    content = '{"answer": "ok"}'
+    sync_done: list[Any] = []
+    sync_facade = _facade(case)
+    sync_patcher = _install_sync_stream(case, sync_facade, _stream_events(case, content))
+    if sync_patcher is None:
+        sync_output = list(sync_facade.stream_chat(
+            **_chat_kwargs(case),
+            json_schema=FLAT_OBJECT_SCHEMA,
+            on_done=sync_done.append,
+        ))
+    else:
+        with sync_patcher:
+            sync_output = list(sync_facade.stream_chat(
+                **_chat_kwargs(case),
+                json_schema=FLAT_OBJECT_SCHEMA,
+                on_done=sync_done.append,
+            ))
+
+    async_done: list[Any] = []
+    async_facade = _facade(case)
+    async_patcher = _install_async_stream(
+        case,
+        async_facade,
+        _stream_events(case, content),
+    )
+    if async_patcher is None:
+        async_output = [
+            text async for text in async_facade.astream_chat(
+                **_chat_kwargs(case),
+                json_schema=FLAT_OBJECT_SCHEMA,
+                on_done=async_done.append,
+            )
+        ]
+    else:
+        with async_patcher:
+            async_output = [
+                text async for text in async_facade.astream_chat(
+                    **_chat_kwargs(case),
+                    json_schema=FLAT_OBJECT_SCHEMA,
+                    on_done=async_done.append,
+                )
+            ]
+
+    assert "".join(sync_output) == content
+    assert "".join(async_output) == content
+    assert sync_done[0].parsed_json == {"answer": "ok"}
+    assert async_done[0].parsed_json == {"answer": "ok"}
+
+
+def _terminal_response(
+    case: PortableProfileCase,
+    outcome: str,
+) -> dict[str, Any]:
+    if outcome == "valid":
+        return _response(case, '{"answer": "ok"}')
+    if outcome == "invalid_json":
+        return _response(case, '{"answer": ')
+    if outcome == "pydantic_validation_error":
+        return _response(case, '{"contact": {}}')
+
+    if outcome == "refusal":
+        if case.organization == "openai":
+            return {
+                "id": "resp_refusal",
+                "model": case.model,
+                "status": "completed",
+                "output": [{"type": "message", "content": [{
+                    "type": "refusal", "refusal": "I can't help with that.",
+                }]}],
+            }
+        if case.organization == "anthropic":
+            return {
+                "id": "msg_refusal",
+                "model": case.model,
+                "stop_reason": "refusal",
+                "stop_details": {"reason": "safety"},
+                "content": [],
+                "usage": {"input_tokens": 2, "output_tokens": 0},
+            }
+        if case.organization == "google":
+            return {
+                "modelVersion": case.model,
+                "candidates": [{
+                    "content": {"parts": []},
+                    "finishReason": "SAFETY",
+                    "finishMessage": "Blocked by safety policy.",
+                }],
+            }
+        return {
+            **_xai_response("unused"),
+            "output": [{"type": "message", "content": [{
+                "type": "refusal", "refusal": "I can't help with that.",
+            }]}],
+        }
+
+    if case.organization == "openai":
+        return {
+            "id": "resp_incomplete",
+            "model": case.model,
+            "status": "incomplete",
+            "incomplete_details": {"reason": "max_output_tokens"},
+            "output": [],
+        }
+    if case.organization == "anthropic":
+        return {
+            "id": "msg_incomplete",
+            "model": case.model,
+            "stop_reason": "max_tokens",
+            "content": [{"type": "text", "text": '{"answer": '}],
+            "usage": {"input_tokens": 2, "output_tokens": 3},
+        }
+    if case.organization == "google":
+        return {
+            "modelVersion": case.model,
+            "candidates": [{
+                "content": {"parts": [{"text": '{"answer": '}]},
+                "finishReason": "MAX_TOKENS",
+            }],
+        }
+    if case.organization == "mistral":
+        return {
+            **_mistral_response('{"answer": '),
+            "choices": [{
+                "message": {"content": '{"answer": '},
+                "finish_reason": "length",
+            }],
+        }
+    return {
+        **_xai_response('{"answer": '),
+        "status": "incomplete",
+        "incomplete_details": {"reason": "max_output_tokens"},
+    }
+
+
+def _terminal_kwargs(case: PortableProfileCase, outcome: str) -> dict[str, Any]:
+    kwargs = _chat_kwargs(case)
+    if outcome == "pydantic_validation_error":
+        kwargs["response_model"] = NestedPydanticResponse
+    else:
+        kwargs["json_schema"] = FLAT_OBJECT_SCHEMA
+    return kwargs
+
+
+def _assert_terminal_outcome(outcome: str, response: Any) -> None:
+    if outcome == "valid":
+        assert response.parsed_json == {"answer": "ok"}
+        return
+    if outcome == "refusal":
+        assert response.refusal
+        assert response.incomplete_reason is None
+    elif outcome == "incomplete":
+        assert response.incomplete_reason
+        assert response.refusal is None
+    else:
+        raise AssertionError(f"Unexpected terminal outcome: {outcome}")
+    assert response.parsed_json is None
+    assert response.parsed_model is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+@pytest.mark.parametrize("case", CASES)
+@pytest.mark.parametrize(
+    "outcome",
+    ("valid", "refusal", "incomplete", "invalid_json", "pydantic_validation_error"),
+)
+async def test_portable_profile_terminal_outcomes_keep_sync_async_contracts(
+    case,
+    outcome,
+    installed_organization_plugins,
+):
+    capabilities = _TERMINAL_OUTCOME_CAPABILITIES[(
+        case.organization,
+        case.model,
+        _ENDPOINTS[case.organization],
+    )]
+    if outcome in {"refusal", "incomplete"} and outcome not in capabilities:
+        pytest.skip(
+            f"{case.organization}/{case.model}/{_ENDPOINTS[case.organization]} "
+            f"does not expose a distinct {outcome} terminal signal",
+        )
+
+    sync_facade = _facade(case)
+    _, sync_patcher = _sync_payload_mock(
+        case,
+        sync_facade,
+        _terminal_response(case, outcome),
+    )
+    kwargs = _terminal_kwargs(case, outcome)
+    if outcome in {"invalid_json", "pydantic_validation_error"}:
+        if sync_patcher is None:
+            with pytest.raises(JSONSchemaError):
+                sync_facade.chat(**kwargs)
+        else:
+            with sync_patcher, pytest.raises(JSONSchemaError):
+                sync_facade.chat(**kwargs)
+    elif sync_patcher is None:
+        _assert_terminal_outcome(outcome, sync_facade.chat(**kwargs))
+    else:
+        with sync_patcher:
+            _assert_terminal_outcome(outcome, sync_facade.chat(**kwargs))
+
+    async_facade = _facade(case)
+    _, async_patcher = _async_payload_mock(
+        case,
+        async_facade,
+        _terminal_response(case, outcome),
+    )
+    if outcome in {"invalid_json", "pydantic_validation_error"}:
+        if async_patcher is None:
+            with pytest.raises(JSONSchemaError):
+                await async_facade.achat(**kwargs)
+        else:
+            with async_patcher, pytest.raises(JSONSchemaError):
+                await async_facade.achat(**kwargs)
+        return
+    if async_patcher is None:
+        async_response = await async_facade.achat(**kwargs)
+    else:
+        with async_patcher:
+            async_response = await async_facade.achat(**kwargs)
+    _assert_terminal_outcome(outcome, async_response)

--- a/tests/unit/test_organization_profile_compatibility.py
+++ b/tests/unit/test_organization_profile_compatibility.py
@@ -1,0 +1,220 @@
+"""Portable structured-output compatibility checks for organization packages."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, field
+from pathlib import Path
+import sys
+from typing import Any
+
+import pytest
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+for source in (
+    REPOSITORY_ROOT / "src",
+    REPOSITORY_ROOT / "packages" / "organizations" / "mistral" / "src",
+    REPOSITORY_ROOT / "packages" / "organizations" / "xai" / "src",
+):
+    source_path = str(source)
+    if source_path not in sys.path:
+        sys.path.insert(0, source_path)
+
+
+import llm_api_adapter.adapters.base_adapter as base_adapter_module
+from llm_api_adapter.errors.llm_api_error import JSONSchemaError
+from llm_api_adapter.llm_registry.llm_registry import RegistrySpec
+from llm_api_adapter.llms.transports import JSONResponse
+from llm_api_adapter.models.messages.chat_message import UserMessage
+from llm_api_adapter_mistral.adapter import MistralAdapter
+from llm_api_adapter_mistral.plugin import PLUGIN as MISTRAL_PLUGIN
+from llm_api_adapter_xai.adapter import XAIAdapter
+from llm_api_adapter_xai.plugin import PLUGIN as XAI_PLUGIN
+from tests.fixtures.structured_output import (
+    NESTED_PYDANTIC_RESPONSE_JSON,
+    NestedPydanticResponse,
+    PORTABLE_PROFILE_SCHEMAS,
+)
+
+
+_NESTED_PYDANTIC_PROVIDER_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "contact": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string", "title": "Name"},
+            },
+            "required": ["name"],
+            "additionalProperties": False,
+            "title": "PortableContact",
+        },
+    },
+    "required": ["contact"],
+    "additionalProperties": False,
+    "title": "NestedPydanticResponse",
+}
+
+
+@dataclass
+class _RecordedTransport:
+    response: dict[str, Any]
+    requests: list[Any] = field(default_factory=list)
+
+    def post_json(self, request: Any, *, http_error_handler: Any = None) -> JSONResponse:
+        self.requests.append(request)
+        return JSONResponse(self.response)
+
+
+@pytest.fixture
+def organization_package_registry(monkeypatch):
+    registry = RegistrySpec()
+    for plugin in (MISTRAL_PLUGIN, XAI_PLUGIN):
+        assert plugin.model_metadata is not None
+        assert registry.register_organization_metadata(plugin.model_metadata) is True
+    monkeypatch.setattr(base_adapter_module, "LLM_REGISTRY", registry)
+    return registry
+
+
+def _mistral_response(content: str) -> dict[str, Any]:
+    return {
+        "model": "mistral-small-2603",
+        "choices": [{"message": {"content": content}}],
+    }
+
+
+def _xai_response(content: str) -> dict[str, Any]:
+    return {
+        "object": "response",
+        "id": "resp-xai-structured-output",
+        "model": "grok-4.6",
+        "created_at": 1_774_274_151,
+        "status": "completed",
+        "output": [
+            {
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_text", "text": content}],
+            }
+        ],
+        "usage": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+    }
+
+
+def _structured_adapter(
+    organization: str,
+    content: str,
+) -> tuple[MistralAdapter | XAIAdapter, _RecordedTransport]:
+    if organization == "mistral":
+        adapter = MistralAdapter(
+            api_key="mistral-test-key",
+            model="mistral-small-2603",
+        )
+        transport = _RecordedTransport(_mistral_response(content))
+        adapter._sync_transport = transport
+        return adapter, transport
+
+    adapter = XAIAdapter(api_key="xai-test-key", model="grok-4.6")
+    transport = _RecordedTransport(_xai_response(content))
+    adapter._client._sync_transport = transport
+    return adapter, transport
+
+
+def _expected_structured_output_format(
+    organization: str,
+    schema: dict,
+) -> dict[str, Any]:
+    if organization == "mistral":
+        return {
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "response",
+                    "strict": True,
+                    "schema": schema,
+                },
+            }
+        }
+    return {
+        "text": {
+            "format": {
+                "type": "json_schema",
+                "name": "response",
+                "schema": schema,
+                "strict": True,
+            }
+        }
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("organization", ("mistral", "xai"))
+@pytest.mark.parametrize("fixture_name", sorted(PORTABLE_PROFILE_SCHEMAS))
+def test_organization_packages_preserve_every_portable_raw_schema(
+    organization,
+    fixture_name,
+    organization_package_registry,
+):
+    source_schema = deepcopy(PORTABLE_PROFILE_SCHEMAS[fixture_name])
+    original_schema = deepcopy(source_schema)
+    adapter, transport = _structured_adapter(organization, '{"answer": "ok"}')
+
+    response = adapter.chat(
+        messages=[UserMessage("Return JSON.")],
+        json_schema=source_schema,
+    )
+
+    assert response.parsed_json == {"answer": "ok"}
+    assert source_schema == original_schema
+    expected = _expected_structured_output_format(organization, original_schema)
+    for key, value in expected.items():
+        assert transport.requests[0].payload[key] == value
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("organization", ("mistral", "xai"))
+def test_organization_packages_share_the_normalized_nested_pydantic_schema(
+    organization,
+    organization_package_registry,
+):
+    source_schema = NestedPydanticResponse.model_json_schema()
+    adapter, transport = _structured_adapter(
+        organization,
+        NESTED_PYDANTIC_RESPONSE_JSON,
+    )
+
+    response = adapter.chat(
+        messages=[UserMessage("Return the nested JSON response.")],
+        response_model=NestedPydanticResponse,
+    )
+
+    assert response.parsed_model == NestedPydanticResponse(
+        contact={"name": "Ada"},
+    )
+    assert NestedPydanticResponse.model_json_schema() == source_schema
+    expected = _expected_structured_output_format(
+        organization,
+        _NESTED_PYDANTIC_PROVIDER_SCHEMA,
+    )
+    for key, value in expected.items():
+        assert transport.requests[0].payload[key] == value
+
+
+@pytest.mark.unit
+def test_xai_rejects_its_documented_boolean_schema_before_http(
+    organization_package_registry,
+):
+    adapter, transport = _structured_adapter("xai", '{"answer": "ok"}')
+    schema = {
+        "type": "object",
+        "properties": {"answer": True},
+        "required": ["answer"],
+        "additionalProperties": False,
+    }
+
+    with pytest.raises(JSONSchemaError, match="xAI structured output rejects boolean schemas"):
+        adapter.chat(messages=[UserMessage("Return JSON.")], json_schema=schema)
+
+    assert transport.requests == []

--- a/tests/unit/test_organization_profile_compatibility.py
+++ b/tests/unit/test_organization_profile_compatibility.py
@@ -25,13 +25,15 @@ for source in (
 import llm_api_adapter.adapters.base_adapter as base_adapter_module
 from llm_api_adapter.errors.llm_api_error import JSONSchemaError
 from llm_api_adapter.llm_registry.llm_registry import RegistrySpec
-from llm_api_adapter.llms.transports import JSONResponse
+from llm_api_adapter.llms.transports import JSONResponse, SSEEvent
 from llm_api_adapter.models.messages.chat_message import UserMessage
 from llm_api_adapter_mistral.adapter import MistralAdapter
 from llm_api_adapter_mistral.plugin import PLUGIN as MISTRAL_PLUGIN
 from llm_api_adapter_xai.adapter import XAIAdapter
 from llm_api_adapter_xai.plugin import PLUGIN as XAI_PLUGIN
+from llm_api_adapter_xai.streaming import XAIResponsesStreamParser
 from tests.fixtures.structured_output import (
+    FLAT_OBJECT_SCHEMA,
     NESTED_PYDANTIC_RESPONSE_JSON,
     NestedPydanticResponse,
     PORTABLE_PROFILE_SCHEMAS,
@@ -61,10 +63,21 @@ _NESTED_PYDANTIC_PROVIDER_SCHEMA = {
 class _RecordedTransport:
     response: dict[str, Any]
     requests: list[Any] = field(default_factory=list)
+    stream_events: list[SSEEvent] = field(default_factory=list)
 
     def post_json(self, request: Any, *, http_error_handler: Any = None) -> JSONResponse:
         self.requests.append(request)
         return JSONResponse(self.response)
+
+    def post_sse(
+        self,
+        request: Any,
+        *,
+        http_error_handler: Any = None,
+        stream_error_handler: Any = None,
+    ):
+        self.requests.append(request)
+        return iter(self.stream_events)
 
 
 @pytest.fixture
@@ -243,3 +256,109 @@ def test_organization_packages_enforce_the_common_profile_before_http(
         adapter.chat(messages=[UserMessage("Return JSON.")], json_schema=schema)
 
     assert transport.requests == []
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("organization", ("mistral", "xai"))
+def test_organization_packages_skip_structured_parsing_for_native_truncation(
+    organization,
+    organization_package_registry,
+):
+    adapter, transport = _structured_adapter(organization, '{"answer": ')
+    if organization == "mistral":
+        transport.response["choices"][0]["finish_reason"] = "length"
+        expected_reason = "length"
+    else:
+        transport.response["status"] = "incomplete"
+        transport.response["incomplete_details"] = {
+            "reason": "max_output_tokens",
+        }
+        expected_reason = "max_output_tokens"
+
+    response = adapter.chat(
+        messages=[UserMessage("Return JSON.")],
+        json_schema=FLAT_OBJECT_SCHEMA,
+    )
+
+    assert response.incomplete_reason == expected_reason
+    assert response.refusal is None
+    assert response.parsed_json is None
+    assert response.parsed_model is None
+
+
+@pytest.mark.unit
+def test_xai_package_exposes_an_explicit_responses_refusal_without_parsing(
+    organization_package_registry,
+):
+    adapter, transport = _structured_adapter("xai", "unused")
+    transport.response["output"][0]["content"] = [{
+        "type": "refusal",
+        "refusal": "I can't help with that.",
+    }]
+
+    response = adapter.chat(
+        messages=[UserMessage("Return JSON.")],
+        json_schema=FLAT_OBJECT_SCHEMA,
+    )
+
+    assert response.refusal == "I can't help with that."
+    assert response.incomplete_reason is None
+    assert response.parsed_json is None
+    assert response.parsed_model is None
+
+
+@pytest.mark.unit
+def test_xai_stream_parser_finalizes_an_incomplete_response(
+    organization_package_registry,
+):
+    state = XAIResponsesStreamParser.new_state(buffer_chars=None)
+    final_response = _xai_response('{"answer": ')
+    final_response["status"] = "incomplete"
+    final_response["incomplete_details"] = {"reason": "max_output_tokens"}
+
+    XAIResponsesStreamParser.consume_event(
+        SSEEvent(
+            event="response.incomplete",
+            data={"response": final_response},
+        ),
+        state,
+    )
+    response = XAIResponsesStreamParser.finalize(
+        state,
+        model="grok-4.6",
+    )
+
+    assert response.finish_reason == "incomplete"
+    assert response.incomplete_reason == "max_output_tokens"
+
+
+@pytest.mark.unit
+def test_mistral_stream_finalizes_a_truncated_structured_result(
+    organization_package_registry,
+):
+    adapter, transport = _structured_adapter("mistral", '{"answer": ')
+    transport.stream_events = [
+        SSEEvent(
+            event=None,
+            data={
+                "choices": [{
+                    "index": 0,
+                    "delta": {"content": '{"answer": '},
+                    "finish_reason": "length",
+                }],
+            },
+        ),
+    ]
+    completed = []
+
+    list(
+        adapter.stream_chat(
+            messages=[UserMessage("Return JSON.")],
+            json_schema=FLAT_OBJECT_SCHEMA,
+            on_done=completed.append,
+        ),
+    )
+
+    assert completed[0].finish_reason == "length"
+    assert completed[0].incomplete_reason == "length"
+    assert completed[0].parsed_json is None

--- a/tests/unit/test_organization_profile_compatibility.py
+++ b/tests/unit/test_organization_profile_compatibility.py
@@ -218,3 +218,28 @@ def test_xai_rejects_its_documented_boolean_schema_before_http(
         adapter.chat(messages=[UserMessage("Return JSON.")], json_schema=schema)
 
     assert transport.requests == []
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("organization", ("mistral", "xai"))
+def test_organization_packages_enforce_the_common_profile_before_http(
+    organization,
+    organization_package_registry,
+):
+    adapter, transport = _structured_adapter(organization, '{"answer": "ok"}')
+    schema = {
+        "type": "object",
+        "properties": {"answer": {"type": "string"}},
+        "required": ["answer"],
+    }
+
+    with pytest.raises(
+        JSONSchemaError,
+        match=(
+            f"{organization} structured-output schema at "
+            "#/additionalProperties: Core portable profile"
+        ),
+    ):
+        adapter.chat(messages=[UserMessage("Return JSON.")], json_schema=schema)
+
+    assert transport.requests == []

--- a/tests/unit/test_structured_output.py
+++ b/tests/unit/test_structured_output.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+import pytest
+
+from src.llm_api_adapter.errors.llm_api_error import JSONSchemaError
+from src.llm_api_adapter.adapters.structured_output import (
+    normalize_local_references,
+    prepare_structured_output,
+)
+from tests.fixtures.structured_output import NestedPydanticResponse
+
+
+def _contains_reference(node: Any) -> bool:
+    if isinstance(node, dict):
+        return "$ref" in node or any(_contains_reference(value) for value in node.values())
+    if isinstance(node, list):
+        return any(_contains_reference(value) for value in node)
+    return False
+
+
+@pytest.mark.unit
+def test_preparation_inlines_local_definition_without_mutating_source_schema():
+    source_schema = {
+        "$defs": {
+            "Contact": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "required": ["name"],
+            },
+        },
+        "type": "object",
+        "properties": {"contact": {"$ref": "#/$defs/Contact"}},
+        "required": ["contact"],
+    }
+    original = deepcopy(source_schema)
+
+    prepared = prepare_structured_output(
+        source_schema,
+        None,
+        None,
+        provider="openai",
+    )
+
+    assert source_schema == original
+    assert prepared.source_schema == original
+    assert prepared.source_schema is not source_schema
+    assert prepared.provider_schema == {
+        "type": "object",
+        "properties": {
+            "contact": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "required": ["name"],
+            },
+        },
+        "required": ["contact"],
+    }
+
+
+@pytest.mark.unit
+def test_normalization_resolves_local_references_inside_arrays():
+    normalized = normalize_local_references(
+        {
+            "$defs": {
+                "Tag": {"type": "string", "enum": ["new", "archived"]},
+            },
+            "type": "object",
+            "properties": {
+                "tags": {
+                    "type": "array",
+                    "items": {"$ref": "#/$defs/Tag"},
+                },
+            },
+        },
+        provider="anthropic",
+    )
+
+    assert normalized["properties"]["tags"]["items"] == {
+        "type": "string",
+        "enum": ["new", "archived"],
+    }
+    assert "$defs" not in normalized
+    assert not _contains_reference(normalized)
+
+
+@pytest.mark.unit
+def test_pydantic_source_schema_and_model_remain_separate_from_provider_schema():
+    prepared = prepare_structured_output(
+        None,
+        NestedPydanticResponse,
+        None,
+        provider="google",
+    )
+
+    assert prepared.response_model is NestedPydanticResponse
+    assert prepared.source_schema == NestedPydanticResponse.model_json_schema()
+    assert "$defs" in prepared.source_schema
+    assert "$defs" not in prepared.provider_schema
+    assert not _contains_reference(prepared.provider_schema)
+    assert prepared.provider_schema["properties"]["contact"]["type"] == "object"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("schema", "expected_path", "expected_detail"),
+    [
+        (
+            {"type": "object", "properties": {"value": {"$ref": "other.json"}}},
+            "#/properties/value",
+            "supports only local",
+        ),
+        (
+            {"type": "object", "properties": {"value": {"$ref": "#/$defs/Missing"}}},
+            "#/properties/value",
+            "cannot resolve",
+        ),
+        (
+            {
+                "$defs": {
+                    "Node": {
+                        "type": "object",
+                        "properties": {"next": {"$ref": "#/$defs/Node"}},
+                    },
+                },
+                "$ref": "#/$defs/Node",
+            },
+            "#/$defs/Node/properties/next",
+            "recursive",
+        ),
+    ],
+)
+def test_preparation_rejects_external_unresolved_and_recursive_references(
+    schema,
+    expected_path,
+    expected_detail,
+):
+    with pytest.raises(JSONSchemaError) as error:
+        prepare_structured_output(schema, None, None, provider="mistral")
+
+    message = str(error.value)
+    assert "mistral structured-output schema" in message
+    assert expected_path in message
+    assert expected_detail in message

--- a/tests/unit/test_structured_output.py
+++ b/tests/unit/test_structured_output.py
@@ -9,8 +9,12 @@ from src.llm_api_adapter.errors.llm_api_error import JSONSchemaError
 from src.llm_api_adapter.adapters.structured_output import (
     normalize_local_references,
     prepare_structured_output,
+    validate_core_portable_schema,
 )
-from tests.fixtures.structured_output import NestedPydanticResponse
+from tests.fixtures.structured_output import (
+    NestedPydanticResponse,
+    PORTABLE_PROFILE_SCHEMAS,
+)
 
 
 def _contains_reference(node: Any) -> bool:
@@ -101,6 +105,77 @@ def test_pydantic_source_schema_and_model_remain_separate_from_provider_schema()
     assert "$defs" not in prepared.provider_schema
     assert not _contains_reference(prepared.provider_schema)
     assert prepared.provider_schema["properties"]["contact"]["type"] == "object"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("provider", ("openai", "anthropic", "google"))
+@pytest.mark.parametrize("schema", PORTABLE_PROFILE_SCHEMAS.values())
+def test_core_portable_profile_accepts_the_shared_fixture_vocabulary(provider, schema):
+    original = deepcopy(schema)
+
+    prepared = validate_core_portable_schema(schema, provider=provider)
+
+    assert prepared == original
+    assert prepared is not schema
+    assert schema == original
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("schema", "expected_path", "expected_detail"),
+    [
+        (
+            {"type": "array", "items": {"type": "string"}},
+            "#",
+            "root object",
+        ),
+        (
+            {
+                "type": "object",
+                "properties": {"answer": {"type": "string"}},
+                "required": [],
+                "additionalProperties": False,
+            },
+            "#/required",
+            "every property",
+        ),
+        (
+            {
+                "type": "object",
+                "properties": {"answer": {"type": "string"}},
+                "required": ["answer"],
+            },
+            "#/additionalProperties",
+            "additionalProperties",
+        ),
+        (
+            {
+                "type": "object",
+                "properties": {
+                    "answer": {
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                    },
+                },
+                "required": ["answer"],
+                "additionalProperties": False,
+            },
+            "#/properties/answer",
+            "does not support anyOf",
+        ),
+    ],
+)
+def test_core_portable_profile_rejects_lossy_or_unsupported_schemas(
+    schema,
+    expected_path,
+    expected_detail,
+):
+    with pytest.raises(JSONSchemaError) as error:
+        validate_core_portable_schema(schema, provider="google")
+
+    message = str(error.value)
+    assert "google structured-output schema" in message
+    assert expected_path in message
+    assert expected_detail in message
 
 
 @pytest.mark.unit


### PR DESCRIPTION
- Adds a unified portable JSON Schema contract for OpenAI, Anthropic, Google, Mistral, and xAI through `json_schema`.
- Adds local `$ref` normalization, portable-profile validation, and `response.parsed_json`.
- Translates the portable schema into each provider’s supported request format.
- Sends Google schemas through `responseJsonSchema`, including nested `additionalProperties: false`.
- Updates streaming terminal outcomes, documentation, and conformance coverage.
- Fixes shared test-fixture imports in the Mistral and xAI packages.
